### PR TITLE
Throw better error when there are parse errors during formatting tests

### DIFF
--- a/crates/air_formatter_test/src/spec.rs
+++ b/crates/air_formatter_test/src/spec.rs
@@ -108,7 +108,13 @@ where
         parsed: &AnyParse,
         format_language: L::FormatLanguage,
     ) -> (String, Printed) {
-        let has_errors = parsed.has_errors();
+        if parsed.has_errors() {
+            panic!(
+                "{:?} has parse errors, refusing to format.",
+                self.test_file.input_file,
+            );
+        }
+
         let syntax = parsed.syntax();
 
         let range = self.test_file.range();
@@ -153,16 +159,14 @@ where
             _ => {
                 let output_code = formatted.as_code();
 
-                if !has_errors {
-                    let check_reformat = CheckReformat::new(
-                        &syntax,
-                        output_code,
-                        self.test_file.file_name(),
-                        &self.language,
-                        format_language,
-                    );
-                    check_reformat.check_reformat();
-                }
+                let check_reformat = CheckReformat::new(
+                    &syntax,
+                    output_code,
+                    self.test_file.file_name(),
+                    &self.language,
+                    format_language,
+                );
+                check_reformat.check_reformat();
 
                 output_code.to_string()
             }

--- a/crates/air_r_formatter/tests/quick_test.rs
+++ b/crates/air_r_formatter/tests/quick_test.rs
@@ -27,6 +27,10 @@ fn quick_test() {
         .with_indent_style(IndentStyle::Space)
         .with_line_width(LineWidth::try_from(80).unwrap());
 
+    if parse.has_errors() {
+        panic!("Can't format when there are parse errors.");
+    }
+
     let formatted = format_node(options.clone(), &parse.syntax()).unwrap();
     let result = formatted.print().unwrap();
 


### PR DESCRIPTION
To avoid quite a bit of headache from confusing formatter error messages