### PR TITLE
Add support for user requested expansion of function definitions

### DIFF
--- a/crates/air_r_formatter/src/r/auxiliary/function_definition.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/function_definition.rs
@@ -86,7 +86,7 @@ impl FormatFunction {
             f,
             [
                 name.format(),
-                group(&format_parameters),
+                &format_parameters,
                 group(&FormatStatementBody::new(&body))
             ]
         )

--- a/crates/air_r_formatter/src/r/auxiliary/parameters.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/parameters.rs
@@ -1,7 +1,10 @@
 use crate::prelude::*;
+use air_r_syntax::RParameterList;
 use air_r_syntax::RParameters;
 use air_r_syntax::RParametersFields;
+use biome_formatter::format_args;
 use biome_formatter::write;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatRParameters;
 impl FormatNodeRule<RParameters> for FormatRParameters {
@@ -14,11 +17,77 @@ impl FormatNodeRule<RParameters> for FormatRParameters {
 
         write!(
             f,
-            [
+            [group(&format_args![
                 l_paren_token.format(),
                 soft_block_indent(&items.format()),
                 r_paren_token.format()
-            ]
+            ])
+            .should_expand(needs_user_requested_expansion(&items))]
         )
     }
+}
+
+/// Check if the user has inserted a leading newline before the very first `parameter`.
+/// If so, we respect that and treat it as a request to break ALL of the parameters in
+/// this function definition. Note this is a case of irreversible formatting!
+///
+/// ```r
+/// # Fits on one line, but newline before `a` forces ALL parameters to break
+///
+/// # Input
+/// fn <- function(
+/// a, b, c) {
+///   body
+/// }
+///
+/// # Output
+/// fn <- function(
+///   a,
+///   b,
+///   c
+/// ) {
+///   body
+/// }
+/// ```
+///
+/// Note that removing this line break is a request to flatten if possible. By only having
+/// this special behavior on the very first parameter, we make it easy to request flattening.
+///
+/// ```r
+/// # Say we start here and want to flatten
+/// fn <- function(
+///   a,
+///   b,
+///   c
+/// ) {
+///   body
+/// }
+///
+/// # Remove the first line break and run air
+/// fn <- function(a,
+///   b,
+///   c
+/// ) {
+///   body
+/// }
+///
+/// # Output
+/// fn <- function(a, b, c) {
+///   body
+/// }
+/// ```
+fn needs_user_requested_expansion(items: &RParameterList) -> bool {
+    // TODO: This should be configurable by an option, since it is a case of
+    // irreversible formatting
+
+    // Dig down to the first parameter
+    // (Could be an empty parameter list, and first element could be a syntax error)
+    let Some(first) = items.first() else {
+        return false;
+    };
+    let Ok(first) = first else {
+        return false;
+    };
+
+    first.syntax().has_leading_newline()
 }

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R
@@ -39,3 +39,86 @@ function() # becomes leading on `1 + 1`
   1 + 1
 
 \(x, y) 1
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first parameter forces expansion
+
+# So this function definition stays expanded even though it fits on one line
+fn <- function(
+  a,
+  b
+) {
+  body
+}
+
+# This flattens to one line
+fn <- function(a,
+  b
+) {
+  body
+}
+
+# This flattens to one line
+fn <- function(a, b
+) {
+  body
+}
+
+# Expansion doesn't propagate to the `c(1, 2, 3)`
+fn <- function(
+  a,
+  b = c(1, 2, 3)
+) {
+  body
+}
+
+# Dots - this expands
+fn <- function(
+  ..., a, b
+) {
+  body
+}
+
+# Dots - this flattens
+fn <- function(...,
+  a, b
+) {
+  body
+}
+
+# User requested expansion of the `c()` call forces expansion of
+# the entire function definition
+fn <- function(a, b = c(
+  1, 2, 3)) {
+  body
+}
+
+# ------------------------------------------------------------------------
+# User requested line break and trailing anonymous functions in calls
+
+# Ensure these features play nicely together
+
+# This user line break expands the function definition, causing the whole
+# `map()` to expand
+map(xs, function(
+  x, option = "a") {
+  x
+})
+
+# This flattens the function definition, but the `map()` stays expanded
+map(
+  xs,
+  function(x,
+    option = "a"
+  ) {
+    x
+  }
+)
+
+# This flattens to one line
+map(xs, function(x,
+  option = "a") {
+  x
+})

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
@@ -47,6 +47,89 @@ function() # becomes leading on `1 + 1`
 
 \(x, y) 1
 
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first parameter forces expansion
+
+# So this function definition stays expanded even though it fits on one line
+fn <- function(
+  a,
+  b
+) {
+  body
+}
+
+# This flattens to one line
+fn <- function(a,
+  b
+) {
+  body
+}
+
+# This flattens to one line
+fn <- function(a, b
+) {
+  body
+}
+
+# Expansion doesn't propagate to the `c(1, 2, 3)`
+fn <- function(
+  a,
+  b = c(1, 2, 3)
+) {
+  body
+}
+
+# Dots - this expands
+fn <- function(
+  ..., a, b
+) {
+  body
+}
+
+# Dots - this flattens
+fn <- function(...,
+  a, b
+) {
+  body
+}
+
+# User requested expansion of the `c()` call forces expansion of
+# the entire function definition
+fn <- function(a, b = c(
+  1, 2, 3)) {
+  body
+}
+
+# ------------------------------------------------------------------------
+# User requested line break and trailing anonymous functions in calls
+
+# Ensure these features play nicely together
+
+# This user line break expands the function definition, causing the whole
+# `map()` to expand
+map(xs, function(
+  x, option = "a") {
+  x
+})
+
+# This flattens the function definition, but the `map()` stays expanded
+map(
+  xs,
+  function(x,
+    option = "a"
+  ) {
+    x
+  }
+)
+
+# This flattens to one line
+map(xs, function(x,
+  option = "a") {
+  x
+})
+
 ```
 
 
@@ -114,4 +197,92 @@ function()
 	1 + 1
 
 \(x, y) 1
+
+# ------------------------------------------------------------------------
+# User requested line break
+
+# A line break before the first parameter forces expansion
+
+# So this function definition stays expanded even though it fits on one line
+fn <- function(
+	a,
+	b
+) {
+	body
+}
+
+# This flattens to one line
+fn <- function(a, b) {
+	body
+}
+
+# This flattens to one line
+fn <- function(a, b) {
+	body
+}
+
+# Expansion doesn't propagate to the `c(1, 2, 3)`
+fn <- function(
+	a,
+	b = c(1, 2, 3)
+) {
+	body
+}
+
+# Dots - this expands
+fn <- function(
+	...,
+	a,
+	b
+) {
+	body
+}
+
+# Dots - this flattens
+fn <- function(..., a, b) {
+	body
+}
+
+# User requested expansion of the `c()` call forces expansion of
+# the entire function definition
+fn <- function(
+	a,
+	b = c(
+		1,
+		2,
+		3
+	)
+) {
+	body
+}
+
+# ------------------------------------------------------------------------
+# User requested line break and trailing anonymous functions in calls
+
+# Ensure these features play nicely together
+
+# This user line break expands the function definition, causing the whole
+# `map()` to expand
+map(
+	xs,
+	function(
+		x,
+		option = "a"
+	) {
+		x
+	}
+)
+
+# This flattens the function definition, but the `map()` stays expanded
+map(
+	xs,
+	function(x, option = "a") {
+		x
+	}
+)
+
+# This flattens to one line
+map(xs, function(x, option = "a") {
+	x
+})
 ```


### PR DESCRIPTION
Branched from #33 

`FormatRParameters` is now in charge of `group()`ing the parameters, with possibly forced expansion if the user put a line break before the first function definition parameter.

It is necessary to move this grouping inside `FormatRParameters` due to the way `fmt_with_options()` with function definitions works. When we are in the special trailing-anonymous-function-definition case of call formatting, we return `FormatError::PoorLayout` if we detect that the `parameters` are going to break. If the user requested expansion here, we want to respect that. That means `FormatRParameters` needs to be in charge of setting `should_expand(true)`, so we can catch that from `fmt_with_options()` and return `FormatError::PoorLayout`.

The example case of this is something like:

```r
map(xs, function(
    x, option = "this") {
  
})
```

Even though `function(x, option = "this") {` doesn't break on its own, since the user has that explicit line break before the `x`, the `parameters` _do_ break, so we return `FormatError::PoorLayout` and let the `map()` fully expand to

```r
map(
  xs,
  function(
    x,
    option = "this"
  ) {
  }
)
```