### PR TITLE
Log a warning on parse errors, but don't return an LSP error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Development version
 
+- Parse errors in your document no longer trigger an LSP error when you request
+  document or range formatting (which typically would show up as an annoying
+  toast notification in your code editor) (#120).
+
 - `air format` is now faster on Windows when nothing changes (#90).
 
 - `air format --check` now works correctly with Windows line endings (#123).


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/65

Merge after https://github.com/posit-dev/air/pull/122