### PR TITLE
Rename `air lsp` to `air language-server`

### DIFF
--- a/crates/air/src/args.rs
+++ b/crates/air/src/args.rs
@@ -17,15 +17,12 @@ pub struct Args {
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
-    /// Start a language server
-    Lsp(LspCommand),
-
     /// Format a set of files or directories
     Format(FormatCommand),
-}
 
-#[derive(Clone, Debug, Parser)]
-pub(crate) struct LspCommand {}
+    /// Start a language server
+    LanguageServer(LanguageServerCommand),
+}
 
 #[derive(Clone, Debug, Parser)]
 #[command(arg_required_else_help(true))]
@@ -39,3 +36,6 @@ pub(crate) struct FormatCommand {
     #[arg(long)]
     pub check: bool,
 }
+
+#[derive(Clone, Debug, Parser)]
+pub(crate) struct LanguageServerCommand {}

--- a/crates/air/src/commands.rs
+++ b/crates/air/src/commands.rs
@@ -1,2 +1,2 @@
 pub(crate) mod format;
-pub(crate) mod lsp;
+pub(crate) mod language_server;

--- a/crates/air/src/commands/language_server.rs
+++ b/crates/air/src/commands/language_server.rs
@@ -1,8 +1,8 @@
-use crate::args::LspCommand;
+use crate::args::LanguageServerCommand;
 use crate::ExitStatus;
 
 #[tokio::main]
-pub(crate) async fn lsp(_command: LspCommand) -> anyhow::Result<ExitStatus> {
+pub(crate) async fn language_server(_command: LanguageServerCommand) -> anyhow::Result<ExitStatus> {
     // Returns after shutdown
     lsp::start_lsp(tokio::io::stdin(), tokio::io::stdout()).await;
 

--- a/crates/air/src/lib.rs
+++ b/crates/air/src/lib.rs
@@ -8,7 +8,7 @@ pub mod status;
 
 pub fn run(args: Args) -> anyhow::Result<ExitStatus> {
     match args.command {
-        Command::Lsp(command) => commands::lsp::lsp(command),
         Command::Format(command) => commands::format::format(command),
+        Command::LanguageServer(command) => commands::language_server::language_server(command),
     }
 }

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -54,7 +54,7 @@ export class Lsp {
 
 		let options: lc.ServerOptions = {
 			command: "air",
-			args: ["lsp"],
+			args: ["language-server"],
 		};
 
 		let clientOptions: lc.LanguageClientOptions = {


### PR DESCRIPTION
And make it come after `format` in the help docs because it is less useful from the CLI for most users

Closes https://github.com/posit-dev/air/issues/97