### PR TITLE
Remove the global `AUXILIARY_EVENT_TX` and use `tracing`

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -95,7 +95,7 @@ impl From<VscDocumentConfig> for DocumentConfig {
                 if var == "tabSize" {
                     x.tab_size
                 } else {
-                    crate::log_warn!("Unknown indent alias {var}, using default");
+                    log::warn!("Unknown indent alias {var}, using default");
                     2
                 }
             }

--- a/crates/lsp/src/handlers_state.rs
+++ b/crates/lsp/src/handlers_state.rs
@@ -33,6 +33,7 @@ use crate::config::DocumentConfig;
 use crate::config::VscDiagnosticsConfig;
 use crate::config::VscDocumentConfig;
 use crate::documents::Document;
+use crate::main_loop::AuxiliaryEventSender;
 use crate::main_loop::LspState;
 use crate::state::workspace_uris;
 use crate::state::WorldState;
@@ -156,6 +157,7 @@ pub(crate) fn did_change(
 pub(crate) fn did_close(
     params: DidCloseTextDocumentParams,
     state: &mut WorldState,
+    auxiliary_event_tx: &AuxiliaryEventSender,
 ) -> anyhow::Result<()> {
     let uri = params.text_document.uri;
 
@@ -167,7 +169,7 @@ pub(crate) fn did_close(
         .remove(&uri)
         .ok_or(anyhow!("Failed to remove document for URI: {uri}"))?;
 
-    crate::log_info!("did_close(): closed document with URI: '{uri}'.");
+    auxiliary_event_tx.log_info(format!("did_close(): closed document with URI: '{uri}'."));
 
     Ok(())
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -19,25 +19,3 @@ pub mod tower_lsp;
 
 #[cfg(test)]
 pub mod tower_lsp_test_client;
-
-// These send LSP messages in a non-async and non-blocking way.
-// The LOG level is not timestamped so we're not using it.
-macro_rules! log_info {
-    ($($arg:tt)+) => ($crate::_log!(tower_lsp::lsp_types::MessageType::INFO, $($arg)+))
-}
-macro_rules! log_warn {
-    ($($arg:tt)+) => ($crate::_log!(tower_lsp::lsp_types::MessageType::WARNING, $($arg)+))
-}
-macro_rules! log_error {
-    ($($arg:tt)+) => ($crate::_log!(tower_lsp::lsp_types::MessageType::ERROR, $($arg)+))
-}
-macro_rules! _log {
-    ($lvl:expr, $($arg:tt)+) => ({
-        $crate::main_loop::log($lvl, format!($($arg)+));
-    });
-}
-
-pub(crate) use _log;
-pub(crate) use log_error;
-pub(crate) use log_info;
-pub(crate) use log_warn;

--- a/crates/lsp/src/main_loop.rs
+++ b/crates/lsp/src/main_loop.rs
@@ -35,13 +35,6 @@ use crate::tower_lsp::LspResponse;
 pub(crate) type TokioUnboundedSender<T> = tokio::sync::mpsc::UnboundedSender<T>;
 pub(crate) type TokioUnboundedReceiver<T> = tokio::sync::mpsc::UnboundedReceiver<T>;
 
-// The global instance of the auxiliary event channel, used for sending log
-// messages or spawning threads from free functions. Since this is an unbounded
-// channel, sending a log message is not async nor blocking. Tokio senders are
-// Send and Sync so this global variable can be safely shared across threads.
-static mut AUXILIARY_EVENT_TX: std::cell::OnceCell<TokioUnboundedSender<AuxiliaryEvent>> =
-    std::cell::OnceCell::new();
-
 // This is the syntax for trait aliases until an official one is stabilised.
 // This alias is for the future of a `JoinHandle<anyhow::Result<T>>`
 trait AnyhowJoinHandleFut<T>:
@@ -74,6 +67,61 @@ pub(crate) enum AuxiliaryEvent {
     SpawnedTask(JoinHandle<anyhow::Result<Option<AuxiliaryEvent>>>),
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct AuxiliaryEventSender {
+    inner: TokioUnboundedSender<AuxiliaryEvent>,
+}
+
+impl AuxiliaryEventSender {
+    pub(crate) fn new(tx: TokioUnboundedSender<AuxiliaryEvent>) -> Self {
+        Self { inner: tx }
+    }
+
+    /// Passthrough `send()` method to the underlying sender
+    pub(crate) fn send(
+        &self,
+        message: AuxiliaryEvent,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<AuxiliaryEvent>> {
+        self.inner.send(message)
+    }
+
+    pub(crate) fn log_info(&self, message: String) {
+        self.log(MessageType::INFO, message);
+    }
+    pub(crate) fn log_warn(&self, message: String) {
+        self.log(MessageType::WARNING, message);
+    }
+    pub(crate) fn log_error(&self, message: String) {
+        self.log(MessageType::ERROR, message);
+    }
+
+    /// Send an `AuxiliaryEvent::Log` message in a non-blocking way
+    fn log(&self, level: lsp_types::MessageType, message: String) {
+        // We're not connected to an LSP client when running unit tests
+        if cfg!(test) {
+            return;
+        }
+
+        // Check that channel is still alive in case the LSP was closed.
+        // If closed, fallthrough.
+        if self
+            .send(AuxiliaryEvent::Log(level, message.clone()))
+            .is_ok()
+        {
+            return;
+        }
+
+        // Log to the kernel as fallback
+        log::warn!("LSP channel is closed, redirecting messages to Jupyter kernel");
+
+        match level {
+            MessageType::ERROR => log::error!("{message}"),
+            MessageType::WARNING => log::warn!("{message}"),
+            _ => log::info!("{message}"),
+        };
+    }
+}
+
 /// Global state for the main loop
 ///
 /// This is a singleton that fully owns the source of truth for `WorldState`
@@ -101,6 +149,16 @@ pub(crate) struct GlobalState {
     /// `Event::Task`.
     events_tx: TokioUnboundedSender<Event>,
     events_rx: TokioUnboundedReceiver<Event>,
+
+    /// State of the internal auxiliary loop.
+    /// Fully managed by the `GlobalState`.
+    /// Initialized as `Some()`, and converted to `None` on `start()`.
+    auxiliary_state: Option<AuxiliaryState>,
+
+    /// Event channel for sending to the auxiliary loop.
+    /// Used for sending latency sensitive events like logs, tasks, and
+    /// diagnostics.
+    auxiliary_event_tx: AuxiliaryEventSender,
 }
 
 /// Unlike `WorldState`, `ParserState` cannot be cloned and is only accessed by
@@ -168,10 +226,14 @@ impl GlobalState {
         // tower-lsp backend and the Jupyter kernel.
         let (events_tx, events_rx) = tokio_unbounded_channel::<Event>();
 
+        let (auxiliary_state, auxiliary_event_tx) = AuxiliaryState::new(client.clone());
+
         Self {
             world: WorldState::default(),
             lsp_state: LspState::default(),
             client,
+            auxiliary_state: Some(auxiliary_state),
+            auxiliary_event_tx,
             events_tx,
             events_rx,
         }
@@ -180,6 +242,11 @@ impl GlobalState {
     /// Get `Event` transmission channel
     pub(crate) fn events_tx(&self) -> TokioUnboundedSender<Event> {
         self.events_tx.clone()
+    }
+
+    /// Get `AuxiliaryEvent` transmission channel
+    pub(crate) fn auxiliary_event_tx(&self) -> AuxiliaryEventSender {
+        self.auxiliary_event_tx.clone()
     }
 
     /// Start the main and auxiliary loops
@@ -202,14 +269,17 @@ impl GlobalState {
     async fn main_loop(mut self) {
         // Spawn latency-sensitive auxiliary loop. Must be first to initialise
         // global transmission channel.
-        let aux = AuxiliaryState::new(self.client.clone());
         let mut set = tokio::task::JoinSet::<()>::new();
-        set.spawn(async move { aux.start().await });
+
+        // Move the `auxiliary_state` owned by the global state to its own thread.
+        // Unwrap: `start()` should only ever be called once.
+        let auxiliary_state = self.auxiliary_state.take().unwrap();
+        set.spawn(async move { auxiliary_state.start().await });
 
         loop {
             let event = self.next_event().await;
             match self.handle_event(event).await {
-                Err(err) => crate::log_error!("Failure while handling event:\n{err:?}"),
+                Err(err) => self.log_error(format!("Failure while handling event:\n{err:?}")),
                 Ok(LoopControl::Shutdown) => break,
                 _ => {}
             }
@@ -269,7 +339,7 @@ impl GlobalState {
                             // Currently ignored
                         },
                         LspNotification::DidCloseTextDocument(params) => {
-                            handlers_state::did_close(params, &mut self.world)?;
+                            handlers_state::did_close(params, &mut self.world, &self.auxiliary_event_tx)?;
                         },
                     }
                 },
@@ -302,7 +372,7 @@ impl GlobalState {
 
         // TODO Make this threshold configurable by the client
         if loop_tick.elapsed() > std::time::Duration::from_millis(50) {
-            crate::log_info!("Handler took {}ms", loop_tick.elapsed().as_millis());
+            self.log_info(format!("Handler took {}ms", loop_tick.elapsed().as_millis()));
         }
 
         Ok(out)
@@ -319,6 +389,7 @@ impl GlobalState {
     /// world state could be run concurrently. On the other hand, handlers that
     /// manipulate documents (e.g. formatting or refactoring) should not.
     fn spawn_handler<T, Handler>(
+        &self,
         response_tx: TokioUnboundedSender<anyhow::Result<LspResponse>>,
         handler: Handler,
         into_lsp_response: impl FnOnce(T) -> LspResponse + Send + 'static,
@@ -326,7 +397,43 @@ impl GlobalState {
         Handler: FnOnce() -> anyhow::Result<T>,
         Handler: Send + 'static,
     {
-        spawn_blocking(move || respond(response_tx, handler(), into_lsp_response).and(Ok(None)))
+        self.spawn_blocking(move || {
+            respond(response_tx, handler(), into_lsp_response).and(Ok(None))
+        })
+    }
+
+    /// Spawn a blocking task
+    ///
+    /// This runs tasks that do semantic analysis on a separate thread pool to avoid
+    /// blocking the main loop.
+    ///
+    /// Can optionally return an event for the auxiliary loop (i.e. a log message or
+    /// diagnostics publication).
+    fn spawn_blocking<Handler>(&self, handler: Handler)
+    where
+        Handler: FnOnce() -> anyhow::Result<Option<AuxiliaryEvent>>,
+        Handler: Send + 'static,
+    {
+        let handle = tokio::task::spawn_blocking(|| handler());
+
+        // Send the join handle to the auxiliary loop so it can log any errors
+        // or panics
+        if let Err(err) = self
+            .auxiliary_event_tx
+            .send(AuxiliaryEvent::SpawnedTask(handle))
+        {
+            log::warn!("Failed to send task to auxiliary loop due to {err}");
+        }
+    }
+
+    fn log_info(&self, message: String) {
+        self.auxiliary_event_tx.log_info(message);
+    }
+    fn log_warn(&self, message: String) {
+        self.auxiliary_event_tx.log_warn(message);
+    }
+    fn log_error(&self, message: String) {
+        self.auxiliary_event_tx.log_error(message);
     }
 }
 
@@ -371,23 +478,10 @@ fn respond<T>(
 unsafe impl Sync for AuxiliaryState {}
 
 impl AuxiliaryState {
-    fn new(client: Client) -> Self {
+    fn new(client: Client) -> (Self, AuxiliaryEventSender) {
         // Channels for communication with the auxiliary loop
         let (auxiliary_event_tx, auxiliary_event_rx) = tokio_unbounded_channel::<AuxiliaryEvent>();
-
-        // Set global instance of this channel. This is used for interacting
-        // with the auxiliary loop (logging messages or spawning a task) from
-        // free functions.
-        unsafe {
-            #[allow(static_mut_refs)]
-            if let Some(val) = AUXILIARY_EVENT_TX.get_mut() {
-                // Reset channel if already set. Happens e.g. on reconnection after a refresh.
-                *val = auxiliary_event_tx;
-            } else {
-                // Set channel for the first time
-                AUXILIARY_EVENT_TX.set(auxiliary_event_tx).unwrap();
-            }
-        }
+        let auxiliary_event_tx = AuxiliaryEventSender::new(auxiliary_event_tx);
 
         // List of pending tasks for which we manage the lifecycle (mainly relay
         // errors and panics)
@@ -401,11 +495,13 @@ impl AuxiliaryState {
             Box::pin(pending) as Pin<Box<dyn AnyhowJoinHandleFut<Option<AuxiliaryEvent>> + Send>>;
         tasks.push(pending);
 
-        Self {
+        let state = Self {
             client,
             auxiliary_event_rx,
             tasks,
-        }
+        };
+
+        (state, auxiliary_event_tx)
     }
 
     /// Start the auxiliary loop
@@ -450,66 +546,4 @@ impl AuxiliaryState {
     async fn log_error(&self, message: String) {
         self.client.log_message(MessageType::ERROR, message).await
     }
-}
-
-fn auxiliary_tx() -> &'static TokioUnboundedSender<AuxiliaryEvent> {
-    // If we get here that means the LSP was initialised at least once. The
-    // channel might be closed if the LSP was dropped, but it should exist.
-    unsafe {
-        #[allow(static_mut_refs)]
-        AUXILIARY_EVENT_TX.get().unwrap()
-    }
-}
-
-fn send_auxiliary(event: AuxiliaryEvent) {
-    if let Err(err) = auxiliary_tx().send(event) {
-        // The error includes the event
-        log::warn!("LSP is shut down, can't send event:\n{err:?}");
-    }
-}
-
-/// Send a message to the LSP client. This is non-blocking and treated on a
-/// latency-sensitive task.
-pub(crate) fn log(level: lsp_types::MessageType, message: String) {
-    // We're not connected to an LSP client when running unit tests
-    if cfg!(test) {
-        return;
-    }
-
-    // Check that channel is still alive in case the LSP was closed.
-    // If closed, fallthrough.
-    if auxiliary_tx()
-        .send(AuxiliaryEvent::Log(level, message.clone()))
-        .is_ok()
-    {
-        return;
-    }
-
-    // Log to the kernel as fallback
-    log::warn!("LSP channel is closed, redirecting messages to Jupyter kernel");
-
-    match level {
-        MessageType::ERROR => log::error!("{message}"),
-        MessageType::WARNING => log::warn!("{message}"),
-        _ => log::info!("{message}"),
-    };
-}
-
-/// Spawn a blocking task
-///
-/// This runs tasks that do semantic analysis on a separate thread pool to avoid
-/// blocking the main loop.
-///
-/// Can optionally return an event for the auxiliary loop (i.e. a log message or
-/// diagnostics publication).
-pub(crate) fn spawn_blocking<Handler>(handler: Handler)
-where
-    Handler: FnOnce() -> anyhow::Result<Option<AuxiliaryEvent>>,
-    Handler: Send + 'static,
-{
-    let handle = tokio::task::spawn_blocking(handler);
-
-    // Send the join handle to the auxiliary loop so it can log any errors
-    // or panics
-    send_auxiliary(AuxiliaryEvent::SpawnedTask(handle));
 }

--- a/crates/lsp/src/tower_lsp.rs
+++ b/crates/lsp/src/tower_lsp.rs
@@ -17,6 +17,7 @@ use tower_lsp::LspService;
 use tower_lsp::{jsonrpc, ClientSocket};
 
 use crate::handlers_ext::ViewFileParams;
+use crate::main_loop::AuxiliaryEventSender;
 use crate::main_loop::Event;
 use crate::main_loop::GlobalState;
 use crate::main_loop::TokioUnboundedSender;
@@ -77,6 +78,10 @@ struct Backend {
     /// Channel for communication with the main loop.
     events_tx: TokioUnboundedSender<Event>,
 
+    /// Channel for communication with the auxiliary loop.
+    /// Used for latency sensitive logging.
+    auxiliary_event_tx: AuxiliaryEventSender,
+
     /// Handle to main loop. Drop it to cancel the loop, all associated tasks,
     /// and drop all owned state.
     _main_loop: tokio::task::JoinSet<()>,
@@ -84,7 +89,7 @@ struct Backend {
 
 impl Backend {
     async fn request(&self, request: LspRequest) -> anyhow::Result<LspResponse> {
-        crate::log_info!("Incoming: {request:#?}");
+        self.log_info(format!("Incoming: {request:#?}"));
 
         let (response_tx, mut response_rx) =
             tokio_unbounded_channel::<anyhow::Result<LspResponse>>();
@@ -97,12 +102,12 @@ impl Backend {
         // Wait for response from main loop
         let out = response_rx.recv().await.unwrap()?;
 
-        crate::log_info!("Outgoing {out:#?}");
+        self.log_info(format!("Outgoing {out:#?}"));
         Ok(out)
     }
 
     fn notify(&self, notif: LspNotification) {
-        crate::log_info!("Incoming: {notif:#?}");
+        self.log_info(format!("Incoming: {notif:#?}"));
 
         // Relay notification to main loop
         self.events_tx
@@ -115,6 +120,10 @@ impl Backend {
             self.request(LspRequest::AirViewFile(params)).await,
             LspResponse::AirViewFile
         )
+    }
+
+    fn log_info(&self, message: String) {
+        self.auxiliary_event_tx.log_info(message);
     }
 }
 
@@ -192,12 +201,14 @@ fn new_lsp() -> (LspService<Backend>, ClientSocket) {
     let init = |client: Client| {
         let state = GlobalState::new(client);
         let events_tx = state.events_tx();
+        let auxiliary_event_tx = state.auxiliary_event_tx();
 
         // Start main loop and hold onto the handle that keeps it alive
         let main_loop = state.start();
 
         Backend {
             events_tx,
+            auxiliary_event_tx,
             _main_loop: main_loop,
         }
     };


### PR DESCRIPTION
Closes #79 

This is a first pass to completely remove `AUXILIARY_EVENT_TX` in favor of passing around state to access `auxiliary_event_tx`, owned by `GlobalState`.

Currently logging is tied up in auxiliary events, which results in a net loss for ergonomics when you want to log something, as you need to pass `auxiliary_event_tx` around to call its `log_error()` methods.

#93 is a follow up to this PR that splits the log specific events out of this, instead hooking up a tracing subscriber for logging so you can use `tracing::error!()` as a free function anywhere in the LSP 

