### PR TITLE
Add support for user requested line breaks in function calls

### DIFF
--- a/crates/air_r_formatter/tests/specs/r/call.R
+++ b/crates/air_r_formatter/tests/specs/r/call.R
@@ -18,6 +18,54 @@ fn(..., a = 1)
 fn(a = 1, another_really_really_long_argument_to_test_this_feature, a_really_long_argument_here, ...)
 
 # ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+dictionary <- list(
+  a = 1,
+  b = 2
+)
+
+# This flattens to one line
+dictionary <- list(a = 1,
+  b = 2
+)
+
+# This flattens to one line
+dictionary <- list(a = 1, b = 2
+)
+
+# Expanding the inner list forces expansion of the outer list
+list(a = 1, b = list(
+  foo = "a", bar = "b"))
+
+# Expansion of `bar()` forces expansion of the whole pipeline
+# (But note `foo(a = 1)` is not expanded)
+df |> foo(a = 1) |> bar(
+  b = 2, c = 3)
+
+# Expansion of `foo()` forces expansion of the whole pipeline
+# (But note `bar(b = 2, c = 3)` is not expanded)
+df |> foo(
+  a = 1) |> bar(b = 2, c = 3)
+
+# Test-like call overrides user requested line break
+# (test-like check comes first and seems more relevant)
+test_that(
+  "description", {
+
+})
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+fn(
+  ,
+  x = 1
+)
+
+# ------------------------------------------------------------------------
 # Trailing braced expression
 
 with(data, {
@@ -30,6 +78,7 @@ with(data,
   }
 )
 
+# User requested line break before `data` is respected
 with(
   data,
   {
@@ -37,9 +86,10 @@ with(
   }
 )
 
+# User requested line break before `data` is respected
 with(
   data,
-  # Prevents flattening
+  # A comment
   {
     col
   }
@@ -51,15 +101,13 @@ with(data, # Prevents flattening
 	}
 )
 
-with(
-  data,
+with(data,
   expr = {
     col
   }
 )
 
-with(
-  data,
+with(data,
   foo = "bar",
   {
     col
@@ -67,8 +115,7 @@ with(
 )
 
 # Not trailing, stays expanded
-with(
-  data,
+with(data,
   {
     col
   },

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -25,6 +25,54 @@ fn(..., a = 1)
 fn(a = 1, another_really_really_long_argument_to_test_this_feature, a_really_long_argument_here, ...)
 
 # ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+dictionary <- list(
+  a = 1,
+  b = 2
+)
+
+# This flattens to one line
+dictionary <- list(a = 1,
+  b = 2
+)
+
+# This flattens to one line
+dictionary <- list(a = 1, b = 2
+)
+
+# Expanding the inner list forces expansion of the outer list
+list(a = 1, b = list(
+  foo = "a", bar = "b"))
+
+# Expansion of `bar()` forces expansion of the whole pipeline
+# (But note `foo(a = 1)` is not expanded)
+df |> foo(a = 1) |> bar(
+  b = 2, c = 3)
+
+# Expansion of `foo()` forces expansion of the whole pipeline
+# (But note `bar(b = 2, c = 3)` is not expanded)
+df |> foo(
+  a = 1) |> bar(b = 2, c = 3)
+
+# Test-like call overrides user requested line break
+# (test-like check comes first and seems more relevant)
+test_that(
+  "description", {
+
+})
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+fn(
+  ,
+  x = 1
+)
+
+# ------------------------------------------------------------------------
 # Trailing braced expression
 
 with(data, {
@@ -37,6 +85,7 @@ with(data,
   }
 )
 
+# User requested line break before `data` is respected
 with(
   data,
   {
@@ -44,9 +93,10 @@ with(
   }
 )
 
+# User requested line break before `data` is respected
 with(
   data,
-  # Prevents flattening
+  # A comment
   {
     col
   }
@@ -58,15 +108,13 @@ with(data, # Prevents flattening
 	}
 )
 
-with(
-  data,
+with(data,
   expr = {
     col
   }
 )
 
-with(
-  data,
+with(data,
   foo = "bar",
   {
     col
@@ -74,8 +122,7 @@ with(
 )
 
 # Not trailing, stays expanded
-with(
-  data,
+with(data,
   {
     col
   },
@@ -263,6 +310,58 @@ fn(
 )
 
 # ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+dictionary <- list(
+	a = 1,
+	b = 2
+)
+
+# This flattens to one line
+dictionary <- list(a = 1, b = 2)
+
+# This flattens to one line
+dictionary <- list(a = 1, b = 2)
+
+# Expanding the inner list forces expansion of the outer list
+list(
+	a = 1,
+	b = list(
+		foo = "a",
+		bar = "b"
+	)
+)
+
+# Expansion of `bar()` forces expansion of the whole pipeline
+# (But note `foo(a = 1)` is not expanded)
+df |>
+	foo(a = 1) |>
+	bar(
+		b = 2,
+		c = 3
+	)
+
+# Expansion of `foo()` forces expansion of the whole pipeline
+# (But note `bar(b = 2, c = 3)` is not expanded)
+df |>
+	foo(
+		a = 1
+	) |>
+	bar(b = 2, c = 3)
+
+# Test-like call overrides user requested line break
+# (test-like check comes first and seems more relevant)
+test_that("description", {
+})
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+fn(, x = 1)
+
+# ------------------------------------------------------------------------
 # Trailing braced expression
 
 with(data, {
@@ -273,13 +372,18 @@ with(data, {
 	col
 })
 
-with(data, {
-	col
-})
-
+# User requested line break before `data` is respected
 with(
 	data,
-	# Prevents flattening
+	{
+		col
+	}
+)
+
+# User requested line break before `data` is respected
+with(
+	data,
+	# A comment
 	{
 		col
 	}
@@ -480,5 +584,6 @@ fn(
 
 # Lines exceeding max width of 80 characters
 ```
-   79: 	my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
+   79: # `RHoleArgument`, so we can't compute the "number of lines before the first token".
+  136: 	my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
 ```

--- a/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
@@ -59,7 +59,10 @@ Line width: 80
 ```R
 mtcars |>
 	mutate(foo = 1) %>%
-	filter(foo == 1, bar == 2, ) |>
+	filter(
+		foo == 1,
+		bar == 2,
+	) |>
 	ggplot(
 		argument_that_is_quite_long = argument_that_is_quite_long,
 		argument_that_is_quite_long = argument_that_is_quite_long
@@ -68,7 +71,10 @@ mtcars |>
 # RHS of assignment should stay on same line as the `<-` operator
 name <- mtcars |>
 	mutate(foo = 1) %>%
-	filter(foo == 1, bar == 2, ) |>
+	filter(
+		foo == 1,
+		bar == 2,
+	) |>
 	ggplot(
 		argument_that_is_quite_long = argument_that_is_quite_long,
 		argument_that_is_quite_long = argument_that_is_quite_long
@@ -76,7 +82,10 @@ name <- mtcars |>
 
 name = mtcars |>
 	mutate(foo = 1) %>%
-	filter(foo == 1, bar == 2, ) |>
+	filter(
+		foo == 1,
+		bar == 2,
+	) |>
 	ggplot(
 		argument_that_is_quite_long = argument_that_is_quite_long,
 		argument_that_is_quite_long = argument_that_is_quite_long

--- a/crates/air_r_formatter/tests/specs/r/subset.R
+++ b/crates/air_r_formatter/tests/specs/r/subset.R
@@ -20,18 +20,56 @@ DT[, by=x, {
   fwrite(.SD, "name")
 }]
 
+# ------------------------------------------------------------------------
 # Holes
+
 fn[,]
 fn[,,]
 fn[a,,b,,]
 fn[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]
 
+# ------------------------------------------------------------------------
 # Dots
+
 fn[...]
 fn[..., a = 1]
 fn[a = 1, another_really_really_long_argument_to_test_this_feature, a_really_long_argument_here, ...]
 
+# ------------------------------------------------------------------------
 # Comments
+
 fn[
   # dangling special case
+]
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+df[
+  df$col > 1,
+  c(2, 3)
+]
+
+# This flattens to one line
+df[df$col > 1,
+  c(2, 3)
+]
+
+# This flattens to one line
+df[df$col > 1, c(2, 3)
+]
+
+# Expanding the inner subset forces expansion of the outer subset
+df[df$col > 7, map[
+  names(df)
+]]
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[
+  ,
+  x = 1
 ]

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -27,20 +27,58 @@ DT[, by=x, {
   fwrite(.SD, "name")
 }]
 
+# ------------------------------------------------------------------------
 # Holes
+
 fn[,]
 fn[,,]
 fn[a,,b,,]
 fn[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]
 
+# ------------------------------------------------------------------------
 # Dots
+
 fn[...]
 fn[..., a = 1]
 fn[a = 1, another_really_really_long_argument_to_test_this_feature, a_really_long_argument_here, ...]
 
+# ------------------------------------------------------------------------
 # Comments
+
 fn[
   # dangling special case
+]
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+df[
+  df$col > 1,
+  c(2, 3)
+]
+
+# This flattens to one line
+df[df$col > 1,
+  c(2, 3)
+]
+
+# This flattens to one line
+df[df$col > 1, c(2, 3)
+]
+
+# Expanding the inner subset forces expansion of the outer subset
+df[df$col > 7, map[
+  names(df)
+]]
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[
+  ,
+  x = 1
 ]
 
 ```
@@ -88,7 +126,9 @@ DT[, by = x, {
 	fwrite(.SD, "name")
 }]
 
+# ------------------------------------------------------------------------
 # Holes
+
 fn[, ]
 fn[, , ]
 fn[a, , b, , ]
@@ -99,7 +139,9 @@ fn[
 	,
 ]
 
+# ------------------------------------------------------------------------
 # Dots
+
 fn[...]
 fn[..., a = 1]
 fn[
@@ -109,8 +151,44 @@ fn[
 	...
 ]
 
+# ------------------------------------------------------------------------
 # Comments
+
 fn[
 	# dangling special case
 ]
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+df[
+	df$col > 1,
+	c(2, 3)
+]
+
+# This flattens to one line
+df[df$col > 1, c(2, 3)]
+
+# This flattens to one line
+df[df$col > 1, c(2, 3)]
+
+# Expanding the inner subset forces expansion of the outer subset
+df[
+	df$col > 7,
+	map[
+		names(df)
+	]
+]
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[, x = 1]
+```
+
+# Lines exceeding max width of 80 characters
+```
+   87: # `RHoleArgument`, so we can't compute the "number of lines before the first token".
 ```

--- a/crates/air_r_formatter/tests/specs/r/subset2.R
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R
@@ -8,18 +8,56 @@ fn[["description", {
   1 + 1
 }]]
 
+# ------------------------------------------------------------------------
 # Holes
+
 fn[[,]]
 fn[[,,]]
 fn[[a,,b,,]]
 fn[[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]]
 
+# ------------------------------------------------------------------------
 # Dots
+
 fn[[...]]
 fn[[..., a = 1]]
 fn[[a = 1, another_really_really_long_argument_to_test_this_feature, a_really_long_argument_here, ...]]
 
+# ------------------------------------------------------------------------
 # Comments
+
 fn[[
   # dangling special case
+]]
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+df[[
+  df$col > 1,
+  c(2, 3)
+]]
+
+# This flattens to one line
+df[[df$col > 1,
+  c(2, 3)
+]]
+
+# This flattens to one line
+df[[df$col > 1, c(2, 3)
+]]
+
+# Expanding the inner subset forces expansion of the outer subset
+df[[df$col > 7, map[[
+  names(df)
+]]]]
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[[
+  ,
+  x = 1
 ]]

--- a/crates/air_r_formatter/tests/specs/r/subset2.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R.snap
@@ -15,20 +15,58 @@ fn[["description", {
   1 + 1
 }]]
 
+# ------------------------------------------------------------------------
 # Holes
+
 fn[[,]]
 fn[[,,]]
 fn[[a,,b,,]]
 fn[[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]]
 
+# ------------------------------------------------------------------------
 # Dots
+
 fn[[...]]
 fn[[..., a = 1]]
 fn[[a = 1, another_really_really_long_argument_to_test_this_feature, a_really_long_argument_here, ...]]
 
+# ------------------------------------------------------------------------
 # Comments
+
 fn[[
   # dangling special case
+]]
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+df[[
+  df$col > 1,
+  c(2, 3)
+]]
+
+# This flattens to one line
+df[[df$col > 1,
+  c(2, 3)
+]]
+
+# This flattens to one line
+df[[df$col > 1, c(2, 3)
+]]
+
+# Expanding the inner subset forces expansion of the outer subset
+df[[df$col > 7, map[[
+  names(df)
+]]]]
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[[
+  ,
+  x = 1
 ]]
 
 ```
@@ -60,7 +98,9 @@ fn[["description", {
 	1 + 1
 }]]
 
+# ------------------------------------------------------------------------
 # Holes
+
 fn[[, ]]
 fn[[, , ]]
 fn[[a, , b, , ]]
@@ -71,7 +111,9 @@ fn[[
 	,
 ]]
 
+# ------------------------------------------------------------------------
 # Dots
+
 fn[[...]]
 fn[[..., a = 1]]
 fn[[
@@ -81,8 +123,44 @@ fn[[
 	...
 ]]
 
+# ------------------------------------------------------------------------
 # Comments
+
 fn[[
 	# dangling special case
 ]]
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first argument forces expansion
+
+# So this data dictionary stays expanded even though it fits on one line
+df[[
+	df$col > 1,
+	c(2, 3)
+]]
+
+# This flattens to one line
+df[[df$col > 1, c(2, 3)]]
+
+# This flattens to one line
+df[[df$col > 1, c(2, 3)]]
+
+# Expanding the inner subset forces expansion of the outer subset
+df[[
+	df$col > 7,
+	map[[
+		names(df)
+	]]
+]]
+
+# TODO: Holes currently don't force expansion. There is no token attached to
+# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[[, x = 1]]
+```
+
+# Lines exceeding max width of 80 characters
+```
+   71: # `RHoleArgument`, so we can't compute the "number of lines before the first token".
 ```


### PR DESCRIPTION
Branched from #27 

Pretttty straightforward. Used the same helper name of `needs_user_requested_expansion()` as in the binary expression case, which will eventually gain support for checking an option.

There is some weirdness with holes outlined in #32 