### PR TITLE
Gather all proto converters in same mods

### DIFF
--- a/crates/lsp/src/from_proto.rs
+++ b/crates/lsp/src/from_proto.rs
@@ -1,0 +1,1 @@
+pub(crate) use biome_lsp_converters::from_proto::text_range;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -6,6 +6,7 @@ pub use tower_lsp::start_lsp;
 pub mod config;
 pub mod documents;
 pub mod encoding;
+pub mod from_proto;
 pub mod handlers;
 pub mod handlers_ext;
 pub mod handlers_format;

--- a/crates/lsp/src/rust_analyzer/utils.rs
+++ b/crates/lsp/src/rust_analyzer/utils.rs
@@ -10,6 +10,8 @@ use biome_lsp_converters::line_index;
 use tower_lsp::lsp_types;
 use triomphe::Arc;
 
+use crate::from_proto;
+
 use super::line_index::{LineEndings, LineIndex};
 
 pub(crate) fn apply_document_changes(
@@ -54,11 +56,8 @@ pub(crate) fn apply_document_changes(
                 *Arc::make_mut(&mut line_index.index) = line_index::LineIndex::new(&text);
             }
             index_valid = range.start.line;
-            if let Ok(range) = biome_lsp_converters::from_proto::text_range(
-                &line_index.index,
-                range,
-                line_index.encoding,
-            ) {
+            if let Ok(range) = from_proto::text_range(&line_index.index, range, line_index.encoding)
+            {
                 text.replace_range(Range::<usize>::from(range), &change.text);
             }
         }

--- a/crates/lsp/src/to_proto.rs
+++ b/crates/lsp/src/to_proto.rs
@@ -7,17 +7,16 @@
 
 // Utilites for converting internal types to LSP types
 
-pub use crate::rust_analyzer::to_proto as rust_analyzer;
+pub(crate) use rust_analyzer::to_proto::text_edit_vec;
 
+use crate::rust_analyzer::{self, line_index::LineIndex, text_edit::TextEdit};
 use tower_lsp::lsp_types;
-
-use crate::rust_analyzer::{line_index::LineIndex, text_edit::TextEdit, to_proto};
 
 pub(crate) fn doc_edit_vec(
     line_index: &LineIndex,
     text_edit: TextEdit,
 ) -> anyhow::Result<Vec<lsp_types::TextDocumentContentChangeEvent>> {
-    let edits = to_proto::text_edit_vec(line_index, text_edit)?;
+    let edits = text_edit_vec(line_index, text_edit)?;
 
     Ok(edits
         .into_iter()
@@ -35,5 +34,5 @@ pub(crate) fn replace_all_edit(
     replace_with: String,
 ) -> anyhow::Result<Vec<lsp_types::TextEdit>> {
     let edit = TextEdit::replace_all(text, replace_with);
-    to_proto::text_edit_vec(line_index, edit)
+    text_edit_vec(line_index, edit)
 }


### PR DESCRIPTION
Gather conversion tools to `src/from_proto.rs` and `src/to_proto.rs`.

Tools from rust-analyzer and biome are reexported there, this way we only have to think about a single module when doing conversions.