### PR TITLE
Implement "leading hole hugging" behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "biome_formatter",
  "biome_parser",
  "biome_rowan",
+ "itertools",
  "tests_macros",
  "tracing",
 ]

--- a/crates/air_r_formatter/Cargo.toml
+++ b/crates/air_r_formatter/Cargo.toml
@@ -16,6 +16,7 @@ version = "0.0.0"
 air_r_syntax = { workspace = true }
 biome_formatter = { workspace = true }
 biome_rowan = { workspace = true }
+itertools = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
@@ -18,6 +18,7 @@ use air_r_syntax::RSyntaxToken;
 use biome_formatter::separated::TrailingSeparator;
 use biome_formatter::{format_args, format_element, write, VecBuffer};
 use biome_rowan::{AstSeparatedElement, AstSeparatedList, SyntaxResult};
+use itertools::Itertools;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatRCallArguments;
@@ -121,28 +122,41 @@ impl Format<RFormatContext> for RCallLikeArguments {
             }
         }
 
-        let last_index = items.len().saturating_sub(1);
-        let mut has_empty_line = false;
+        let mut iter_elements = items.elements();
 
-        // Wrap `RArgumentList` elements in a `FormatCallArgument` type that
+        // TODO: Don't clone, maybe delay interning until first format()
+        // call by using interior mutability?
+        let comments = f.comments().clone();
+
+        // Split leading holes out from the remainder of the arguments.
+        // Leading holes tightly hug the `l_token` no matter what.
+        // Because they are intended to tightly hug, a node is only considered
+        // a leading hole if there isn't a comment attached.
+        let leading_holes: Vec<_> = iter_elements
+            .take_while_ref(|element| {
+                element.node().map_or(false, |node| {
+                    node.is_hole() && !comments.has_comments(node.syntax())
+                })
+            })
+            .map(|element| FormatCallArgumentHole::new(element, f))
+            .collect();
+
+        let last_index = (items.len() - leading_holes.len()).saturating_sub(1);
+
+        // Wrap remaining `RArgumentList` elements in a `FormatCallArgument` type that
         // knows how to cache itself when we use `will_break()` to check if
         // the argument breaks
-        let arguments: Vec<_> = items
-            .elements()
+        let arguments: Vec<_> = iter_elements
             .enumerate()
-            .map(|(index, element)| {
-                let leading_lines = element
-                    .node()
-                    .map_or(0, |node| get_lines_before(node.syntax()));
-                has_empty_line = has_empty_line || leading_lines > 1;
-
-                FormatCallArgument::Default {
-                    element,
-                    is_last: index == last_index,
-                    leading_lines,
-                }
-            })
+            .map(|(index, element)| FormatCallArgument::new(element, index == last_index))
             .collect();
+
+        let has_empty_line = leading_holes
+            .iter()
+            .any(|leading_hole| leading_hole.leading_lines() > 1)
+            || arguments
+                .iter()
+                .any(|argument| argument.leading_lines() > 1);
 
         // Special case where the user has requested a fully empty line between
         // some of their arguments. Let's respect that and use it as an
