### PR TITLE
Don't normalize strings in the CLI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # Windows specific test files where we need CRLF endings
 crates/air/tests/fixtures/crlf/*.R text eol=crlf
 crates/air_r_formatter/tests/specs/r/crlf/*.R text eol=crlf
+crates/air_r_parser/tests/snapshots/ok/crlf/*.R text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
 
 # Windows specific test files where we need CRLF endings
+crates/air/tests/fixtures/crlf/*.R text eol=crlf
 crates/air_r_formatter/tests/specs/r/crlf/*.R text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Development version
 
+- `air format` is now faster on Windows when nothing changes (#90).
+
+- `air format --check` now works correctly with Windows line endings (#123).
+
 - Magic line breaks are now supported in left assignment (#118).
 
 

--- a/crates/air/tests/fixtures/crlf/multiline_string_value.R
+++ b/crates/air/tests/fixtures/crlf/multiline_string_value.R
@@ -1,0 +1,2 @@
+"multiline
+string"

--- a/crates/air/tests/format.rs
+++ b/crates/air/tests/format.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+use std::path::PathBuf;
+
 use air::args::Args;
 use air::run;
 use air::status::ExitStatus;
@@ -20,4 +23,23 @@ fn default_options() -> anyhow::Result<()> {
 
     assert_eq!(err, ExitStatus::Success);
     Ok(())
+}
+
+#[test]
+fn test_check_returns_cleanly_for_multiline_strings_with_crlf_line_endings() -> anyhow::Result<()> {
+    let fixtures = path_fixtures();
+    let path = fixtures.join("crlf").join("multiline_string_value.R");
+    let path = path.to_str().unwrap();
+
+    let args = Args::parse_from(["", "format", path, "--check"]);
+    let err = run(args)?;
+
+    assert_eq!(err, ExitStatus::Success);
+    Ok(())
+}
+
+fn path_fixtures() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
 }

--- a/crates/air_formatter_test/src/spec.rs
+++ b/crates/air_formatter_test/src/spec.rs
@@ -28,9 +28,6 @@ impl<'a> SpecTestFile<'a> {
 
         let input_code = std::fs::read_to_string(input_file).unwrap();
 
-        // Normalize to Unix line endings
-        let input_code = line_ending::normalize(input_code);
-
         // For the whole file, not a specific range right now
         let range_start_index = None;
         let range_end_index = None;

--- a/crates/air_r_formatter/src/lib.rs
+++ b/crates/air_r_formatter/src/lib.rs
@@ -25,6 +25,7 @@ mod prelude;
 mod r;
 pub(crate) mod separated;
 mod statement_body;
+mod string_literal;
 
 #[rustfmt::skip]
 mod generated;

--- a/crates/air_r_formatter/src/r/auxiliary/string_value.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/string_value.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::string_literal::FormatStringLiteralToken;
 use air_r_syntax::RStringValue;
 use air_r_syntax::RStringValueFields;
 use biome_formatter::write;
@@ -8,6 +9,6 @@ pub(crate) struct FormatRStringValue;
 impl FormatNodeRule<RStringValue> for FormatRStringValue {
     fn fmt_fields(&self, node: &RStringValue, f: &mut RFormatter) -> FormatResult<()> {
         let RStringValueFields { value_token } = node.as_fields();
-        write![f, [value_token.format()]]
+        write![f, [FormatStringLiteralToken::new(&value_token?)]]
     }
 }

--- a/crates/air_r_formatter/src/string_literal.rs
+++ b/crates/air_r_formatter/src/string_literal.rs
@@ -76,7 +76,8 @@ impl Format<RFormatContext> for FormatNormalizedStringLiteralToken<'_> {
 /// This function:
 /// - Normalizes all line endings to `\n`
 ///
-/// We may perform more normalization in the future.
+/// We may perform more normalization in the future. We don't use utilities from the
+/// `line_ending` crate because we don't own the string.
 ///
 /// This function is particularly useful for multiline strings, which capture the existing
 /// line ending inside the string token itself. We must normalize those line endings to

--- a/crates/air_r_formatter/src/string_literal.rs
+++ b/crates/air_r_formatter/src/string_literal.rs
@@ -1,0 +1,147 @@
+use air_r_syntax::RSyntaxKind::R_STRING_LITERAL;
+use air_r_syntax::RSyntaxToken;
+use biome_formatter::prelude::syntax_token_cow_slice;
+use biome_formatter::prelude::Formatter;
+use biome_formatter::trivia::format_replaced;
+use biome_formatter::Format;
+use biome_formatter::FormatResult;
+use std::borrow::Cow;
+use std::cell::Cell;
+
+use crate::context::RFormatContext;
+use crate::RFormatter;
+
+/// Helper utility for formatting a string literal token
+///
+/// The main job of this utility is to `normalize()` the string and handle the
+/// complicated way we have to call [format_replaced] with that normalized result.
+pub(crate) struct FormatStringLiteralToken<'token> {
+    /// The string literal token to format
+    token: &'token RSyntaxToken,
+}
+
+impl<'token> FormatStringLiteralToken<'token> {
+    pub(crate) fn new(token: &'token RSyntaxToken) -> Self {
+        Self { token }
+    }
+
+    fn normalize(&self) -> FormatNormalizedStringLiteralToken {
+        let token = self.token;
+
+        debug_assert!(
+            matches!(token.kind(), R_STRING_LITERAL),
+            "Found kind {:?}",
+            token.kind()
+        );
+
+        let text = token.text_trimmed();
+        let text = normalize_string(text);
+        let text = Cell::new(text);
+
+        FormatNormalizedStringLiteralToken { token, text }
+    }
+}
+
+impl Format<RFormatContext> for FormatStringLiteralToken<'_> {
+    fn fmt(&self, f: &mut RFormatter) -> FormatResult<()> {
+        self.normalize().fmt(f)
+    }
+}
+
+struct FormatNormalizedStringLiteralToken<'token> {
+    /// The original string literal token before normalization
+    token: &'token RSyntaxToken,
+
+    /// The normalized text
+    /// Wrapped in a [`Cell`] to avoid having to clone when passing to [`syntax_token_cow_slice`]
+    text: Cell<Cow<'token, str>>,
+}
+
+impl Format<RFormatContext> for FormatNormalizedStringLiteralToken<'_> {
+    fn fmt(&self, f: &mut Formatter<RFormatContext>) -> FormatResult<()> {
+        format_replaced(
+            self.token,
+            &syntax_token_cow_slice(
+                self.text.take(),
+                self.token,
+                self.token.text_trimmed_range().start(),
+            ),
+        )
+        .fmt(f)
+    }
+}
+
+/// Normalize a string, returning a [`Cow::Borrowed`] if the input was already normalized
+///
+/// This function:
+/// - Normalizes all line endings to `\n`
+///
+/// We may perform more normalization in the future.
+///
+/// This function is particularly useful for multiline strings, which capture the existing
+/// line ending inside the string token itself. We must normalize those line endings to
+/// `\n` before the formatter -> printer stage, because the printer can't handle other
+/// line endings and will panic on them. At the printer -> string stage at the very end,
+/// the printer will replace all `\n` with the `LineEnding` requested by the user.
+/// https://github.com/biomejs/biome/blob/a658a294087c143b83350cbeb6b44f7a2e9afdd1/crates/biome_formatter/src/printer/mod.rs#L714-L718
+fn normalize_string(input: &str) -> Cow<str> {
+    // The normalized string if `input` is not yet normalized.
+    // `output` must remain empty if `input` is already normalized.
+    let mut output = String::new();
+
+    // Tracks the last index of `input` that has been written to `output`.
+    // If `last_loc` is `0` at the end, then the input is already normalized and can be returned as is.
+    let mut last_loc = 0;
+
+    let mut iter = input.char_indices().peekable();
+
+    while let Some((loc, char)) = iter.next() {
+        if char == '\r' {
+            output.push_str(&input[last_loc..loc]);
+
+            if iter.peek().is_some_and(|(_, next)| next == &'\n') {
+                // CRLF support - skip over the '\r' character, keep the `\n`
+                iter.next();
+            } else {
+                // CR support - Replace the `\r` with a `\n`
+                output.push('\n');
+            }
+
+            last_loc = loc + '\r'.len_utf8();
+        }
+    }
+
+    if last_loc == 0 {
+        Cow::Borrowed(input)
+    } else {
+        output.push_str(&input[last_loc..]);
+        Cow::Owned(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::string_literal::normalize_string;
+    use std::borrow::Cow;
+
+    #[test]
+    fn normalize_empty() {
+        let x = "";
+        assert_eq!(normalize_string(x), Cow::Borrowed(x));
+    }
+
+    #[test]
+    fn normalize_newlines() {
+        let x = "abcd";
+        assert_eq!(normalize_string(x), Cow::Borrowed(x));
+
+        let x = "a\nb\nc\nd\n";
+        assert_eq!(normalize_string(x), Cow::Borrowed(x));
+
+        let x = "a\nb\rc\r\nd\n";
+        assert_eq!(
+            normalize_string(x),
+            Cow::Owned::<str>(String::from("a\nb\nc\nd\n"))
+        );
+    }
+}

--- a/crates/air_r_parser/tests/snapshots/ok/crlf/multiline_string_value.R
+++ b/crates/air_r_parser/tests/snapshots/ok/crlf/multiline_string_value.R
@@ -1,0 +1,2 @@
+"multiline
+string"

--- a/crates/air_r_parser/tests/snapshots/ok/crlf/multiline_string_value.R.snap
+++ b/crates/air_r_parser/tests/snapshots/ok/crlf/multiline_string_value.R.snap
@@ -1,0 +1,38 @@
+---
+source: crates/air_r_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```R
+"multiline
+string"
+
+```
+
+
+## AST
+
+```
+RRoot {
+    bom_token: missing (optional),
+    expressions: RExpressionList [
+        RStringValue {
+            value_token: R_STRING_LITERAL@0..19 "\"multiline\r\nstring\"" [] [],
+        },
+    ],
+    eof_token: EOF@19..21 "" [Newline("\r\n")] [],
+}
+```
+
+## CST
+
+```
+0: R_ROOT@0..21
+  0: (empty)
+  1: R_EXPRESSION_LIST@0..19
+    0: R_STRING_VALUE@0..19
+      0: R_STRING_LITERAL@0..19 "\"multiline\r\nstring\"" [] []
+  2: EOF@19..21 "" [Newline("\r\n")] []
+
+```

--- a/crates/air_r_parser/tests/spec_test.rs
+++ b/crates/air_r_parser/tests/spec_test.rs
@@ -52,9 +52,6 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
     let content = fs::read_to_string(test_case_path)
         .expect("Expected test path to be a readable file in UTF8 encoding");
 
-    // Normalize to Unix line endings
-    let content = line_ending::normalize(content);
-
     let options = RParserOptions::default();
     let parsed = parse(&content, options);
     let root = RRoot::unwrap_cast(parsed.syntax());


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/90
Closes https://github.com/posit-dev/air/issues/123

Follow up to https://github.com/posit-dev/air/pull/78

- The CLI now never normalizes line endings, allowing `--check` to work correctly, and allowing us to take advantage of an optimization where we detect that no changes occurred during the formatting
- The LSP continues to always normalizes line endings to Unix endings. Since _everything_ is Unix line endings there, we could add the optimization there too (and pre-emptively return `None` in the response to the format request if we detect no changes, rather than running an expensive diff algorithm)

As mentioned in https://github.com/posit-dev/air/issues/90, our parser and Biome's formatter are happy with alternative line endings when they appear in the _trivia_, but if non-unix line endings appear in a _token_ then the formatter panics. This happens in multiline strings, so we now normalize strings efficiently using a `Cow::Borrowed` when nothing changed.

The way this all flows through biome is (as implemented by https://github.com/rome/tools/pull/1672):
- We send a parse tree with CRLF line endings into the formatter
- The formatter normalizes all _trivia_ to Unix line endings
- We normalize all _tokens_ to Unix line endings (only multiline strings have this issue)
- At Print time, the formatter turns a Unix line ending into the user requested `LineEnding` 

The last step there is why the Printer doesn't allow any non-Unix line endings internally. It really just looks for `\n` at print time to decide when to apply `LineEnding`, so `\r\n` would make it behave incorrectly.