### PR TITLE
Build extension on push

### DIFF
--- a/.github/workflows/build-vscode.yml
+++ b/.github/workflows/build-vscode.yml
@@ -1,0 +1,41 @@
+name: Build VS Code Extension
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "editors/code/**"
+  pull_request:
+    paths:
+      - "editors/code/**"
+  workflow_dispatch:
+
+jobs:
+  build-extension:
+    runs-on: ubuntu-latest
+    outputs:
+      vsixPath: ${{ steps.package_extension.outputs.vsixPath }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
+      - run: cd editors/code && npm install
+
+      - name: Package extension
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: package_extension
+        with:
+          pat: not-a-real-pat
+          dryRun: true
+          preRelease: true
+          packagePath: editors/code
+
+      - name: Upload extension vsix file as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: air-vscode-${{ github.sha }}
+          path: ${{ steps.package_extension.outputs.vsixPath }}


### PR DESCRIPTION
The workflow is only triggered if a file in `editors/code` changes.