@@ -152,6 +166,7 @@ impl Format<RFormatContext> for RCallLikeArguments {
                 f,
                 [FormatAllArgsBrokenOut {
                     l_token: &l_token.format(),
+                    leading_holes: &leading_holes,
                     args: &arguments,
                     r_token: &r_token.format(),
                     expand: true,
@@ -160,12 +175,13 @@ impl Format<RFormatContext> for RCallLikeArguments {
         }
 
         // Special case where a line break exists between the `l_token` and the
-        // first argument. Treat this as a user request to expand.
-        if needs_user_requested_expansion(&arguments) {
+        // first non-hole argument. Treat this as a user request to expand.
+        if needs_user_requested_expansion(&leading_holes, &arguments) {
             return write!(
                 f,
                 [FormatAllArgsBrokenOut {
                     l_token: &l_token.format(),
+                    leading_holes: &leading_holes,
                     args: &arguments,
                     r_token: &r_token.format(),
                     expand: true,
@@ -174,12 +190,13 @@ impl Format<RFormatContext> for RCallLikeArguments {
         }
 
         if let Some(group_layout) = arguments_grouped_layout(&items, f.comments()) {
-            write_grouped_arguments(&l_token, &r_token, arguments, group_layout, f)
+            write_grouped_arguments(l_token, leading_holes, arguments, r_token, group_layout, f)
         } else {
             write!(
                 f,
                 [FormatAllArgsBrokenOut {
                     l_token: &l_token.format(),
+                    leading_holes: &leading_holes,
                     args: &arguments,
                     r_token: &r_token.format(),
                     expand: false,
@@ -189,8 +206,9 @@ impl Format<RFormatContext> for RCallLikeArguments {
     }
 }
 
-/// Check if the user has inserted a leading newline before the very first `argument`.
-/// If so, we respect that and treat it as a request to break ALL of the arguments.
+/// Check if the user has inserted a leading newline before the very first
+/// non-hole `argument`. If so, we respect that and treat it as a request to
+/// break ALL of the arguments.
 /// Note this is a case of irreversible formatting!
 ///
 /// ```r
@@ -225,12 +243,116 @@ impl Format<RFormatContext> for RCallLikeArguments {
 /// # Output
 /// dictionary <- list(bob = "burger", dina = "dairy", john = "juice")
 /// ```
-fn needs_user_requested_expansion(arguments: &[FormatCallArgument]) -> bool {
+///
+/// The leading line check is done on the first non-hole argument, so this
+/// is considered a user requested expansion and stays as is because there
+/// is a leading newline before the `j` argument node.
+///
+/// ```r
+/// dt[,
+///   j = complex + things,
+///   by = col
+/// ]
+/// ```
+///
+/// This is also considered a user requested expansion. We treat holes as
+/// "invisible" for this check, so if you squint and remove the leading `,`
+/// and there are any leading lines before the first non-hole argument,
+/// that is still considered a user requested expansion, but the `,`s attached
+/// to the hole will get moved to hug the `[`.
+///
+/// ```r
+/// dt[
+///   , j = complex + things,
+///   by = col
+/// ]
+/// ```
+fn needs_user_requested_expansion(
+    leading_holes: &[FormatCallArgumentHole],
+    arguments: &[FormatCallArgument],
+) -> bool {
     // TODO: This should be configurable by an option, since it is a case of
     // irreversible formatting
-    arguments
+
+    // Do any leading holes have leading lines?
+    // We treat leading holes as "invisible" so a leading line in the hole
+    // implies a leading line in the first argument.
+    if leading_holes.iter().any(|hole| hole.leading_lines() > 0) {
+        return true;
+    }
+
+    // Does the first non-hole argument have leading lines?
+    if arguments
         .first()
         .map_or(false, |argument| argument.leading_lines() > 0)
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Helper for formatting a call argument hole
+///
+/// We format on creation and cache the result. This is necessary because
+/// using `BestFitting` will try and print the hole multiple times as it
+/// tries out the different variants, which would be an error if it wasn't
+/// cached.
+struct FormatCallArgumentHole {
+    /// The formatted element
+    content: FormatResult<Option<FormatElement>>,
+
+    /// The number of lines before this node
+    leading_lines: usize,
+}
+
+impl FormatCallArgumentHole {
+    fn new(
+        element: AstSeparatedElement<RLanguage, RArgument>,
+        f: &mut Formatter<RFormatContext>,
+    ) -> Self {
+        // Note that holes by their very nature don't have any physical nodes
+        // to attach trivia to, so we can't use `get_lines_before()` on the
+        // node. Instead we look at the attached `,` token and look for lines
+        // before that!
+        let leading_lines = element
+            .trailing_separator()
+            .unwrap_or(None)
+            .map_or(0, get_lines_before_token);
+
+        // Go ahead and intern the node, its printed contents are going to
+        // be requested multiple times
+        let content = f.intern(&format_with(|f| {
+            write!(
+                f,
+                [
+                    element.node()?.format(),
+                    element.trailing_separator()?.format()
+                ]
+            )
+        }));
+
+        Self {
+            content,
+            leading_lines,
+        }
+    }
+
+    fn leading_lines(&self) -> usize {
+        self.leading_lines
+    }
+}
+
+impl Format<RFormatContext> for FormatCallArgumentHole {
+    fn fmt(&self, f: &mut Formatter<RFormatContext>) -> FormatResult<()> {
+        match self.content.clone()? {
+            Some(element) => {
+                f.write_element(element)?;
+                Ok(())
+            }
+            None => Ok(()),
+        }
+    }
 }
 
 /// Helper for formatting a call argument
@@ -262,6 +384,18 @@ enum FormatCallArgument {
 }
 
 impl FormatCallArgument {
+    fn new(element: AstSeparatedElement<RLanguage, RArgument>, is_last: bool) -> Self {
+        let leading_lines = element
+            .node()
+            .map_or(0, |node| get_lines_before(node.syntax()));
+
+        FormatCallArgument::Default {
+            element,
+            is_last,
+            leading_lines,
+        }
+    }
+
     /// Returns `true` if this argument contains any content that forces a group to [`break`](FormatElements::will_break).
     ///
     /// Caches the formatted content after we check, so we can utilize it later
@@ -465,9 +599,10 @@ impl Format<RFormatContext> for FormatCallArgument {
 /// )
 /// ```
 fn write_grouped_arguments(
-    l_token: &RSyntaxToken,
-    r_token: &RSyntaxToken,
+    l_token: RSyntaxToken,
+    leading_holes: Vec<FormatCallArgumentHole>,
     mut arguments: Vec<FormatCallArgument>,
+    r_token: RSyntaxToken,
     group_layout: GroupedCallArgumentLayout,
     f: &mut RFormatter,
 ) -> FormatResult<()> {
@@ -493,6 +628,7 @@ fn write_grouped_arguments(
                 f,
                 [FormatAllArgsBrokenOut {
                     l_token: &l_token.format(),
+                    leading_holes: &leading_holes,
                     args: &arguments,
                     r_token: &r_token.format(),
                     expand: true,
@@ -520,6 +656,7 @@ fn write_grouped_arguments(
             buffer,
             [FormatAllArgsBrokenOut {
                 l_token: &l_token,
+                leading_holes: &leading_holes,
                 args: &arguments,
                 r_token: &r_token,
                 expand: true,
@@ -573,6 +710,8 @@ fn write_grouped_arguments(
             buffer,
             [
                 l_token,
+                format_with(|f| { f.join().entries(leading_holes.iter()).finish() }),
+                maybe_space(!leading_holes.is_empty() && !grouped.is_empty()),
                 format_with(|f| {
                     f.join_with(soft_line_break_or_space())
                         .entries(grouped.iter())
@@ -613,6 +752,8 @@ fn write_grouped_arguments(
             buffer,
             [
                 l_token,
+                format_with(|f| { f.join().entries(leading_holes.iter()).finish() }),
+                maybe_space(!leading_holes.is_empty() && !grouped.is_empty()),
                 format_with(|f| {
                     let mut joiner = f.join_with(soft_line_break_or_space());
 
@@ -769,6 +910,7 @@ impl Format<RFormatContext> for FormatGroupedArgument {
 
 struct FormatAllArgsBrokenOut<'a> {
     l_token: &'a dyn Format<RFormatContext>,
+    leading_holes: &'a [FormatCallArgumentHole],
     args: &'a [FormatCallArgument],
     r_token: &'a dyn Format<RFormatContext>,
     expand: bool,
@@ -797,6 +939,8 @@ impl<'a> Format<RFormatContext> for FormatAllArgsBrokenOut<'a> {
             f,
             [group(&format_args![
                 self.l_token,
+                format_with(|f| f.join().entries(self.leading_holes.iter()).finish()),
+                maybe_space(!self.leading_holes.is_empty() && !self.args.is_empty()),
                 soft_block_indent(&args),
                 self.r_token,
             ])

--- a/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
@@ -23,7 +23,6 @@ use biome_rowan::{AstSeparatedElement, AstSeparatedList, SyntaxResult};
 pub(crate) struct FormatRCallArguments;
 impl FormatNodeRule<RCallArguments> for FormatRCallArguments {
     fn fmt_fields(&self, node: &RCallArguments, f: &mut RFormatter) -> FormatResult<()> {
-        // TODO: Special handling for comments? See `handle_array_holes` for JS.
         RCallLikeArguments::Call(node.clone()).fmt(f)
     }
 

--- a/crates/air_r_formatter/src/r/auxiliary/subset_2_arguments.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/subset_2_arguments.rs
@@ -6,7 +6,6 @@ use air_r_syntax::RSubset2Arguments;
 pub(crate) struct FormatRSubset2Arguments;
 impl FormatNodeRule<RSubset2Arguments> for FormatRSubset2Arguments {
     fn fmt_fields(&self, node: &RSubset2Arguments, f: &mut RFormatter) -> FormatResult<()> {
-        // TODO: Special handling for comments? See `handle_array_holes` for JS.
         RCallLikeArguments::Subset2(node.clone()).fmt(f)
     }
 

--- a/crates/air_r_formatter/src/r/auxiliary/subset_arguments.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/subset_arguments.rs
@@ -6,7 +6,6 @@ use air_r_syntax::RSubsetArguments;
 pub(crate) struct FormatRSubsetArguments;
 impl FormatNodeRule<RSubsetArguments> for FormatRSubsetArguments {
     fn fmt_fields(&self, node: &RSubsetArguments, f: &mut RFormatter) -> FormatResult<()> {
-        // TODO: Special handling for comments? See `handle_array_holes` for JS.
         RCallLikeArguments::Subset(node.clone()).fmt(f)
     }
 

--- a/crates/air_r_formatter/tests/specs/r/call.R
+++ b/crates/air_r_formatter/tests/specs/r/call.R
@@ -4,9 +4,16 @@ fn(a)
 # ------------------------------------------------------------------------
 # Holes
 
+# Leading holes should hug the `(` token
 fn(,)
 fn(,,)
+
+# Non-leading holes retain spaces because they are considered "weird"
+# and we want them to stand out
+fn(, a,)
+fn(, a, , )
 fn(a,,b,,)
+
 fn(a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,)
 
 # ------------------------------------------------------------------------
@@ -64,11 +71,167 @@ test_that(
 
 })
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+# ------------------------------------------------------------------------
+# User requested line break and leading holes
+
+# Leading holes are "invisible" when determining user requested expansion
+# These all expand
+fn(,
+  x = 1
+)
+
 fn(
   ,
   x = 1
+)
+
+fn(
+  , x = 1
+)
+
+fn(
+  ,, x = 1
+)
+
+# A comment connected to a hole prevents it from being a "leading hole",
+# instead it just becomes part of the typical arguments list and expands
+fn(
+  # comment
+  ,
+  x = 1
+)
+
+fn(
+  ,
+  # comment
+  ,
+  x = 1
+)
+
+# ------------------------------------------------------------------------
+# Comments "inside" holes
+
+fn(# comment
+  ,
+)
+
+fn(, # comment
+)
+fn(,
+  # comment
+)
+fn(
+  , # comment
+)
+fn(
+  ,
+  # comment
+)
+
+fn(, # comment
+  ,
+)
+fn(,
+  # comment
+  ,
+)
+fn(
+  , # comment
+  ,
+)
+fn(
+  ,
+  # comment
+  ,
+)
+
+fn(
+  ,
+  , # comment1
+  # comment2
+  ,
+  x
+)
+
+# Trails `a`
+fn(
+  a, # comment
+  ,
+  b
+)
+# Trails `a` technically, but should stay on own line
+fn(
+  a,
+  # comment
+  ,
+  b
+)
+# Trails `a`
+fn(
+  a, # comment
+  # comment2
+  ,
+  b
+)
+
+# Special test - ensure this leads `b` rather than trails `a`
+fn(
+  ,
+  a,
+  , # comment
+  b
+)
+
+# Both comments lead the hole
+fn(# comment1
+  # comment2
+  ,
+  x
+)
+
+# Comment leads hole
+# Following token is `,`, preceding before hole is another hole
+fn(
+  a,
+  , # comment
+  ,
+  b
+)
+fn(
+  , # comment
+  ,
+  x
+)
+
+# Comment leads `{` but doesn't move inside it
+fn(
+  ,
+  , # comment
+  { 1 +  1 }
+)
+
+# A particular motivating case. Want trailing `,` commentB to stay on `b`.
+list2(
+  a, # commentA
+  b, # commentB
+)
+
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+# Both get attached to `x`
+# Following token isn't `,`, `)`, `]`, or `]]`, and following node is non-hole,
+# so we attach to it
+fn(
+  ,
+  , # comment
+  x
+)
+fn(
+  ,
+  , # comment1
+  # comment2
+  x
 )
 
 # ------------------------------------------------------------------------
@@ -438,6 +601,27 @@ fn(
 
   # comment2
   c
+)
+
+# Due to holes not having tokens, we collapse full empty lines in them
+fn(
+
+  # comment1
+  ,
+
+  # comment2
+  ,
+
+  b
+)
+
+fn(
+  ,
+
+  # comment2
+  ,
+
+  b
 )
 
 # ------------------------------------------------------------------------

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -11,9 +11,16 @@ fn(a)
 # ------------------------------------------------------------------------
 # Holes
 
+# Leading holes should hug the `(` token
 fn(,)
 fn(,,)
+
+# Non-leading holes retain spaces because they are considered "weird"
+# and we want them to stand out
+fn(, a,)
+fn(, a, , )
 fn(a,,b,,)
+
 fn(a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,)
 
 # ------------------------------------------------------------------------
@@ -71,11 +78,167 @@ test_that(
 
 })
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
+# ------------------------------------------------------------------------
+# User requested line break and leading holes
+
+# Leading holes are "invisible" when determining user requested expansion
+# These all expand
+fn(,
+  x = 1
+)
+
 fn(
   ,
   x = 1
+)
+
+fn(
+  , x = 1
+)
+
+fn(
+  ,, x = 1
+)
+
+# A comment connected to a hole prevents it from being a "leading hole",
+# instead it just becomes part of the typical arguments list and expands
+fn(
+  # comment
+  ,
+  x = 1
+)
+
+fn(
+  ,
+  # comment
+  ,
+  x = 1
+)
+
+# ------------------------------------------------------------------------
+# Comments "inside" holes
+
+fn(# comment
+  ,
+)
+
+fn(, # comment
+)
+fn(,
+  # comment
+)
+fn(
+  , # comment
+)
+fn(
+  ,
+  # comment
+)
+
+fn(, # comment
+  ,
+)
+fn(,
+  # comment
+  ,
+)
+fn(
+  , # comment
+  ,
+)
+fn(
+  ,
+  # comment
+  ,
+)
+
+fn(
+  ,
+  , # comment1
+  # comment2
+  ,
+  x
+)
+
+# Trails `a`
+fn(
+  a, # comment
+  ,
+  b
+)
+# Trails `a` technically, but should stay on own line
+fn(
+  a,
+  # comment
+  ,
+  b
+)
+# Trails `a`
+fn(
+  a, # comment
+  # comment2
+  ,
+  b
+)
+
+# Special test - ensure this leads `b` rather than trails `a`
+fn(
+  ,
+  a,
+  , # comment
+  b
+)
+
+# Both comments lead the hole
+fn(# comment1
+  # comment2
+  ,
+  x
+)
+
+# Comment leads hole
+# Following token is `,`, preceding before hole is another hole
+fn(
+  a,
+  , # comment
+  ,
+  b
+)
+fn(
+  , # comment
+  ,
+  x
+)
+
+# Comment leads `{` but doesn't move inside it
+fn(
+  ,
+  , # comment
+  { 1 +  1 }
+)
+
+# A particular motivating case. Want trailing `,` commentB to stay on `b`.
+list2(
+  a, # commentA
+  b, # commentB
+)
+
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+# Both get attached to `x`
+# Following token isn't `,`, `)`, `]`, or `]]`, and following node is non-hole,
+# so we attach to it
+fn(
+  ,
+  , # comment
+  x
+)
+fn(
+  ,
+  , # comment1
+  # comment2
+  x
 )
 
 # ------------------------------------------------------------------------
@@ -447,6 +610,27 @@ fn(
   c
 )
 
+# Due to holes not having tokens, we collapse full empty lines in them
+fn(
+
+  # comment1
+  ,
+
+  # comment2
+  ,
+
+  b
+)
+
+fn(
+  ,
+
+  # comment2
+  ,
+
+  b
+)
+
 # ------------------------------------------------------------------------
 # Comments
 
@@ -488,9 +672,16 @@ fn(a)
 # ------------------------------------------------------------------------
 # Holes
 
-fn(, )
-fn(, , )
+# Leading holes should hug the `(` token
+fn(,)
+fn(,,)
+
+# Non-leading holes retain spaces because they are considered "weird"
+# and we want them to stand out
+fn(, a, )
+fn(, a, , )
 fn(a, , b, , )
+
 fn(
 	a_really_long_argument_here,
 	,
@@ -565,9 +756,167 @@ df |>
 test_that("description", {
 })
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-fn(, x = 1)
+# ------------------------------------------------------------------------
+# User requested line break and leading holes
+
+# Leading holes are "invisible" when determining user requested expansion
+# These all expand
+fn(,
+	x = 1
+)
+
+fn(,
+	x = 1
+)
+
+fn(,
+	x = 1
+)
+
+fn(,,
+	x = 1
+)
+
+# A comment connected to a hole prevents it from being a "leading hole",
+# instead it just becomes part of the typical arguments list and expands
+fn(
+	# comment
+	,
+	x = 1
+)
+
+fn(,
+	# comment
+	,
+	x = 1
+)
+
+# ------------------------------------------------------------------------
+# Comments "inside" holes
+
+fn(
+	# comment
+	,
+)
+
+fn(,
+	# comment
+)
+fn(,
+	# comment
+)
+fn(,
+	# comment
+)
+fn(,
+	# comment
+)
+
+fn(,
+	# comment
+	,
+)
+fn(,
+	# comment
+	,
+)
+fn(,
+	# comment
+	,
+)
+fn(,
+	# comment
+	,
+)
+
+fn(,,
+	# comment1
+	# comment2
+	,
+	x
+)
+
+# Trails `a`
+fn(
+	a, # comment
+	,
+	b
+)
+# Trails `a` technically, but should stay on own line
+fn(
+	a,
+	# comment
+	,
+	b
+)
+# Trails `a`
+fn(
+	a, # comment
+	# comment2
+	,
+	b
+)
+
+# Special test - ensure this leads `b` rather than trails `a`
+fn(,
+	a,
+	,
+	# comment
+	b
+)
+
+# Both comments lead the hole
+fn(
+	# comment1
+	# comment2
+	,
+	x
+)
+
+# Comment leads hole
+# Following token is `,`, preceding before hole is another hole
+fn(
+	a,
+	,
+	# comment
+	,
+	b
+)
+fn(,
+	# comment
+	,
+	x
+)
+
+# Comment leads `{` but doesn't move inside it
+fn(,,
+	# comment
+	{
+		1 + 1
+	}
+)
+
+# A particular motivating case. Want trailing `,` commentB to stay on `b`.
+list2(
+	a, # commentA
+	b, # commentB
+)
+
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+# Both get attached to `x`
+# Following token isn't `,`, `)`, `]`, or `]]`, and following node is non-hole,
+# so we attach to it
+fn(,,
+	# comment
+	x
+)
+fn(,,
+	# comment1
+	# comment2
+	x
+)
 
 # ------------------------------------------------------------------------
 # Trailing braced expression
@@ -958,6 +1307,23 @@ fn(
 	c
 )
 
+# Due to holes not having tokens, we collapse full empty lines in them
+fn(
+	# comment1
+	,
+	# comment2
+	,
+
+	b
+)
+
+fn(,
+	# comment2
+	,
+
+	b
+)
+
 # ------------------------------------------------------------------------
 # Comments
 
@@ -979,6 +1345,5 @@ fn(
 
 # Lines exceeding max width of 80 characters
 ```
-   85: # `RHoleArgument`, so we can't compute the "number of lines before the first token".
-  142: 	my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
+  307: 	my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
 ```

--- a/crates/air_r_formatter/tests/specs/r/subset.R
+++ b/crates/air_r_formatter/tests/specs/r/subset.R
@@ -112,6 +112,25 @@ df[df$col > 7, map[
 ]]
 
 # ------------------------------------------------------------------------
+# User requested line break and leading holes
+
+# Leading holes are "invisible" when computing user requested line breaks,
+# so you can break the line before or after the hole as long as you are
+# before the first argument.
+# Starting from:
+# dt[, j, by = col]
+
+dt[
+  , j, by = col]
+
+dt[,
+  j, by = col]
+
+# No longer user requested expansion
+dt[, j
+  , by = col]
+
+# ------------------------------------------------------------------------
 # Comments "after" holes
 
 # Common in data.table world

--- a/crates/air_r_formatter/tests/specs/r/subset.R
+++ b/crates/air_r_formatter/tests/specs/r/subset.R
@@ -7,7 +7,7 @@ fn["description", {
   1 + 1
 }]
 
-# TODO: Think about data.table usage, like:
+# Leading hole hugs `[`
 DT[, {
   # write each group to a different file
   fwrite(.SD, "name")
@@ -22,10 +22,48 @@ DT[, by=x, {
 # ------------------------------------------------------------------------
 # Holes
 
+# Leading holes should hug the `[` token
 fn[,]
 fn[,,]
+
+# Trailing holes get a trailing space
+df[a,]
+
 fn[a,,b,,]
 fn[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]
+
+# Holes are "invisible" when determining user requested expansion
+# These all expand
+fn[,
+  x = 1
+]
+fn[
+  ,
+  x = 1
+]
+fn[
+  , x = 1
+]
+fn[
+  ,, x = 1
+]
+
+# ------------------------------------------------------------------------
+# Holes and trailing inline functions / braced expressions
+
+dt[, {
+  1 + 1
+}]
+dt[, , j, {
+  1 + 1
+}]
+
+dt[, function(x) {
+  1 + x
+}]
+dt[, , j, function(x) {
+  1 + x
+}]
 
 # ------------------------------------------------------------------------
 # Dots
@@ -73,9 +111,11 @@ df[df$col > 7, map[
   names(df)
 ]]
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-df[
-  ,
-  x = 1
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+# Common in data.table world
+dt[,
+  # comment
+  x
 ]

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -119,6 +119,25 @@ df[df$col > 7, map[
 ]]
 
 # ------------------------------------------------------------------------
+# User requested line break and leading holes
+
+# Leading holes are "invisible" when computing user requested line breaks,
+# so you can break the line before or after the hole as long as you are
+# before the first argument.
+# Starting from:
+# dt[, j, by = col]
+
+dt[
+  , j, by = col]
+
+dt[,
+  j, by = col]
+
+# No longer user requested expansion
+dt[, j
+  , by = col]
+
+# ------------------------------------------------------------------------
 # Comments "after" holes
 
 # Common in data.table world
@@ -270,6 +289,28 @@ df[
 		names(df)
 	]
 ]
+
+# ------------------------------------------------------------------------
+# User requested line break and leading holes
+
+# Leading holes are "invisible" when computing user requested line breaks,
+# so you can break the line before or after the hole as long as you are
+# before the first argument.
+# Starting from:
+# dt[, j, by = col]
+
+dt[,
+	j,
+	by = col
+]
+
+dt[,
+	j,
+	by = col
+]
+
+# No longer user requested expansion
+dt[, j, by = col]
 
 # ------------------------------------------------------------------------
 # Comments "after" holes

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -14,7 +14,7 @@ fn["description", {
   1 + 1
 }]
 
-# TODO: Think about data.table usage, like:
+# Leading hole hugs `[`
 DT[, {
   # write each group to a different file
   fwrite(.SD, "name")
@@ -29,10 +29,48 @@ DT[, by=x, {
 # ------------------------------------------------------------------------
 # Holes
 
+# Leading holes should hug the `[` token
 fn[,]
 fn[,,]
+
+# Trailing holes get a trailing space
+df[a,]
+
 fn[a,,b,,]
 fn[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]
+
+# Holes are "invisible" when determining user requested expansion
+# These all expand
+fn[,
+  x = 1
+]
+fn[
+  ,
+  x = 1
+]
+fn[
+  , x = 1
+]
+fn[
+  ,, x = 1
+]
+
+# ------------------------------------------------------------------------
+# Holes and trailing inline functions / braced expressions
+
+dt[, {
+  1 + 1
+}]
+dt[, , j, {
+  1 + 1
+}]
+
+dt[, function(x) {
+  1 + x
+}]
+dt[, , j, function(x) {
+  1 + x
+}]
 
 # ------------------------------------------------------------------------
 # Dots
@@ -80,11 +118,13 @@ df[df$col > 7, map[
   names(df)
 ]]
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-df[
-  ,
-  x = 1
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+# Common in data.table world
+dt[,
+  # comment
+  x
 ]
 
 ```
@@ -115,9 +155,8 @@ fn["description", {
 	1 + 1
 }]
 
-# TODO: Think about data.table usage, like:
-DT[
-	,
+# Leading hole hugs `[`
+DT[,
 	{
 		# write each group to a different file
 		fwrite(.SD, "name")
@@ -134,8 +173,13 @@ DT[, by = x, {
 # ------------------------------------------------------------------------
 # Holes
 
-fn[, ]
-fn[, , ]
+# Leading holes should hug the `[` token
+fn[,]
+fn[,,]
+
+# Trailing holes get a trailing space
+df[a, ]
+
 fn[a, , b, , ]
 fn[
 	a_really_long_argument_here,
@@ -143,6 +187,38 @@ fn[
 	another_really_really_long_argument_to_test_this_feature,
 	,
 ]
+
+# Holes are "invisible" when determining user requested expansion
+# These all expand
+fn[,
+	x = 1
+]
+fn[,
+	x = 1
+]
+fn[,
+	x = 1
+]
+fn[,,
+	x = 1
+]
+
+# ------------------------------------------------------------------------
+# Holes and trailing inline functions / braced expressions
+
+dt[, {
+	1 + 1
+}]
+dt[,, j, {
+	1 + 1
+}]
+
+dt[, function(x) {
+	1 + x
+}]
+dt[,, j, function(x) {
+	1 + x
+}]
 
 # ------------------------------------------------------------------------
 # Dots
@@ -195,12 +271,12 @@ df[
 	]
 ]
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-df[, x = 1]
-```
+# ------------------------------------------------------------------------
+# Comments "after" holes
 
-# Lines exceeding max width of 80 characters
-```
-   93: # `RHoleArgument`, so we can't compute the "number of lines before the first token".
+# Common in data.table world
+dt[,
+	# comment
+	x
+]
 ```

--- a/crates/air_r_formatter/tests/specs/r/subset2.R
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R
@@ -10,10 +10,28 @@ fn[["description", {
 # ------------------------------------------------------------------------
 # Holes
 
+# Leading holes should hug the `[[` token
 fn[[,]]
 fn[[,,]]
+
 fn[[a,,b,,]]
 fn[[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]]
+
+# Holes are "invisible" when determining user requested expansion
+# These all expand
+fn[[,
+  x = 1
+]]
+fn[[
+  ,
+  x = 1
+]]
+fn[[
+  , x = 1
+]]
+fn[[
+  ,, x = 1
+]]
 
 # ------------------------------------------------------------------------
 # Dots
@@ -61,9 +79,10 @@ df[[df$col > 7, map[[
   names(df)
 ]]]]
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-df[[
-  ,
-  x = 1
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+df[[,
+  # comment
+  x
 ]]

--- a/crates/air_r_formatter/tests/specs/r/subset2.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R.snap
@@ -17,10 +17,28 @@ fn[["description", {
 # ------------------------------------------------------------------------
 # Holes
 
+# Leading holes should hug the `[[` token
 fn[[,]]
 fn[[,,]]
+
 fn[[a,,b,,]]
 fn[[a_really_long_argument_here,,another_really_really_long_argument_to_test_this_feature,,]]
+
+# Holes are "invisible" when determining user requested expansion
+# These all expand
+fn[[,
+  x = 1
+]]
+fn[[
+  ,
+  x = 1
+]]
+fn[[
+  , x = 1
+]]
+fn[[
+  ,, x = 1
+]]
 
 # ------------------------------------------------------------------------
 # Dots
@@ -68,11 +86,12 @@ df[[df$col > 7, map[[
   names(df)
 ]]]]
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-df[[
-  ,
-  x = 1
+# ------------------------------------------------------------------------
+# Comments "after" holes
+
+df[[,
+  # comment
+  x
 ]]
 
 ```
@@ -106,14 +125,31 @@ fn[["description", {
 # ------------------------------------------------------------------------
 # Holes
 
-fn[[, ]]
-fn[[, , ]]
+# Leading holes should hug the `[[` token
+fn[[,]]
+fn[[,,]]
+
 fn[[a, , b, , ]]
 fn[[
 	a_really_long_argument_here,
 	,
 	another_really_really_long_argument_to_test_this_feature,
 	,
+]]
+
+# Holes are "invisible" when determining user requested expansion
+# These all expand
+fn[[,
+	x = 1
+]]
+fn[[,
+	x = 1
+]]
+fn[[,
+	x = 1
+]]
+fn[[,,
+	x = 1
 ]]
 
 # ------------------------------------------------------------------------
@@ -167,12 +203,11 @@ df[[
 	]]
 ]]
 
-# TODO: Holes currently don't force expansion. There is no token attached to
-# `RHoleArgument`, so we can't compute the "number of lines before the first token".
-df[[, x = 1]]
-```
+# ------------------------------------------------------------------------
+# Comments "after" holes
 
-# Lines exceeding max width of 80 characters
-```
-   77: # `RHoleArgument`, so we can't compute the "number of lines before the first token".
+df[[,
+	# comment
+	x
+]]
 ```

--- a/crates/air_r_syntax/src/argument_ext.rs
+++ b/crates/air_r_syntax/src/argument_ext.rs
@@ -1,0 +1,19 @@
+use crate::RArgument;
+
+impl RArgument {
+    /// Is this argument a "hole"?
+    ///
+    /// To be a hole, the argument must be missing both its `name =` clause
+    /// and its value.
+    ///
+    /// ```r
+    /// # First argument is a hole
+    /// fn( , x)
+    ///
+    /// # First argument is not a hole
+    /// fn(x = , x)
+    /// ```
+    pub fn is_hole(&self) -> bool {
+        self.name_clause().is_none() && self.value().is_none()
+    }
+}

--- a/crates/air_r_syntax/src/lib.rs
+++ b/crates/air_r_syntax/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 mod generated;
+pub mod argument_ext;
 pub mod call_ext;
 mod file_source;
 pub mod string_ext;


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/32

Two main changes:

- Implemented hugging for what I call "leading holes", which greatly improves data.table formatting where its common to have a leading `,` hole for an empty `i` expression (explained below)
- Was forced to sit down and confront comment handling for holes, something I had some TODO comments in there for and knew we'd have to do eventually

# Leading holes

Imagine you have this data.table expression, and you want to expand it over multiple lines

```r
dt2 = dt[, .(total_value_received = sum(price * count)), by = "product_id"]
```

Before this PR, your only option was to hit enter between the `[` and the first `,` and you'd get this:

```r
dt2 = dt[
  , 
  .(total_value_received = sum(price * count)), 
  by = "product_id"
]
```

Not great!

After this PR, the "hole" `[<here>,` is considered a "leading hole". Leading holes "hug" tightly to the opening `[` token no matter what, so you get this:

```r
dt2 = dt[,
  .(total_value_received = sum(price * count)),
  by = "product_id"
]
```

So much nicer! This is pretty common with data.table users, and even chains nicely:

```r
dt2 = ProductReceived[
  Products,
  on = c("product_id" = "id"),
][,
  .(total_value_received = sum(price * count)),
  by = "product_id"
]
```

Note that you can have any number of repeated leading `,`s, they all get aggregated together as a set of leading holes.

If there is a comment within a hole, it is no longer a candidate to be a "leading hole" and is instead considered as a normal argument, subject to typical "fully expanded" rules

```r
dt2 = dt[
	# no longer a leading hole
	,
	.(total_value_received = sum(price * count)),
	by = "product_id"
]
```

To be clear, only holes up front can be leading holes. Trailing and intermediate holes still fully break, like this

```r
dt2 = dt[,
	.(total_value_received = sum(price * count)),
	,
	by = "product_id"
]
```

I think this is good behavior because these holes are relatively "weird" and the extra spacing makes them very visible.

## Leading holes and user requested line breaks

We treat leading holes as roughly invisible when detecting if the user requested a line break. With the example from before:

```r
dt2 = dt[, .(total_value_received = sum(price * count)), by = "product_id"]
```

You can actually add a newline _before or after_ that `,` and it will be treated like a user line break. The `,` will snap back to hugging the `[` tightly but the arguments will get expanded. The principle for user requested expansion here is:

> The user added a line break anywhere before the first non-hole argument in a call

This seems to result in the least surprising behavior.