### PR TITLE
Send structured `InitializationOptions` to the server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,10 @@
         "editor.formatOnSaveMode": "file",
         "editor.defaultFormatter": "rust-lang.rust-analyzer"
     },
+    "[typescript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.imports.prefix": "crate",
     "rust-analyzer.imports.granularity.group": "item",

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -15,6 +15,7 @@ pub mod handlers_state;
 pub mod logging;
 pub mod main_loop;
 pub mod rust_analyzer;
+pub mod settings;
 pub mod state;
 pub mod to_proto;
 pub mod tower_lsp;

--- a/crates/lsp/src/main_loop.rs
+++ b/crates/lsp/src/main_loop.rs
@@ -26,6 +26,8 @@ use crate::handlers_state;
 use crate::handlers_state::ConsoleInputs;
 use crate::logging::LogMessageSender;
 use crate::logging::LogState;
+use crate::settings::ClientSettings;
+use crate::settings::ClientWorkspaceSettings;
 use crate::state::WorldState;
 use crate::tower_lsp::LspMessage;
 use crate::tower_lsp::LspNotification;
@@ -145,9 +147,15 @@ pub(crate) struct GlobalState {
     log_tx: Option<LogMessageSender>,
 }
 
-/// Unlike `WorldState`, `ParserState` cannot be cloned and is only accessed by
+/// Unlike `WorldState`, `LspState` cannot be cloned and is only accessed by
 /// exclusive handlers.
 pub(crate) struct LspState {
+    /// User level [`ClientSettings`] sent over from the client
+    pub(crate) user_client_settings: ClientSettings,
+
+    /// Workspace level [`ClientSettings`] sent over from the client
+    pub(crate) workspace_client_settings: Vec<ClientWorkspaceSettings>,
+
     /// The negociated encoding for document positions. Note that documents are
     /// always stored as UTF-8 in Rust Strings. This encoding is only used to
     /// translate UTF-16 positions sent by the client to UTF-8 ones.
@@ -165,6 +173,8 @@ pub(crate) struct LspState {
 impl Default for LspState {
     fn default() -> Self {
         Self {
+            user_client_settings: ClientSettings::default(),
+            workspace_client_settings: Vec::new(),
             // Default encoding specified in the LSP protocol
             position_encoding: PositionEncoding::Wide(WideEncoding::Utf16),
             parsers: Default::default(),

--- a/crates/lsp/src/settings.rs
+++ b/crates/lsp/src/settings.rs
@@ -1,0 +1,53 @@
+use serde::Deserialize;
+use serde_json::Value;
+use url::Url;
+
+// These settings are only needed once, typically for initialization.
+// They are read at the global scope on the client side and are never refreshed.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClientGlobalSettings {
+    pub(crate) log_level: Option<crate::logging::LogLevel>,
+    pub(crate) dependency_log_levels: Option<String>,
+}
+
+/// This is a direct representation of the user level settings schema sent
+/// by the client. It is refreshed after configuration changes.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClientSettings {}
+
+/// This is a direct representation of the workspace level settings schema sent by the
+/// client. It is the same as the user level settings with the addition of the workspace
+/// path.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClientWorkspaceSettings {
+    pub(crate) url: Url,
+    #[serde(flatten)]
+    pub(crate) settings: ClientSettings,
+}
+
+/// This is the exact schema for initialization options sent in by the client
+/// during initialization.
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InitializationOptions {
+    pub(crate) global_settings: ClientGlobalSettings,
+    pub(crate) user_settings: ClientSettings,
+    pub(crate) workspace_settings: Vec<ClientWorkspaceSettings>,
+}
+
+impl InitializationOptions {
+    pub(crate) fn from_value(value: Value) -> Self {
+        serde_json::from_value(value)
+            .map_err(|err| {
+                tracing::error!("Failed to deserialize initialization options: {err}. Falling back to default client settings.");
+            })
+            .unwrap_or_default()
+    }
+}

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -11,11 +11,13 @@
 			"dependencies": {
 				"@types/p-queue": "^3.1.0",
 				"adm-zip": "^0.5.16",
+				"fs-extra": "^11.2.0",
 				"p-queue": "npm:@esm2cjs/p-queue@^7.3.0",
 				"vscode-languageclient": "^9.0.1"
 			},
 			"devDependencies": {
 				"@types/adm-zip": "^0.5.6",
+				"@types/fs-extra": "^11.0.4",
 				"@types/mocha": "^10.0.9",
 				"@types/node": "20.x",
 				"@types/vscode": "^1.90.0",
@@ -467,6 +469,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/fs-extra": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+			"integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsonfile": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -480,6 +493,16 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/jsonfile": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+			"integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/mocha": {
 			"version": "10.0.10",
@@ -2115,6 +2138,20 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/fs-extra": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2215,7 +2252,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -2691,6 +2727,18 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"node_modules/jszip": {
 			"version": "3.10.1",
@@ -4233,6 +4281,15 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.1",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -6,6 +6,10 @@
 	"publisher": "Posit",
 	"license": "MIT",
 	"repository": "https://github.com/posit-dev/air",
+	"serverInfo": {
+		"name": "Air",
+		"module": "air"
+	},
 	"engines": {
 		"vscode": "^1.90.0"
 	},
@@ -35,6 +39,29 @@
 				]
 			}
 		],
+		"configuration": {
+			"properties": {
+				"air.logLevel": {
+					"default": null,
+					"markdownDescription": "Controls the log level of the language server.\n\n**This setting requires a restart to take effect.**",
+					"enum": [
+					  "error",
+					  "warning",
+					  "info",
+					  "debug",
+					  "trace"
+					],
+					"scope": "application",
+					"type": "string"
+				},
+				"air.dependencyLogLevels": {
+					"default": null,
+					"markdownDescription": "Controls the log level of the Rust crates that the language server depends on.\n\n**This setting requires a restart to take effect.**",
+					"scope": "application",
+					"type": "string"
+				}
+			}
+		},
 		"configurationDefaults": {
 			"[r]": {
 				"editor.defaultFormatter": "Posit.air"
@@ -88,10 +115,12 @@
 		"@types/p-queue": "^3.1.0",
 		"p-queue": "npm:@esm2cjs/p-queue@^7.3.0",
 		"adm-zip": "^0.5.16",
+		"fs-extra": "^11.2.0",
 		"vscode-languageclient": "^9.0.1"
 	},
 	"devDependencies": {
 		"@types/adm-zip": "^0.5.6",
+		"@types/fs-extra": "^11.0.4",
 		"@types/mocha": "^10.0.9",
 		"@types/node": "20.x",
 		"@types/vscode": "^1.90.0",

--- a/editors/code/src/common/README.md
+++ b/editors/code/src/common/README.md
@@ -1,0 +1,4 @@
+This directory contains "common" utilities used across language server extensions.
+
+They are pulled directly from this MIT licensed repo:
+https://github.com/microsoft/vscode-python-tools-extension-template

--- a/editors/code/src/common/constants.ts
+++ b/editors/code/src/common/constants.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// https://github.com/microsoft/vscode-python-tools-extension-template
+
+import * as path from "path";
+
+const folderName = path.basename(__dirname);
+
+export const EXTENSION_ROOT_DIR =
+	folderName === "common"
+		? path.dirname(path.dirname(__dirname))
+		: path.dirname(__dirname);

--- a/editors/code/src/common/log/logging.ts
+++ b/editors/code/src/common/log/logging.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// https://github.com/microsoft/vscode-python-tools-extension-template
+
+import * as util from "util";
+import { Disposable, OutputChannel } from "vscode";
+
+type Arguments = unknown[];
+class OutputChannelLogger {
+	constructor(private readonly channel: OutputChannel) {}
+
+	public traceLog(...data: Arguments): void {
+		this.channel.appendLine(util.format(...data));
+	}
+}
+
+let channel: OutputChannelLogger | undefined;
+export function registerLogger(outputChannel: OutputChannel): Disposable {
+	channel = new OutputChannelLogger(outputChannel);
+	return {
+		dispose: () => {
+			channel = undefined;
+		},
+	};
+}
+
+export function traceLog(...args: Arguments): void {
+	channel?.traceLog(...args);
+}

--- a/editors/code/src/common/setup.ts
+++ b/editors/code/src/common/setup.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// https://github.com/microsoft/vscode-python-tools-extension-template
+
+import * as path from "path";
+import * as fs from "fs-extra";
+import { EXTENSION_ROOT_DIR } from "./constants";
+
+export interface IServerInfo {
+	name: string;
+	module: string;
+}
+
+export function loadServerDefaults(): IServerInfo {
+	const packageJson = path.join(EXTENSION_ROOT_DIR, "package.json");
+	const content = fs.readFileSync(packageJson).toString();
+	const config = JSON.parse(content);
+	return config.serverInfo as IServerInfo;
+}

--- a/editors/code/src/common/vscodeapi.ts
+++ b/editors/code/src/common/vscodeapi.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// https://github.com/microsoft/vscode-python-tools-extension-template
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+	commands,
+	ConfigurationScope,
+	Disposable,
+	LogOutputChannel,
+	Uri,
+	window,
+	workspace,
+	WorkspaceConfiguration,
+	WorkspaceFolder,
+} from "vscode";
+
+export function createOutputChannel(name: string): LogOutputChannel {
+	return window.createOutputChannel(name, { log: true });
+}
+
+export function getConfiguration(
+	config: string,
+	scope?: ConfigurationScope
+): WorkspaceConfiguration {
+	return workspace.getConfiguration(config, scope);
+}
+
+export function registerCommand(
+	command: string,
+	callback: (...args: any[]) => any,
+	thisArg?: any
+): Disposable {
+	return commands.registerCommand(command, callback, thisArg);
+}
+
+export const { onDidChangeConfiguration } = workspace;
+
+export function isVirtualWorkspace(): boolean {
+	const isVirtual =
+		workspace.workspaceFolders &&
+		workspace.workspaceFolders.every((f) => f.uri.scheme !== "file");
+	return !!isVirtual;
+}
+
+export function getWorkspaceFolders(): readonly WorkspaceFolder[] {
+	return workspace.workspaceFolders ?? [];
+}
+
+export function getWorkspaceFolder(uri: Uri): WorkspaceFolder | undefined {
+	return workspace.getWorkspaceFolder(uri);
+}

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -1,6 +1,14 @@
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 import { default as PQueue } from "p-queue";
+import { IServerInfo, loadServerDefaults } from "./common/setup";
+import { registerLogger, traceLog } from "./common/log/logging";
+import {
+	getGlobalSettings,
+	getUserSettings,
+	getWorkspaceSettings,
+	IInitializationOptions,
+} from "./settings";
 
 // All session management operations are put on a queue. They can't run
 // concurrently and either result in a started or stopped state. Starting when
@@ -14,6 +22,8 @@ enum State {
 export class Lsp {
 	public client: lc.LanguageClient | null = null;
 
+	private serverInfo: IServerInfo;
+
 	// We use the same output channel for all LSP instances (e.g. a new instance
 	// after a restart) to avoid having multiple channels in the Output viewpane.
 	private channel: vscode.OutputChannel;
@@ -23,7 +33,8 @@ export class Lsp {
 
 	constructor(context: vscode.ExtensionContext) {
 		this.channel = vscode.window.createOutputChannel("Air Language Server");
-		context.subscriptions.push(this.channel);
+		context.subscriptions.push(this.channel, registerLogger(this.channel));
+		this.serverInfo = loadServerDefaults();
 		this.stateQueue = new PQueue({ concurrency: 1 });
 	}
 
@@ -52,7 +63,23 @@ export class Lsp {
 			return;
 		}
 
-		let options: lc.ServerOptions = {
+		// Log server information
+		traceLog(`Name: ${this.serverInfo.name}`);
+		traceLog(`Module: ${this.serverInfo.module}`);
+
+		const globalSettings = await getGlobalSettings(this.serverInfo.module);
+		const userSettings = await getUserSettings(this.serverInfo.module);
+		const workspaceSettings = await getWorkspaceSettings(
+			this.serverInfo.module
+		);
+
+		const initializationOptions: IInitializationOptions = {
+			globalSettings,
+			userSettings,
+			workspaceSettings,
+		};
+
+		let serverOptions: lc.ServerOptions = {
 			command: "air",
 			args: ["language-server"],
 		};
@@ -71,13 +98,14 @@ export class Lsp {
 					vscode.workspace.createFileSystemWatcher("**/*.[Rr]"),
 			},
 			outputChannel: this.channel,
+			initializationOptions: initializationOptions,
 		};
 
 		const client = new lc.LanguageClient(
 			"airLanguageServer",
 			"Air Language Server",
-			options,
-			clientOptions,
+			serverOptions,
+			clientOptions
 		);
 		await client.start();
 

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -1,0 +1,85 @@
+import { WorkspaceConfiguration, WorkspaceFolder } from "vscode";
+import { getConfiguration, getWorkspaceFolders } from "./common/vscodeapi";
+
+type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+
+// One time settings that aren't ever refreshed within the extension's lifetime.
+// They are read at the user (i.e. global) scope.
+export interface IGlobalSettings {
+	logLevel?: LogLevel;
+	dependencyLogLevels?: string;
+}
+
+// Client representation of user level client settings.
+// TODO: These are refreshed using a `Configuration` LSP request from the server.
+// (It is possible we should ONLY get these through `Configuration` and not through
+// initializationOptions)
+export interface ISettings {}
+
+// Client representation of workspace level client settings.
+// Same as the user level settings, with the addition of the workspace path.
+// TODO: These are refreshed using a `Configuration` LSP request from the server.
+// (It is possible we should ONLY get these through `Configuration` and not through
+// initializationOptions)
+export interface IWorkspaceSettings {
+	url: string;
+	settings: ISettings;
+}
+
+// This is a direct representation of the Client settings sent to the Server in the
+// `initializationOptions` field of `InitializeParams`
+export type IInitializationOptions = {
+	globalSettings: IGlobalSettings;
+	userSettings: ISettings;
+	workspaceSettings: IWorkspaceSettings[];
+};
+
+export async function getGlobalSettings(
+	namespace: string
+): Promise<IGlobalSettings> {
+	const config = getConfiguration(namespace);
+
+	return {
+		logLevel: getOptionalUserValue<LogLevel>(config, "logLevel"),
+		dependencyLogLevels: getOptionalUserValue<string>(
+			config,
+			"dependencyLogLevels"
+		),
+	};
+}
+
+export async function getUserSettings(namespace: string): Promise<ISettings> {
+	const config = getConfiguration(namespace);
+
+	return {};
+}
+
+export function getWorkspaceSettings(
+	namespace: string
+): Promise<IWorkspaceSettings[]> {
+	return Promise.all(
+		getWorkspaceFolders().map((workspaceFolder) =>
+			getWorkspaceFolderSettings(namespace, workspaceFolder)
+		)
+	);
+}
+
+async function getWorkspaceFolderSettings(
+	namespace: string,
+	workspace: WorkspaceFolder
+): Promise<IWorkspaceSettings> {
+	const config = getConfiguration(namespace, workspace.uri);
+
+	return {
+		url: workspace.uri.toString(),
+		settings: {},
+	};
+}
+
+function getOptionalUserValue<T>(
+	config: WorkspaceConfiguration,
+	key: string
+): T | undefined {
+	const inspect = config.inspect<T>(key);
+	return inspect?.globalValue;
+}


### PR DESCRIPTION
In particular, this lets us respect `air.logLevel` and `air.dependencyLogLevels` on server startup

User and workspace level settings are not used yet but are included for completeness