### PR TITLE
Import Ark LSP infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +418,12 @@ source = "git+https://github.com/biomejs/biome?rev=561b54c93625c9a83035562022af4
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -430,6 +458,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "case"
@@ -528,6 +562,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,10 +603,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "dashmap"
@@ -564,6 +642,17 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -583,6 +672,12 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
@@ -652,6 +747,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +858,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -700,7 +884,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "ignore",
  "walkdir",
 ]
@@ -724,13 +908,154 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "hermit-abi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -779,6 +1104,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -853,6 +1187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1209,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lsp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "futures",
+ "itertools",
+ "log",
+ "serde",
+ "serde_json",
+ "struct-field-names-as-array",
+ "tokio",
+ "tower-lsp",
+ "tracing",
+ "tree-sitter",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1254,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -905,7 +1290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20bb345f290c46058ba650fef7ca2b579612cf2786b927ebad7b8bec0845a7"
 dependencies = [
  "cfg-if",
- "dashmap",
+ "dashmap 6.1.0",
  "dunce",
  "indexmap",
  "json-strip-comments",
@@ -916,6 +1301,16 @@ dependencies = [
  "simdutf8",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -938,10 +1333,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -997,7 +1418,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1074,7 +1495,7 @@ version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1216,10 +1637,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simdutf8"
@@ -1248,10 +1689,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "spin"
@@ -1260,10 +1720,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "struct-field-names-as-array"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ba4bae771f9cc992c4f403636c54d2ef13acde6367583e99d06bb336674dd9"
+dependencies = [
+ "struct-field-names-as-array-derive",
+]
+
+[[package]]
+name = "struct-field-names-as-array-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2dbf8b57f3ce20e4bb171a11822b283bdfab6c4bb0fe64fa729f045f23a0938"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
 
 [[package]]
 name = "subtle"
@@ -1291,6 +1777,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1349,19 +1846,116 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
+name = "tokio"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap 5.5.3",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1422,12 +2016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,15 +2026,6 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1484,20 +2063,42 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "vcpkg"
@@ -1634,6 +2235,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "xtask"
 version = "0.0.0"
 dependencies = [
@@ -1657,7 +2270,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "lsp"
+version = "0.1.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+crossbeam = "0.8.4"
+futures = "0.3.31"
+itertools = "0.13.0"
+log = "0.4.22"
+serde.workspace = true
+serde_json = "1.0.132"
+struct-field-names-as-array = "0.3.0"
+tokio = { version = "1.41.1", features = ["full"] }
+tower-lsp = "0.20.0"
+tracing.workspace = true
+tree-sitter = "0.23.0"
+url = "2.5.3"
+uuid = { version = "1.11.0", features = ["v4"] }
+
+[lints]
+workspace = true

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,15 +1,17 @@
+//
+// config.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
 use serde::Deserialize;
 use serde::Serialize;
 use struct_field_names_as_array::FieldNamesAsArray;
 
-use crate::lsp;
-use crate::lsp::diagnostics::DiagnosticsConfig;
-
 /// Configuration of the LSP
 #[derive(Clone, Debug)]
-pub(crate) struct LspConfig {
-    pub(crate) diagnostics: DiagnosticsConfig,
-}
+pub(crate) struct LspConfig {}
 
 /// Configuration of a document.
 ///
@@ -62,9 +64,7 @@ pub(crate) enum VscIndentSize {
 
 impl Default for LspConfig {
     fn default() -> Self {
-        Self {
-            diagnostics: Default::default(),
-        }
+        Self {}
     }
 }
 
@@ -101,10 +101,10 @@ impl From<VscDocumentConfig> for DocumentConfig {
                 if var == "tabSize" {
                     x.tab_size
                 } else {
-                    lsp::log_warn!("Unknown indent alias {var}, using default");
+                    crate::log_warn!("Unknown indent alias {var}, using default");
                     2
                 }
-            },
+            }
         };
 
         Self {
@@ -122,14 +122,6 @@ impl VscDiagnosticsConfig {
         match key {
             "enable" => "positron.r.diagnostics.enable",
             _ => "unknown", // To be caught via downstream errors
-        }
-    }
-}
-
-impl From<VscDiagnosticsConfig> for DiagnosticsConfig {
-    fn from(value: VscDiagnosticsConfig) -> Self {
-        Self {
-            enable: value.enable,
         }
     }
 }

--- a/crates/lsp/src/documents.rs
+++ b/crates/lsp/src/documents.rs
@@ -1,47 +1,19 @@
 //
-// document.rs
+// documents.rs
 //
 // Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
 use anyhow::*;
-use ropey::Rope;
 use tower_lsp::lsp_types::DidChangeTextDocumentParams;
 use tower_lsp::lsp_types::TextDocumentContentChangeEvent;
-use tree_sitter::InputEdit;
-use tree_sitter::Parser;
-use tree_sitter::Point;
-use tree_sitter::Tree;
 
-use crate::lsp::config::DocumentConfig;
-use crate::lsp::encoding::convert_position_to_point;
-use crate::lsp::traits::rope::RopeExt;
-
-fn compute_point(point: Point, text: &str) -> Point {
-    // figure out where the newlines in this edit are
-    let newline_indices: Vec<_> = text.match_indices('\n').collect();
-    let num_newlines = newline_indices.len();
-    let num_bytes = text.as_bytes().len();
-
-    if newline_indices.len() == 0 {
-        return Point::new(point.row, point.column + num_bytes);
-    } else {
-        let last_newline_index = newline_indices.last().unwrap();
-        return Point::new(
-            point.row + num_newlines,
-            num_bytes - last_newline_index.0 - 1,
-        );
-    }
-}
+use crate::config::DocumentConfig;
 
 #[derive(Clone)]
 pub struct Document {
-    // The document's textual contents.
-    pub contents: Rope,
-
-    // The document's AST.
-    pub ast: Tree,
+    pub syntax: (),
 
     // The version of the document we last synchronized with.
     // None if the document hasn't been synchronized yet.
@@ -54,37 +26,22 @@ pub struct Document {
 impl std::fmt::Debug for Document {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Document")
-            .field("contents", &self.contents)
-            .field("ast", &self.ast)
+            .field("syntax", &self.syntax)
             .finish()
     }
 }
 
 impl Document {
-    pub fn new(contents: &str, version: Option<i32>) -> Self {
-        // A one-shot parser, assumes the `Document` won't be incrementally reparsed.
-        // Useful for testing, `with_document()`, and `index_file()`.
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_r::LANGUAGE.into())
-            .unwrap();
-
-        Self::new_with_parser(contents, &mut parser, version)
-    }
-
-    pub fn new_with_parser(contents: &str, parser: &mut Parser, version: Option<i32>) -> Self {
-        let document = Rope::from(contents);
-        let ast = parser.parse(contents, None).unwrap();
-
+    pub fn new(_contents: &str, version: Option<i32>) -> Self {
+        // TODO! Parse `contents`
         Self {
-            contents: document,
+            syntax: (),
             version,
-            ast,
             config: Default::default(),
         }
     }
 
-    pub fn on_did_change(&mut self, parser: &mut Parser, params: &DidChangeTextDocumentParams) {
+    pub fn on_did_change(&mut self, params: &DidChangeTextDocumentParams) {
         let new_version = params.text_document.version;
 
         // Check for out-of-order change notifications
@@ -101,7 +58,7 @@ impl Document {
         }
 
         for event in &params.content_changes {
-            if let Err(err) = self.update(parser, event) {
+            if let Err(err) = self.update(event) {
                 panic!("Failed to update document: {err:?}");
             }
         }
@@ -110,94 +67,16 @@ impl Document {
         self.version = Some(new_version);
     }
 
-    fn update(
-        &mut self,
-        parser: &mut Parser,
-        change: &TextDocumentContentChangeEvent,
-    ) -> Result<()> {
+    fn update(&mut self, change: &TextDocumentContentChangeEvent) -> Result<()> {
         // Extract edit range. Nothing to do if there wasn't an edit.
-        let range = match change.range {
+        let _range = match change.range {
             Some(r) => r,
             None => return Ok(()),
         };
 
-        // Update the AST. We do this before updating the underlying document
-        // contents, because edit computations need to be done using the current
-        // state of the document (prior to the edit being applied) so that byte
-        // offsets can be computed correctly.
-        let ast = &mut self.ast;
-
-        let start_point = convert_position_to_point(&self.contents, range.start);
-        let start_byte = self.contents.point_to_byte(start_point);
-
-        let old_end_point = convert_position_to_point(&self.contents, range.end);
-        let old_end_byte = self.contents.point_to_byte(old_end_point);
-
-        let new_end_point = compute_point(start_point, &change.text);
-        let new_end_byte = start_byte + change.text.as_bytes().len();
-
-        // Confusing tree sitter names, the `start_position` is really a `Point`
-        let edit = InputEdit {
-            start_byte,
-            old_end_byte,
-            new_end_byte,
-            start_position: start_point,
-            old_end_position: old_end_point,
-            new_end_position: new_end_point,
-        };
-
-        ast.edit(&edit);
-
-        // Now, apply edits to the underlying document.
-        // Convert from byte offsets to character offsets.
-        let start_character = self.contents.byte_to_char(start_byte);
-        let old_end_character = self.contents.byte_to_char(old_end_byte);
-
-        // Remove the old slice of text, and insert the new slice of text.
-        self.contents.remove(start_character..old_end_character);
-        self.contents.insert(start_character, change.text.as_str());
-
-        // We've edited the AST, and updated the document. We can now re-parse.
-        let contents = &self.contents;
-        let callback = &mut |byte, point| Self::parse_callback(contents, byte, point);
-
-        let ast = parser.parse_with(callback, Some(&self.ast));
-        self.ast = ast.unwrap();
+        // TODO!
 
         Ok(())
-    }
-
-    /// A tree-sitter `parse_with()` callback to efficiently return a slice of the
-    /// document in the `Rope` that tree-sitter can reparse with.
-    ///
-    /// According to the tree-sitter docs:
-    /// * `callback` A function that takes a byte offset and position and
-    ///   returns a slice of UTF8-encoded text starting at that byte offset
-    ///   and position. The slices can be of any length. If the given position
-    ///   is at the end of the text, the callback should return an empty slice.
-    ///
-    /// We expect that tree-sitter will call the callback again with an updated `byte`
-    /// if the chunk doesn't contain enough text to fully reparse.
-    fn parse_callback(contents: &Rope, byte: usize, point: Point) -> &[u8] {
-        // Get Rope "chunk" that lines up with this `byte`
-        let Some((chunk, chunk_byte_idx, _chunk_char_idx, _chunk_line_idx)) =
-            contents.get_chunk_at_byte(byte)
-        else {
-            let contents = contents.to_string();
-            log::error!(
-                "Failed to get Rope chunk at byte {byte}, point {point}. Text '{contents}'.",
-            );
-            return "\n".as_bytes();
-        };
-
-        // How far into this chunk are we?
-        let byte = byte - chunk_byte_idx;
-
-        // Now return the slice from that `byte` to the end of the chunk.
-        // SAFETY: This should never panic, since `get_chunk_at_byte()` worked.
-        let slice = &chunk[byte..];
-
-        slice.as_bytes()
     }
 }
 
@@ -206,30 +85,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_point_computation() {
-        // empty strings shouldn't do anything
-        let point = compute_point(Point::new(0, 0), "");
-        assert_eq!(point, Point::new(0, 0));
-
-        let point = compute_point(Point::new(42, 42), "");
-        assert_eq!(point, Point::new(42, 42));
-
-        // text insertion without newlines should just extend the column position
-        let point = compute_point(Point::new(0, 0), "abcdef");
-        assert_eq!(point, Point::new(0, 6));
-
-        // text insertion with newlines should change the row
-        let point = compute_point(Point::new(0, 0), "abc\ndef\nghi");
-        assert_eq!(point, Point::new(2, 3));
-
-        let point = compute_point(Point::new(0, 0), "abcdefghi\n");
-        assert_eq!(point, Point::new(1, 0));
-    }
-
-    #[test]
     fn test_document_starts_at_0_0_with_leading_whitespace() {
-        let document = Document::new("\n\n# hi there", None);
-        let root = document.ast.root_node();
-        assert_eq!(root.start_position(), Point::new(0, 0));
+        let _document = Document::new("\n\n# hi there", None);
+        // TODO!
+        // let root = document.ast.root_node();
+        // assert_eq!(root.start_position(), Point::new(0, 0));
     }
 }

--- a/crates/lsp/src/handlers.rs
+++ b/crates/lsp/src/handlers.rs
@@ -5,77 +5,14 @@
 //
 //
 
-use anyhow::anyhow;
-use dashmap::DashMap;
-use once_cell::sync::Lazy;
-use serde_json::Value;
-use stdext::unwrap;
 use struct_field_names_as_array::FieldNamesAsArray;
-use tower_lsp::lsp_types::CompletionItem;
-use tower_lsp::lsp_types::CompletionParams;
-use tower_lsp::lsp_types::CompletionResponse;
-use tower_lsp::lsp_types::DocumentOnTypeFormattingParams;
-use tower_lsp::lsp_types::DocumentSymbolParams;
-use tower_lsp::lsp_types::DocumentSymbolResponse;
-use tower_lsp::lsp_types::GotoDefinitionParams;
-use tower_lsp::lsp_types::GotoDefinitionResponse;
-use tower_lsp::lsp_types::Hover;
-use tower_lsp::lsp_types::HoverContents;
-use tower_lsp::lsp_types::HoverParams;
-use tower_lsp::lsp_types::Location;
-use tower_lsp::lsp_types::MessageType;
-use tower_lsp::lsp_types::ReferenceParams;
-use tower_lsp::lsp_types::Registration;
-use tower_lsp::lsp_types::SelectionRange;
-use tower_lsp::lsp_types::SelectionRangeParams;
-use tower_lsp::lsp_types::SignatureHelp;
-use tower_lsp::lsp_types::SignatureHelpParams;
-use tower_lsp::lsp_types::SymbolInformation;
-use tower_lsp::lsp_types::TextEdit;
-use tower_lsp::lsp_types::WorkspaceEdit;
-use tower_lsp::lsp_types::WorkspaceSymbolParams;
+use tower_lsp::lsp_types;
 use tower_lsp::Client;
 use tracing::Instrument;
-use tree_sitter::Point;
 
-use crate::analysis::input_boundaries::input_boundaries;
-use crate::lsp;
-use crate::lsp::completions::provide_completions;
-use crate::lsp::completions::resolve_completion;
-use crate::lsp::config::VscDiagnosticsConfig;
-use crate::lsp::config::VscDocumentConfig;
-use crate::lsp::definitions::goto_definition;
-use crate::lsp::document_context::DocumentContext;
-use crate::lsp::encoding::convert_position_to_point;
-use crate::lsp::help_topic::help_topic;
-use crate::lsp::help_topic::HelpTopicParams;
-use crate::lsp::help_topic::HelpTopicResponse;
-use crate::lsp::hover::r_hover;
-use crate::lsp::indent::indent_edit;
-use crate::lsp::input_boundaries::InputBoundariesParams;
-use crate::lsp::input_boundaries::InputBoundariesResponse;
-use crate::lsp::main_loop::LspState;
-use crate::lsp::offset::IntoLspOffset;
-use crate::lsp::references::find_references;
-use crate::lsp::selection_range::convert_selection_range_from_tree_sitter_to_lsp;
-use crate::lsp::selection_range::selection_range;
-use crate::lsp::signature_help::r_signature_help;
-use crate::lsp::state::WorldState;
-use crate::lsp::statement_range::statement_range;
-use crate::lsp::statement_range::StatementRangeParams;
-use crate::lsp::statement_range::StatementRangeResponse;
-use crate::lsp::symbols;
-use crate::r_task;
-
-pub static ARK_VDOC_REQUEST: &'static str = "ark/internal/virtualDocument";
-
-#[derive(Debug, Eq, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct VirtualDocumentParams {
-    pub path: String,
-}
-
-pub(crate) type VirtualDocumentResponse = String;
+use crate::config::VscDiagnosticsConfig;
+use crate::config::VscDocumentConfig;
+use crate::main_loop::LspState;
 
 // Handlers that do not mutate the world state. They take a sharing reference or
 // a clone of the state.
@@ -87,7 +24,7 @@ pub(crate) async fn handle_initialized(
     let span = tracing::info_span!("handle_initialized").entered();
 
     // Register capabilities to the client
-    let mut regs: Vec<Registration> = vec![];
+    let mut regs: Vec<lsp_types::Registration> = vec![];
 
     if lsp_state.needs_registration.did_change_configuration {
         // The `didChangeConfiguration` request instructs the client to send
@@ -100,7 +37,7 @@ pub(crate) async fn handle_initialized(
             VscDocumentConfig::FIELD_NAMES_AS_ARRAY.to_vec(),
             VscDocumentConfig::section_from_key,
         );
-        let mut config_diagnostics_regs: Vec<Registration> = collect_regs(
+        let mut config_diagnostics_regs: Vec<lsp_types::Registration> = collect_regs(
             VscDiagnosticsConfig::FIELD_NAMES_AS_ARRAY.to_vec(),
             VscDiagnosticsConfig::section_from_key,
         );
@@ -116,290 +53,16 @@ pub(crate) async fn handle_initialized(
     Ok(())
 }
 
-fn collect_regs(fields: Vec<&str>, into_section: impl Fn(&str) -> &str) -> Vec<Registration> {
+fn collect_regs(
+    fields: Vec<&str>,
+    into_section: impl Fn(&str) -> &str,
+) -> Vec<lsp_types::Registration> {
     fields
         .into_iter()
-        .map(|field| Registration {
+        .map(|field| lsp_types::Registration {
             id: uuid::Uuid::new_v4().to_string(),
             method: String::from("workspace/didChangeConfiguration"),
             register_options: Some(serde_json::json!({ "section": into_section(field) })),
         })
         .collect()
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_symbol(
-    params: WorkspaceSymbolParams,
-) -> anyhow::Result<Option<Vec<SymbolInformation>>> {
-    symbols::symbols(&params)
-        .map(|res| Some(res))
-        .or_else(|err| {
-            // Missing doc: Why are we not propagating errors to the frontend?
-            lsp::log_error!("{err:?}");
-            Ok(None)
-        })
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_document_symbol(
-    params: DocumentSymbolParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<DocumentSymbolResponse>> {
-    symbols::document_symbols(state, &params)
-        .map(|res| Some(DocumentSymbolResponse::Nested(res)))
-        .or_else(|err| {
-            // Missing doc: Why are we not propagating errors to the frontend?
-            lsp::log_error!("{err:?}");
-            Ok(None)
-        })
-}
-
-pub(crate) async fn handle_execute_command(client: &Client) -> anyhow::Result<Option<Value>> {
-    match client.apply_edit(WorkspaceEdit::default()).await {
-        Ok(res) if res.applied => client.log_message(MessageType::INFO, "applied").await,
-        Ok(_) => client.log_message(MessageType::INFO, "rejected").await,
-        Err(err) => client.log_message(MessageType::ERROR, err).await,
-    }
-    Ok(None)
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_completion(
-    params: CompletionParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<CompletionResponse>> {
-    // Get reference to document.
-    let uri = params.text_document_position.text_document.uri;
-    let document = state.get_document(&uri)?;
-
-    let position = params.text_document_position.position;
-    let point = convert_position_to_point(&document.contents, position);
-
-    let trigger = params.context.and_then(|ctxt| ctxt.trigger_character);
-
-    // Build the document context.
-    let context = DocumentContext::new(&document, point, trigger);
-    lsp::log_info!("Completion context: {:#?}", context);
-
-    let completions = r_task(|| provide_completions(&context, state))?;
-
-    if !completions.is_empty() {
-        Ok(Some(CompletionResponse::Array(completions)))
-    } else {
-        Ok(None)
-    }
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_completion_resolve(
-    mut item: CompletionItem,
-) -> anyhow::Result<CompletionItem> {
-    r_task(|| resolve_completion(&mut item))?;
-    Ok(item)
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_hover(
-    params: HoverParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<Hover>> {
-    let uri = params.text_document_position_params.text_document.uri;
-    let document = state.get_document(&uri)?;
-
-    let position = params.text_document_position_params.position;
-    let point = convert_position_to_point(&document.contents, position);
-
-    // build document context
-    let context = DocumentContext::new(&document, point, None);
-
-    // request hover information
-    let result = r_task(|| r_hover(&context));
-
-    // unwrap errors
-    let result = unwrap!(result, Err(err) => {
-        lsp::log_error!("{err:?}");
-        return Ok(None);
-    });
-
-    // unwrap empty options
-    let result = unwrap!(result, None => {
-        return Ok(None);
-    });
-
-    // we got a result; use it
-    Ok(Some(Hover {
-        contents: HoverContents::Markup(result),
-        range: None,
-    }))
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_signature_help(
-    params: SignatureHelpParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<SignatureHelp>> {
-    let uri = params.text_document_position_params.text_document.uri;
-    let document = state.get_document(&uri)?;
-
-    let position = params.text_document_position_params.position;
-    let point = convert_position_to_point(&document.contents, position);
-
-    let context = DocumentContext::new(&document, point, None);
-
-    // request signature help
-    let result = r_task(|| r_signature_help(&context));
-
-    // unwrap errors
-    let result = unwrap!(result, Err(err) => {
-        lsp::log_error!("{err:?}");
-        return Ok(None);
-    });
-
-    // unwrap empty options
-    let result = unwrap!(result, None => {
-        return Ok(None);
-    });
-
-    Ok(Some(result))
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_goto_definition(
-    params: GotoDefinitionParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<GotoDefinitionResponse>> {
-    // get reference to document
-    let uri = &params.text_document_position_params.text_document.uri;
-    let document = state.get_document(uri)?;
-
-    // build goto definition context
-    let result = unwrap!(unsafe { goto_definition(&document, params) }, Err(err) => {
-        lsp::log_error!("{err:?}");
-        return Ok(None);
-    });
-
-    Ok(result)
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_selection_range(
-    params: SelectionRangeParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<Vec<SelectionRange>>> {
-    // Get reference to document
-    let uri = params.text_document.uri;
-    let document = state.get_document(&uri)?;
-
-    let tree = &document.ast;
-
-    // Get tree-sitter points to return selection ranges for
-    let points: Vec<Point> = params
-        .positions
-        .into_iter()
-        .map(|position| convert_position_to_point(&document.contents, position))
-        .collect();
-
-    let Some(selections) = selection_range(tree, points) else {
-        return Ok(None);
-    };
-
-    // Convert tree-sitter points to LSP positions everywhere
-    let selections = selections
-        .into_iter()
-        .map(|selection| convert_selection_range_from_tree_sitter_to_lsp(selection, &document))
-        .collect();
-
-    Ok(Some(selections))
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_references(
-    params: ReferenceParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<Vec<Location>>> {
-    let locations = match find_references(params, state) {
-        Ok(locations) => locations,
-        Err(_error) => {
-            return Ok(None);
-        },
-    };
-
-    if locations.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(locations))
-    }
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_statement_range(
-    params: StatementRangeParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<StatementRangeResponse>> {
-    let uri = &params.text_document.uri;
-    let document = state.get_document(uri)?;
-
-    let root = document.ast.root_node();
-    let contents = &document.contents;
-
-    let position = params.position;
-    let point = convert_position_to_point(contents, position);
-
-    let row = point.row;
-
-    statement_range(root, contents, point, row)
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_help_topic(
-    params: HelpTopicParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<HelpTopicResponse>> {
-    let uri = &params.text_document.uri;
-    let document = state.get_document(uri)?;
-    let contents = &document.contents;
-
-    let position = params.position;
-    let point = convert_position_to_point(contents, position);
-
-    help_topic(point, &document)
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn handle_indent(
-    params: DocumentOnTypeFormattingParams,
-    state: &WorldState,
-) -> anyhow::Result<Option<Vec<TextEdit>>> {
-    let ctxt = params.text_document_position;
-    let uri = ctxt.text_document.uri;
-
-    let doc = state.get_document(&uri)?;
-    let pos = ctxt.position;
-    let point = convert_position_to_point(&doc.contents, pos);
-
-    let res = indent_edit(doc, point.row);
-
-    Result::map(res, |opt| {
-        Option::map(opt, |edits| edits.into_lsp_offset(&doc.contents))
-    })
-}
-
-// TODO: Should be in WorldState and updated via message passing
-pub static mut ARK_VDOCS: Lazy<DashMap<String, String>> = Lazy::new(|| DashMap::new());
-
-pub(crate) fn handle_virtual_document(
-    params: VirtualDocumentParams,
-) -> anyhow::Result<VirtualDocumentResponse> {
-    if let Some(doc) = unsafe { ARK_VDOCS.get(&params.path) } {
-        Ok(doc.clone())
-    } else {
-        Err(anyhow!("Can't find virtual document {}", params.path))
-    }
-}
-
-pub(crate) fn handle_input_boundaries(
-    params: InputBoundariesParams,
-) -> anyhow::Result<InputBoundariesResponse> {
-    let boundaries = r_task(|| input_boundaries(&params.text))?;
-    Ok(InputBoundariesResponse { boundaries })
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1,0 +1,33 @@
+// TODO: Remove this
+#![allow(dead_code)]
+
+pub mod config;
+pub mod documents;
+pub mod encoding;
+pub mod handlers;
+pub mod main_loop;
+pub mod state;
+pub mod state_handlers;
+pub mod tower_lsp;
+
+// These send LSP messages in a non-async and non-blocking way.
+// The LOG level is not timestamped so we're not using it.
+macro_rules! log_info {
+    ($($arg:tt)+) => ($crate::_log!(tower_lsp::lsp_types::MessageType::INFO, $($arg)+))
+}
+macro_rules! log_warn {
+    ($($arg:tt)+) => ($crate::_log!(tower_lsp::lsp_types::MessageType::WARNING, $($arg)+))
+}
+macro_rules! log_error {
+    ($($arg:tt)+) => ($crate::_log!(tower_lsp::lsp_types::MessageType::ERROR, $($arg)+))
+}
+macro_rules! _log {
+    ($lvl:expr, $($arg:tt)+) => ({
+        $crate::main_loop::log($lvl, format!($($arg)+));
+    });
+}
+
+pub(crate) use _log;
+pub(crate) use log_error;
+pub(crate) use log_info;
+pub(crate) use log_warn;

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use anyhow::anyhow;
 use url::Url;
 
-use crate::lsp::config::LspConfig;
-use crate::lsp::documents::Document;
+use crate::config::LspConfig;
+use crate::documents::Document;
 
 #[derive(Clone, Default, Debug)]
 /// The world state, i.e. all the inputs necessary for analysing or refactoring

--- a/crates/lsp/src/tower_lsp.rs
+++ b/crates/lsp/src/tower_lsp.rs
@@ -10,39 +10,20 @@
 use std::sync::Arc;
 
 use crossbeam::channel::Sender;
-use serde_json::Value;
-use stdext::result::ResultOrLog;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::unbounded_channel as tokio_unbounded_channel;
 use tower_lsp::jsonrpc;
 use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::request::GotoImplementationParams;
-use tower_lsp::lsp_types::request::GotoImplementationResponse;
-use tower_lsp::lsp_types::SelectionRange;
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;
 use tower_lsp::LanguageServer;
 use tower_lsp::LspService;
 use tower_lsp::Server;
 
-use crate::interface::RMain;
-use crate::lsp::handlers::VirtualDocumentParams;
-use crate::lsp::handlers::VirtualDocumentResponse;
-use crate::lsp::handlers::ARK_VDOC_REQUEST;
-use crate::lsp::help_topic;
-use crate::lsp::help_topic::HelpTopicParams;
-use crate::lsp::help_topic::HelpTopicResponse;
-use crate::lsp::input_boundaries;
-use crate::lsp::input_boundaries::InputBoundariesParams;
-use crate::lsp::input_boundaries::InputBoundariesResponse;
-use crate::lsp::main_loop::Event;
-use crate::lsp::main_loop::GlobalState;
-use crate::lsp::main_loop::TokioUnboundedSender;
-use crate::lsp::statement_range;
-use crate::lsp::statement_range::StatementRangeParams;
-use crate::lsp::statement_range::StatementRangeResponse;
-use crate::r_task;
+use crate::main_loop::Event;
+use crate::main_loop::GlobalState;
+use crate::main_loop::TokioUnboundedSender;
 
 // Based on https://stackoverflow.com/a/69324393/1725177
 macro_rules! cast_response {
@@ -80,44 +61,12 @@ pub(crate) enum LspNotification {
 pub(crate) enum LspRequest {
     Initialize(InitializeParams),
     Shutdown(),
-    WorkspaceSymbol(WorkspaceSymbolParams),
-    DocumentSymbol(DocumentSymbolParams),
-    ExecuteCommand(ExecuteCommandParams),
-    Completion(CompletionParams),
-    CompletionResolve(CompletionItem),
-    Hover(HoverParams),
-    SignatureHelp(SignatureHelpParams),
-    GotoDefinition(GotoDefinitionParams),
-    GotoImplementation(GotoImplementationParams),
-    SelectionRange(SelectionRangeParams),
-    References(ReferenceParams),
-    StatementRange(StatementRangeParams),
-    HelpTopic(HelpTopicParams),
-    OnTypeFormatting(DocumentOnTypeFormattingParams),
-    VirtualDocument(VirtualDocumentParams),
-    InputBoundaries(InputBoundariesParams),
 }
 
 #[derive(Debug)]
 pub(crate) enum LspResponse {
     Initialize(InitializeResult),
     Shutdown(()),
-    WorkspaceSymbol(Option<Vec<SymbolInformation>>),
-    DocumentSymbol(Option<DocumentSymbolResponse>),
-    ExecuteCommand(Option<Value>),
-    Completion(Option<CompletionResponse>),
-    CompletionResolve(CompletionItem),
-    Hover(Option<Hover>),
-    SignatureHelp(Option<SignatureHelp>),
-    GotoDefinition(Option<GotoDefinitionResponse>),
-    GotoImplementation(Option<GotoImplementationResponse>),
-    SelectionRange(Option<Vec<SelectionRange>>),
-    References(Option<Vec<Location>>),
-    StatementRange(Option<StatementRangeResponse>),
-    HelpTopic(Option<HelpTopicResponse>),
-    OnTypeFormatting(Option<Vec<TextEdit>>),
-    VirtualDocument(VirtualDocumentResponse),
-    InputBoundaries(InputBoundariesResponse),
 }
 
 #[derive(Debug)]
@@ -184,36 +133,6 @@ impl LanguageServer for Backend {
         self.notify(LspNotification::DidChangeWatchedFiles(params));
     }
 
-    async fn symbol(
-        &self,
-        params: WorkspaceSymbolParams,
-    ) -> Result<Option<Vec<SymbolInformation>>> {
-        cast_response!(
-            self.request(LspRequest::WorkspaceSymbol(params)).await,
-            LspResponse::WorkspaceSymbol
-        )
-    }
-
-    async fn document_symbol(
-        &self,
-        params: DocumentSymbolParams,
-    ) -> Result<Option<DocumentSymbolResponse>> {
-        cast_response!(
-            self.request(LspRequest::DocumentSymbol(params)).await,
-            LspResponse::DocumentSymbol
-        )
-    }
-
-    async fn execute_command(
-        &self,
-        params: ExecuteCommandParams,
-    ) -> jsonrpc::Result<Option<Value>> {
-        cast_response!(
-            self.request(LspRequest::ExecuteCommand(params)).await,
-            LspResponse::ExecuteCommand
-        )
-    }
-
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         self.notify(LspNotification::DidOpenTextDocument(params));
     }
@@ -229,214 +148,53 @@ impl LanguageServer for Backend {
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         self.notify(LspNotification::DidCloseTextDocument(params));
     }
-
-    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
-        cast_response!(
-            self.request(LspRequest::Completion(params)).await,
-            LspResponse::Completion
-        )
-    }
-
-    async fn completion_resolve(&self, item: CompletionItem) -> Result<CompletionItem> {
-        cast_response!(
-            self.request(LspRequest::CompletionResolve(item)).await,
-            LspResponse::CompletionResolve
-        )
-    }
-
-    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
-        cast_response!(
-            self.request(LspRequest::Hover(params)).await,
-            LspResponse::Hover
-        )
-    }
-
-    async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
-        cast_response!(
-            self.request(LspRequest::SignatureHelp(params)).await,
-            LspResponse::SignatureHelp
-        )
-    }
-
-    async fn goto_definition(
-        &self,
-        params: GotoDefinitionParams,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        cast_response!(
-            self.request(LspRequest::GotoDefinition(params)).await,
-            LspResponse::GotoDefinition
-        )
-    }
-
-    async fn goto_implementation(
-        &self,
-        params: GotoImplementationParams,
-    ) -> Result<Option<GotoImplementationResponse>> {
-        cast_response!(
-            self.request(LspRequest::GotoImplementation(params)).await,
-            LspResponse::GotoImplementation
-        )
-    }
-
-    async fn selection_range(
-        &self,
-        params: SelectionRangeParams,
-    ) -> Result<Option<Vec<SelectionRange>>> {
-        cast_response!(
-            self.request(LspRequest::SelectionRange(params)).await,
-            LspResponse::SelectionRange
-        )
-    }
-
-    async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
-        cast_response!(
-            self.request(LspRequest::References(params)).await,
-            LspResponse::References
-        )
-    }
-
-    async fn on_type_formatting(
-        &self,
-        params: DocumentOnTypeFormattingParams,
-    ) -> Result<Option<Vec<TextEdit>>> {
-        cast_response!(
-            self.request(LspRequest::OnTypeFormatting(params)).await,
-            LspResponse::OnTypeFormatting
-        )
-    }
 }
 
-// Custom methods for the backend.
-//
-// NOTE: Request / notification methods _must_ accept a params object,
-// even for notifications that don't include any auxiliary data.
-//
-// I'm not positive, but I think this is related to the way VSCode
-// serializes parameters for notifications / requests when no data
-// is supplied. Instead of supplying "nothing", it supplies something
-// like `[null]` which tower_lsp seems to quietly reject when attempting
-// to invoke the registered method.
-//
-// See also:
-//
-// https://github.com/Microsoft/vscode-languageserver-node/blob/18fad46b0e8085bb72e1b76f9ea23a379569231a/client/src/common/client.ts#L802-L838
-// https://github.com/Microsoft/vscode-languageserver-node/blob/18fad46b0e8085bb72e1b76f9ea23a379569231a/client/src/common/client.ts#L701-L752
 impl Backend {
-    async fn statement_range(
-        &self,
-        params: StatementRangeParams,
-    ) -> jsonrpc::Result<Option<StatementRangeResponse>> {
-        cast_response!(
-            self.request(LspRequest::StatementRange(params)).await,
-            LspResponse::StatementRange
-        )
-    }
+    pub fn start_lsp(runtime: Arc<Runtime>, address: String, conn_init_tx: Sender<bool>) {
+        runtime.block_on(async {
+            log::trace!("Connecting to LSP at '{}'", &address);
+            let listener = TcpListener::bind(&address).await.unwrap();
 
-    async fn help_topic(
-        &self,
-        params: HelpTopicParams,
-    ) -> jsonrpc::Result<Option<HelpTopicResponse>> {
-        cast_response!(
-            self.request(LspRequest::HelpTopic(params)).await,
-            LspResponse::HelpTopic
-        )
-    }
-
-    async fn virtual_document(
-        &self,
-        params: VirtualDocumentParams,
-    ) -> tower_lsp::jsonrpc::Result<VirtualDocumentResponse> {
-        cast_response!(
-            self.request(LspRequest::VirtualDocument(params)).await,
-            LspResponse::VirtualDocument
-        )
-    }
-
-    async fn input_boundaries(
-        &self,
-        params: InputBoundariesParams,
-    ) -> tower_lsp::jsonrpc::Result<InputBoundariesResponse> {
-        cast_response!(
-            self.request(LspRequest::InputBoundaries(params)).await,
-            LspResponse::InputBoundaries
-        )
-    }
-
-    async fn notification(&self, params: Option<Value>) {
-        log::info!("Received Positron notification: {:?}", params);
-    }
-}
-
-pub fn start_lsp(runtime: Arc<Runtime>, address: String, conn_init_tx: Sender<bool>) {
-    runtime.block_on(async {
-        log::trace!("Connecting to LSP at '{}'", &address);
-        let listener = TcpListener::bind(&address).await.unwrap();
-
-        // Notify frontend that we are ready to accept connections
-        conn_init_tx
-            .send(true)
-            .or_log_warning("Couldn't send LSP server init notification");
-
-        let (stream, _) = listener.accept().await.unwrap();
-        log::trace!("Connected to LSP at '{}'", address);
-        let (read, write) = tokio::io::split(stream);
-
-        let init = |client: Client| {
-            let state = GlobalState::new(client);
-            let events_tx = state.events_tx();
-
-            // Start main loop and hold onto the handle that keeps it alive
-            let main_loop = state.start();
-
-            // Forward event channel along to `RMain`.
-            // This also updates an outdated channel after a reconnect.
-            // `RMain` should be initialized by now, since the caller of this
-            // function waits to receive the init notification sent on
-            // `kernel_init_rx`. Even if it isn't, this should be okay because
-            // `r_task()` defensively blocks until its sender is initialized.
-            r_task({
-                let events_tx = events_tx.clone();
-                move || {
-                    let main = RMain::get_mut();
-                    main.set_lsp_channel(events_tx);
-                }
-            });
-
-            Backend {
-                events_tx,
-                _main_loop: main_loop,
+            // Notify frontend that we are ready to accept connections
+            if let Err(err) = conn_init_tx.send(true) {
+                log::warn!("Couldn't send LSP server init notification: {err:?}");
             }
-        };
 
-        let (service, socket) = LspService::build(init)
-            .custom_method(
-                statement_range::POSITRON_STATEMENT_RANGE_REQUEST,
-                Backend::statement_range,
-            )
-            .custom_method(help_topic::POSITRON_HELP_TOPIC_REQUEST, Backend::help_topic)
-            .custom_method(ARK_VDOC_REQUEST, Backend::virtual_document)
-            // In principle this should probably be a Jupyter request
-            .custom_method(
-                input_boundaries::POSITRON_INPUT_BOUNDARIES_REQUEST,
-                Backend::input_boundaries,
-            )
-            .custom_method("positron/notification", Backend::notification)
-            .finish();
+            let (stream, _) = listener.accept().await.unwrap();
+            log::trace!("Connected to LSP at '{}'", address);
+            let (read, write) = tokio::io::split(stream);
 
-        let server = Server::new(read, write, socket);
-        server.serve(service).await;
+            let init = |client: Client| {
+                let state = GlobalState::new(client);
+                let events_tx = state.events_tx();
 
-        log::trace!(
-            "LSP thread exiting gracefully after connection closed ({:?}).",
-            address
-        );
-    })
+                // Start main loop and hold onto the handle that keeps it alive
+                let main_loop = state.start();
+
+                Backend {
+                    events_tx,
+                    _main_loop: main_loop,
+                }
+            };
+
+            let (service, socket) = LspService::build(init).finish();
+
+            let server = Server::new(read, write, socket);
+            server.serve(service).await;
+
+            log::trace!(
+                "LSP thread exiting gracefully after connection closed ({:?}).",
+                address
+            );
+        })
+    }
 }
 
 fn new_jsonrpc_error(message: String) -> jsonrpc::Error {
     jsonrpc::Error {
         code: jsonrpc::ErrorCode::ServerError(-1),
-        message,
+        message: message.into(),
         data: None,
     }
 }


### PR DESCRIPTION
This PR adds a new internal crate `lsp` and imports the infrastructure and relevant features of Ark's LSP. The Git history has been preserved.

It does not do anything else and doesn't need a review. It will serve as base of the first Air LSP PR.

All of these commits are from ark.