### PR TITLE
Dont `group()` around identifiers

### DIFF
--- a/crates/air_r_formatter/src/r/auxiliary/identifier.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/identifier.rs
@@ -8,6 +8,6 @@ pub(crate) struct FormatRIdentifier;
 impl FormatNodeRule<RIdentifier> for FormatRIdentifier {
     fn fmt_fields(&self, node: &RIdentifier, f: &mut RFormatter) -> FormatResult<()> {
         let RIdentifierFields { name_token } = node.as_fields();
-        write![f, [group(&name_token.format())]]
+        write![f, [name_token.format()]]
     }
 }


### PR DESCRIPTION
Closes #54 

For 

```r
map(x, foo(a, b))
```

Look at this old IR

```
[
  group(["map"]),
  group([
    "(",
    indent([
      soft_line_break,
      group(["x"]),
      ",",
      soft_line_break_or_space,
      group(["foo"]),
      group([
        "(",
        indent([
          soft_line_break,
          group(["a"]),
          ",",
          soft_line_break_or_space,
          group(["b"])
        ]),
        soft_line_break,
        ")"
      ])
    ]),
    soft_line_break,
    ")"
  ]),
  hard_line_break
]
```

compared to this new one, with much less `group()`ing

```
[
  "map",
  group([
    "(",
    indent([
      soft_line_break,
      "x,",
      soft_line_break_or_space,
      "foo",
      group([
        "(",
        indent([soft_line_break, "a,", soft_line_break_or_space, "b"]),
        soft_line_break,
        ")"
      ])
    ]),
    soft_line_break,
    ")"
  ]),
  hard_line_break
]
```