### PR TITLE
Change to 2 spaces by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Development version
 
+- The default indent style has been changed to spaces. The default indent width
+  has been changed to two. This more closely matches the overwhelming majority
+  of existing R code.
+
 - Parse errors in your document no longer trigger an LSP error when you request
   document or range formatting (which typically would show up as an annoying
   toast notification in your code editor) (#120).

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
@@ -526,8 +526,8 @@ base_version <-
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -536,24 +536,24 @@ Line width: 80
 1 + 2 + 3 + 4
 
 argument_that_is_quite_long +
-	argument_that_is_quite_long +
-	argument_that_is_quite_long +
-	argument_that_is_quite_long
+  argument_that_is_quite_long +
+  argument_that_is_quite_long +
+  argument_that_is_quite_long
 
 1 + 2^3 + 4
 
 argument_that_is_quite_long +
-	argument_that_is_quite_long^argument_that_is_quite_long +
-	argument_that_is_quite_long
+  argument_that_is_quite_long^argument_that_is_quite_long +
+  argument_that_is_quite_long
 
 1 + # comment
-	2
+  2
 
 1 +
 
-	# comment1
+  # comment1
 
-	2 # comment2
+  2 # comment2
 
 # The following expressions should have spaces
 1 ~ 2
@@ -600,88 +600,88 @@ alias????"^try"
 
 # Soft line breaks kick in for long expressions
 a_really_really_really_really_really_really_long_thing_here ~
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 a_really_really_really_really_really_really_long_thing_here >
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 a_really_really_really_really_really_really_long_thing_here >=
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 a_really_really_really_really_really_really_long_thing_here <
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 a_really_really_really_really_really_really_long_thing_here <=
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 a_really_really_really_really_really_really_long_thing_here ==
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 a_really_really_really_really_really_really_long_thing_here !=
-	a_really_really_really_really_really_really_long_thing_here2
+  a_really_really_really_really_really_really_long_thing_here2
 
 # Chaining does not occur
 a_really_really_long_thing_here1 ~ a_really_really_long_thing_here2 ~
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here3
 
 # Chaining occurs by chance due to how precedence naturally groups these
 # along with having extremely long names
 a_really_really_long_thing_here1 ~
-	a_really_really_really_really_really_really_long_thing_here2 ~
-	a_really_really_long_thing_here3
+  a_really_really_really_really_really_really_long_thing_here2 ~
+  a_really_really_long_thing_here3
 
 # Forced groups
 (a_really_really_long_thing_here1 ~ a_really_really_long_thing_here2) ~
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 ~
-	(a_really_really_long_thing_here2 ~ a_really_really_long_thing_here3)
+  (a_really_really_long_thing_here2 ~ a_really_really_long_thing_here3)
 
 # Mixing with a chaining operator
 a_really_really_long_thing_here1 ~
-	a_really_really_long_thing_here2 +
-		a_really_really_long_thing_here3 +
-		a_really_really_long_thing_here4
+  a_really_really_long_thing_here2 +
+    a_really_really_long_thing_here3 +
+    a_really_really_long_thing_here4
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3 ~
-	a_really_really_long_thing_here4
+  a_really_really_long_thing_here2 +
+  a_really_really_long_thing_here3 ~
+  a_really_really_long_thing_here4
 
 # Chaining operator with high precedence forces non-chaining operator to expand
 # (to convey a reading order that actually matches execution order)
 df |>
-	fn() ~
-	x
+  fn() ~
+  x
 df |>
-	fn() >
-	x
+  fn() >
+  x
 df |>
-	fn() >=
-	x
+  fn() >=
+  x
 df |>
-	fn() <
-	x
+  fn() <
+  x
 df |>
-	fn() <=
-	x
+  fn() <=
+  x
 df |>
-	fn() ==
-	x
+  fn() ==
+  x
 df |>
-	fn() !=
-	x
+  fn() !=
+  x
 # Note that `~` is lower precedence than `&`, so it belongs in this section!
 df &
-	fn() ~
-	x
+  fn() ~
+  x
 
 # Chaining operator with low precedence does not force non-chaining operator to
 # expand (because non-chaining operator does happen first!)
 df &
-	fn() > x
+  fn() > x
 df &
-	fn() >= x
+  fn() >= x
 df &
-	fn() < x
+  fn() < x
 df &
-	fn() <= x
+  fn() <= x
 df &
-	fn() == x
+  fn() == x
 df &
-	fn() != x
+  fn() != x
 
 # User requested line break not respected for non-chainable items
 # (This is debatable, but I see no need to enable it right now)
@@ -696,215 +696,215 @@ a == b
 
 # Chaining same operator
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 +
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 -
-	a_really_really_long_thing_here2 -
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 -
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2 *
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 *
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 /
-	a_really_really_long_thing_here2 /
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 /
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 &
-	a_really_really_long_thing_here2 &
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 &
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 |
-	a_really_really_long_thing_here2 |
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 |
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 &&
-	a_really_really_long_thing_here2 &&
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 &&
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 ||
-	a_really_really_long_thing_here2 ||
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 ||
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 |>
-	a_really_really_long_thing_here2 |>
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 |>
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 %>%
-	a_really_really_long_thing_here2 %>%
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 %>%
+  a_really_really_long_thing_here3
 
 # Chaining mixed operator, same precedence group
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 -
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 -
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 -
-	a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 +
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2 /
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 /
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 /
-	a_really_really_long_thing_here2 *
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 *
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 |>
-	a_really_really_long_thing_here2 %>%
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 %>%
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 %>%
-	a_really_really_long_thing_here2 |>
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 |>
+  a_really_really_long_thing_here3
 
 # TODO: Do we really want these chained? It seems like no good can come of that even though they have same precedence
 a_really_really_long_thing_here1 &
-	a_really_really_long_thing_here2 &&
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 &&
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 |
-	a_really_really_long_thing_here2 ||
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 ||
+  a_really_really_long_thing_here3
 
 # Continuous chaining as long as precedence is high -> low from left -> right
 # (e.g. `*` > `+` in terms of precedence, so keep chaining)
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 +
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 &
-	a_really_really_long_thing_here2 |
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 |
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 &&
-	a_really_really_long_thing_here2 ||
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 ||
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 %>%
-	a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 +
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 %>%
-	a_really_really_long_thing_here2 *
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 *
+  a_really_really_long_thing_here3
 
 # Chaining breaks when precedence goes from low -> high at any point from
 # left -> right (e.g. `+` < `*` in terms of precedence, so we break)
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 * a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 * a_really_really_long_thing_here3
 a_really_really_long_thing_here1 |
-	a_really_really_long_thing_here2 & a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 & a_really_really_long_thing_here3
 a_really_really_long_thing_here1 ||
-	a_really_really_long_thing_here2 && a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 && a_really_really_long_thing_here3
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 %>% a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 %>% a_really_really_long_thing_here3
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2 %>% a_really_really_long_thing_here3
+  a_really_really_long_thing_here2 %>% a_really_really_long_thing_here3
 
 # Chaining breaks when precedence goes from low -> high at any point from
 # left -> right (e.g. `+` < `*` in terms of precedence, so we break)
 # AND we get a second indent if the sub group also breaks
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 *
-		a_really_really_really_really_really_really_really_really_long_thing_here3
+  a_really_really_long_thing_here2 *
+    a_really_really_really_really_really_really_really_really_long_thing_here3
 a_really_really_long_thing_here1 |
-	a_really_really_long_thing_here2 &
-		a_really_really_really_really_really_really_really_really_long_thing_here3
+  a_really_really_long_thing_here2 &
+    a_really_really_really_really_really_really_really_really_long_thing_here3
 a_really_really_long_thing_here1 ||
-	a_really_really_long_thing_here2 &&
-		a_really_really_really_really_really_really_really_really_long_thing_here3
+  a_really_really_long_thing_here2 &&
+    a_really_really_really_really_really_really_really_really_long_thing_here3
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 %>%
-		a_really_really_really_really_really_really_really_really_long_thing_here3
+  a_really_really_long_thing_here2 %>%
+    a_really_really_really_really_really_really_really_really_long_thing_here3
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2 %>%
-		a_really_really_really_really_really_really_really_really_long_thing_here3
+  a_really_really_long_thing_here2 %>%
+    a_really_really_really_really_really_really_really_really_long_thing_here3
 
 # Chaining fully expands when there is a user requested line break
 # in the higher precedence subgroup
 a +
-	b *
-		c
+  b *
+    c
 a |
-	b &
-		c
+  b &
+    c
 a ||
-	b &&
-		c
+  b &&
+    c
 a +
-	b %>%
-		c
+  b %>%
+    c
 a *
-	b %>%
-		c
+  b %>%
+    c
 
 # Chaining doesn't fully expand when there is a user requested line break
 # in the lower precedence subgroup
 a +
-	b * c
+  b * c
 a |
-	b & c
+  b & c
 a ||
-	b && c
+  b && c
 a +
-	b %>% c
+  b %>% c
 a *
-	b %>% c
+  b %>% c
 
 # With sticky operators
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2**a_really_really_long_thing_here3
+  a_really_really_long_thing_here2**a_really_really_long_thing_here3
 a_really_really_long_thing_here1**a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2**a_really_really_long_thing_here3
+  a_really_really_long_thing_here2**a_really_really_long_thing_here3
 a_really_really_long_thing_here1**a_really_really_long_thing_here2 *
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2:a_really_really_long_thing_here3
+  a_really_really_long_thing_here2:a_really_really_long_thing_here3
 a_really_really_long_thing_here1:a_really_really_long_thing_here2 +
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here3
 a_really_really_long_thing_here1 *
-	a_really_really_long_thing_here2:a_really_really_long_thing_here3
+  a_really_really_long_thing_here2:a_really_really_long_thing_here3
 a_really_really_long_thing_here1:a_really_really_long_thing_here2 *
-	a_really_really_long_thing_here3
+  a_really_really_long_thing_here3
 
 # The `*` in the middle splits the `+` chain
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 * a_really_really_long_thing_here3 +
-	a_really_really_long_thing_here1
+  a_really_really_long_thing_here2 * a_really_really_long_thing_here3 +
+  a_really_really_long_thing_here1
 
 # The user line break after the `*` is respected
 # Note how we use indents to show how the LHS/RHS of `*`
 # are grouped even with the user line break, and then dedent
 # before printing `a_really_really_long_thing_here4`
 a_really_really_long_thing_here1 +
-	a_really_really_long_thing_here2 *
-		a_really_really_long_thing_here3 +
-	a_really_really_long_thing_here4
+  a_really_really_long_thing_here2 *
+    a_really_really_long_thing_here3 +
+  a_really_really_long_thing_here4
 
 # -----------------------------------------------------------------------------
 # Binary expression conditionals in if statements
 
 # It fits, nothing to do
 if (long_conditional1 && long_conditional2) {
-	1 + 1
+  1 + 1
 }
 
 # User requested break
 if (
-	long_conditional1 &&
-		long_conditional2
+  long_conditional1 &&
+    long_conditional2
 ) {
-	1 + 1
+  1 + 1
 }
 
 # User requested break, parentheses prevent further splitting
 if (
-	long_conditional1 &&
-		(long_conditional2 || long_conditional3)
+  long_conditional1 &&
+    (long_conditional2 || long_conditional3)
 ) {
-	1 + 1
+  1 + 1
 }
 
 # Not a user respected break because it comes before the `&&`,
 # and we require it to come after
 if (long_conditional1 && long_conditional2) {
-	1 + 1
+  1 + 1
 }
 
 if (
-	long_conditional1 &&
-		long_conditional2 &&
-		long_conditional3 &&
-		long_conditional4 &&
-		long_conditional5
+  long_conditional1 &&
+    long_conditional2 &&
+    long_conditional3 &&
+    long_conditional4 &&
+    long_conditional5
 ) {
-	1 + 1
+  1 + 1
 }
 
 # -----------------------------------------------------------------------------
@@ -915,9 +915,9 @@ if (
 df |> foo() |> bar() |> baz()
 
 df |>
-	foo() |>
-	bar() |>
-	baz()
+  foo() |>
+  bar() |>
+  baz()
 
 df |> foo() |> bar() |> baz()
 
@@ -931,18 +931,18 @@ df |> foo() |> bar() |> baz()
 
 # Works with mixed binary operator types
 df |>
-	foo() %>%
-	bar() |>
-	baz()
+  foo() %>%
+  bar() |>
+  baz()
 
 # One line
 df |> ggplot() + geom_line() + geom_bar()
 
 # Expansion requested
 df |>
-	ggplot() +
-	geom_line() +
-	geom_bar()
+  ggplot() +
+  geom_line() +
+  geom_bar()
 
 # Flattened, this is one big chain due to monotonically decreasing
 # precedence, so user requested expansion only applies to 1st operator
@@ -954,40 +954,40 @@ df |> ggplot() + geom_line() + geom_bar()
 
 # Non-binary operators break the expansion propagation
 (df |> foo()) |>
-	bar() |>
-	baz() |>
-	{
-		. |> and() |> this()
-	}
+  bar() |>
+  baz() |>
+  {
+    . |> and() |> this()
+  }
 
 (df |> foo()) |>
-	bar() |>
-	baz() |>
-	{
-		. |>
-			and() |>
-			this()
-	}
+  bar() |>
+  baz() |>
+  {
+    . |>
+      and() |>
+      this()
+  }
 
 (1 + 2 * 3) +
-	(4 + 5 * 6) +
-	(7 + 8)
+  (4 + 5 * 6) +
+  (7 + 8)
 
 # Sticky binary operators break the expansion propagation
 # (`2:3` stays together, `6^7` stays together)
 1 +
-	2:3 +
-	4 +
-	5 +
-	6^7 +
-	8 +
-	9
+  2:3 +
+  4 +
+  5 +
+  6^7 +
+  8 +
+  9
 
 # Precedence is taken into account correctly
 1:2 + 3
 
 1:2 +
-	3
+  3
 
 # Inside parentheses, subset, or, subset2, you can put a newline before
 # the `|>`, which isn't valid R code at top level. This doesn't result
@@ -1001,18 +1001,18 @@ x[[df |> foo()]]
 
 # This does retain the break, because it comes after the pipe
 (
-	df |>
-		foo()
+  df |>
+    foo()
 )
 
 x[
-	df |>
-		foo()
+  df |>
+    foo()
 ]
 
 x[[
-	df |>
-		foo()
+  df |>
+    foo()
 ]]
 
 # -----------------------------------------------------------------------------
@@ -1023,14 +1023,14 @@ x[[
 # and between sequential arguments in calls.
 # This is common with pipelines.
 df |>
-	a() |>
+  a() |>
 
-	# Some important notes about this complex call
-	b() |>
+  # Some important notes about this complex call
+  b() |>
 
-	# Some more important notes
-	c() |>
-	d()
+  # Some more important notes
+  c() |>
+  d()
 
 # -----------------------------------------------------------------------------
 # Comments in chains
@@ -1039,37 +1039,37 @@ df |> foo() # Trailing of `df |> foo()` pipe chain
 
 # Leading of `df |> foo() |> bar() |> baz()` pipe chain
 df |>
-	foo() |>
-	bar() |>
-	baz()
+  foo() |>
+  bar() |>
+  baz()
 
 df |>
-	# Leading of `foo()` call
-	foo() |>
-	# Leading of `bar()` call
-	bar() |>
-	# Leading of `baz()` call
-	baz()
+  # Leading of `foo()` call
+  foo() |>
+  # Leading of `bar()` call
+  bar() |>
+  # Leading of `baz()` call
+  baz()
 
 df |> # Trailing of `df` identifier
-	foo() |>
-	bar() |>
-	baz()
+  foo() |>
+  bar() |>
+  baz()
 
 df |>
-	foo() |> # Trailing of `df |> foo()` pipe chain
-	bar() |>
-	baz()
+  foo() |> # Trailing of `df |> foo()` pipe chain
+  bar() |>
+  baz()
 
 df |>
-	foo() |>
-	bar() |> # Trailing of `df |> foo() |> bar()` pipe chain
-	baz()
+  foo() |>
+  bar() |> # Trailing of `df |> foo() |> bar()` pipe chain
+  baz()
 
 df |>
-	foo() |>
-	bar() |>
-	baz() # Trailing of `df |> foo() |> bar() |> baz()` pipe chain
+  foo() |>
+  bar() |>
+  baz() # Trailing of `df |> foo() |> bar() |> baz()` pipe chain
 
 # -----------------------------------------------------------------------------
 # Mixing pipes and pluses
@@ -1079,23 +1079,23 @@ df |>
 # We don't add an extra level of indent after the first `+`,
 # it is specially treated as being within the same group as the `|>`
 df |>
-	ggplot() +
-	geom_line() +
-	geom_bar()
+  ggplot() +
+  geom_line() +
+  geom_bar()
 
 df %>%
-	ggplot() +
-	geom_line() +
-	geom_bar()
+  ggplot() +
+  geom_line() +
+  geom_bar()
 
 # Piping OUT of a `+` chain should add an extra indent.
 # This is illogical behavior, it results in `identity(geom_bar())`, which is
 # definitely not what the user wants, so the extra indent is a good thing
 # as it proves that you've entered a different "group".
 ggplot() +
-	geom_line() +
-	geom_bar() %>%
-		identity()
+  geom_line() +
+  geom_bar() %>%
+    identity()
 
 # -----------------------------------------------------------------------------
 # Assignment
@@ -1103,20 +1103,20 @@ ggplot() +
 # The following assignments should start the LHS/RHS on the same
 # line as the operator
 fn = function(x) {
-	x
+  x
 }
 fn <- function(x) {
-	x
+  x
 }
 fn <<- function(x) {
-	x
+  x
 }
 
 # Assignment comment tests
 fn <- function(x) {
-	# comment1
-	# comment2
-	x # comment3
+  # comment1
+  # comment2
+  x # comment3
 } # comment4
 
 identity(1) -> x
@@ -1127,16 +1127,16 @@ identity(1) ->> x
 
 # Magic line break after the left assignment
 fn =
-	value
+  value
 fn <-
-	value
+  value
 fn <<-
-	value
+  value
 
 # Important that comment3 trails `value` here!
 fn <- # comment1
-	# comment2
-	value # comment3
+  # comment2
+  value # comment3
 
 # No magic line break after walrus operator
 fn := value
@@ -1151,18 +1151,18 @@ fn ->> value
 
 # https://github.com/posit-dev/air/issues/91
 is_condition_true <-
-	if (condition) {
-		"yes"
-	} else {
-		"no"
-	}
+  if (condition) {
+    "yes"
+  } else {
+    "no"
+  }
 
 # https://github.com/posit-dev/air/issues/91
 base_version <-
-	version %||%
-		b_get(brand, "defaults", "shiny", "theme", "version") %||%
-		b_get(brand, "defaults", "bootstrap", "version") %||%
-		version_default()
+  version %||%
+    b_get(brand, "defaults", "shiny", "theme", "version") %||%
+    b_get(brand, "defaults", "bootstrap", "version") %||%
+    version_default()
 ```
 
 # Lines exceeding max width of 80 characters

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
@@ -60,8 +60,8 @@ argument_that_is_quite_quite_quite_quite_long(argument_that_is_quite_quite_quite
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -89,80 +89,80 @@ argument_that_is_quite_quite_quite_quite_long:argument_that_is_quite_quite_quite
 
 # If the RHS contains other complex expressions, they are allowed to break
 argument_that_is_quite_quite_quite_quite_long$argument_that_is_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long@argument_that_is_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long::argument_that_is_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long:::argument_that_is_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long?argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long**argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long^argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long:argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 
 # `$` and `@` and regular binary operators are allowed complex expressions on their LHS
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )$argument_that_is_quite_quite_quite_long
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )@argument_that_is_quite_quite_quite_long
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )?argument_that_is_quite_quite_quite_quite_long
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )**argument_that_is_quite_quite_quite_quite_long
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )^argument_that_is_quite_quite_quite_quite_long
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 ):argument_that_is_quite_quite_quite_quite_long
 
 # Chaining of method calls
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )$argument_that_is_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )@argument_that_is_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )?argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )**argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )^argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 ):argument_that_is_quite_quite_quite_quite_long(
-	argument_that_is_quite_quite_quite_long
+  argument_that_is_quite_quite_quite_long
 )
 ```
 

--- a/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
@@ -89,8 +89,8 @@ fn({{
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -108,11 +108,11 @@ if (a) {
 }
 
 {
-	1
+  1
 }
 
 {
-	# comment
+  # comment
 }
 
 # ------------------------------------------------------------------------
@@ -126,91 +126,91 @@ fn(mean({{ var }}))
 fn({{ var }} + 1)
 
 fn(
-	{{
-		var_that_is_extremely_long_and_eventually_forces_a_line_break_once_we_eventually_get_to_the_end
-	}}
+  {{
+    var_that_is_extremely_long_and_eventually_forces_a_line_break_once_we_eventually_get_to_the_end
+  }}
 )
 
 fn(
-	{{
-		# Leading of `var`
-		var
-	}}
+  {{
+    # Leading of `var`
+    var
+  }}
 )
 
 # Comprehensive comment test
 fn(
-	# C1
-	# C2 (lifted up)
-	# C3 (lifted up)
-	{{
-		# C4 (leads var)
-		# C5 (leads var)
-		var
-		# C6
-	}} # C7 (this line, but after folded 2nd `}`)
-	# C8 (after both `}}`) # C9 (same line as C8)
-	# C10
+  # C1
+  # C2 (lifted up)
+  # C3 (lifted up)
+  {{
+    # C4 (leads var)
+    # C5 (leads var)
+    var
+    # C6
+  }} # C7 (this line, but after folded 2nd `}`)
+  # C8 (after both `}}`) # C9 (same line as C8)
+  # C10
 )
 
 # Not curly-curly, not a symbol
 fn({
-	{
-		1
-	}
+  {
+    1
+  }
 })
 fn({
-	{
-		(var)
-	}
+  {
+    (var)
+  }
 })
 
 # Not curly-curly, not inside an argument
 {
-	{
-		var
-	}
+  {
+    var
+  }
 }
 function(
-	a = {
-		{
-			var
-		}
-	}
+  a = {
+    {
+      var
+    }
+  }
 ) {
 }
 
 # Not curly-curly, 2 inner expressions
 fn({
-	{
-		1
-		2
-	}
+  {
+    1
+    2
+  }
 })
 
 # Not curly-curly, 2 outer expressions
 fn({
-	{
-		foo
-	}
-	bar
+  {
+    foo
+  }
+  bar
 })
 
 # Not curly-curly, 0 inner expressions
 fn({
-	{
-	}
+  {
+  }
 })
 
 # Not curly-curly, 0 inner expressions (important, even with dangling comment!)
 fn({
-	{
-		# dangling
-	}
+  {
+    # dangling
+  }
 })
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-   32: 		var_that_is_extremely_long_and_eventually_forces_a_line_break_once_we_eventually_get_to_the_end
+   32:     var_that_is_extremely_long_and_eventually_forces_a_line_break_once_we_eventually_get_to_the_end
 ```

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -659,8 +659,8 @@ fn(
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -683,10 +683,10 @@ fn(, a, , )
 fn(a, , b, , )
 
 fn(
-	a_really_long_argument_here,
-	,
-	another_really_really_long_argument_to_test_this_feature,
-	,
+  a_really_long_argument_here,
+  ,
+  another_really_really_long_argument_to_test_this_feature,
+  ,
 )
 
 # ------------------------------------------------------------------------
@@ -696,10 +696,10 @@ fn(...)
 fn(..., a = 1)
 fn(a = 1, ... = 2)
 fn(
-	a = 1,
-	another_really_really_long_argument_to_test_this_feature,
-	a_really_long_argument_here,
-	...
+  a = 1,
+  another_really_really_long_argument_to_test_this_feature,
+  a_really_long_argument_here,
+  ...
 )
 
 # ------------------------------------------------------------------------
@@ -715,8 +715,8 @@ fn(..1 = 1, ..2 = 2)
 
 # So this data dictionary stays expanded even though it fits on one line
 dictionary <- list(
-	a = 1,
-	b = 2
+  a = 1,
+  b = 2
 )
 
 # This flattens to one line
@@ -727,29 +727,29 @@ dictionary <- list(a = 1, b = 2)
 
 # Expanding the inner list forces expansion of the outer list
 list(
-	a = 1,
-	b = list(
-		foo = "a",
-		bar = "b"
-	)
+  a = 1,
+  b = list(
+    foo = "a",
+    bar = "b"
+  )
 )
 
 # Expansion of `bar()` forces expansion of the whole pipeline
 # (But note `foo(a = 1)` is not expanded)
 df |>
-	foo(a = 1) |>
-	bar(
-		b = 2,
-		c = 3
-	)
+  foo(a = 1) |>
+  bar(
+    b = 2,
+    c = 3
+  )
 
 # Expansion of `foo()` forces expansion of the whole pipeline
 # (But note `bar(b = 2, c = 3)` is not expanded)
 df |>
-	foo(
-		a = 1
-	) |>
-	bar(b = 2, c = 3)
+  foo(
+    a = 1
+  ) |>
+  bar(b = 2, c = 3)
 
 # Test-like call overrides user requested line break
 # (test-like check comes first and seems more relevant)
@@ -762,144 +762,144 @@ test_that("description", {
 # Leading holes are "invisible" when determining user requested expansion
 # These all expand
 fn(,
-	x = 1
+  x = 1
 )
 
 fn(,
-	x = 1
+  x = 1
 )
 
 fn(,
-	x = 1
+  x = 1
 )
 
 fn(,,
-	x = 1
+  x = 1
 )
 
 # A comment connected to a hole prevents it from being a "leading hole",
 # instead it just becomes part of the typical arguments list and expands
 fn(
-	# comment
-	,
-	x = 1
+  # comment
+  ,
+  x = 1
 )
 
 fn(,
-	# comment
-	,
-	x = 1
+  # comment
+  ,
+  x = 1
 )
 
 # ------------------------------------------------------------------------
 # Comments "inside" holes
 
 fn(
-	# comment
-	,
+  # comment
+  ,
 )
 
 fn(,
-	# comment
+  # comment
 )
 fn(,
-	# comment
+  # comment
 )
 fn(,
-	# comment
+  # comment
 )
 fn(,
-	# comment
+  # comment
 )
 
 fn(,
-	# comment
-	,
+  # comment
+  ,
 )
 fn(,
-	# comment
-	,
+  # comment
+  ,
 )
 fn(,
-	# comment
-	,
+  # comment
+  ,
 )
 fn(,
-	# comment
-	,
+  # comment
+  ,
 )
 
 fn(,,
-	# comment1
-	# comment2
-	,
-	x
+  # comment1
+  # comment2
+  ,
+  x
 )
 
 # Trails `a`
 fn(
-	a, # comment
-	,
-	b
+  a, # comment
+  ,
+  b
 )
 # Trails `a` technically, but should stay on own line
 fn(
-	a,
-	# comment
-	,
-	b
+  a,
+  # comment
+  ,
+  b
 )
 # Trails `a`
 fn(
-	a, # comment
-	# comment2
-	,
-	b
+  a, # comment
+  # comment2
+  ,
+  b
 )
 
 # Special test - ensure this leads `b` rather than trails `a`
 fn(,
-	a,
-	,
-	# comment
-	b
+  a,
+  ,
+  # comment
+  b
 )
 
 # Both comments lead the hole
 fn(
-	# comment1
-	# comment2
-	,
-	x
+  # comment1
+  # comment2
+  ,
+  x
 )
 
 # Comment leads hole
 # Following token is `,`, preceding before hole is another hole
 fn(
-	a,
-	,
-	# comment
-	,
-	b
+  a,
+  ,
+  # comment
+  ,
+  b
 )
 fn(,
-	# comment
-	,
-	x
+  # comment
+  ,
+  x
 )
 
 # Comment leads `{` but doesn't move inside it
 fn(,,
-	# comment
-	{
-		1 + 1
-	}
+  # comment
+  {
+    1 + 1
+  }
 )
 
 # A particular motivating case. Want trailing `,` commentB to stay on `b`.
 list2(
-	a, # commentA
-	b, # commentB
+  a, # commentA
+  b, # commentB
 )
 
 # ------------------------------------------------------------------------
@@ -909,124 +909,124 @@ list2(
 # Following token isn't `,`, `)`, `]`, or `]]`, and following node is non-hole,
 # so we attach to it
 fn(,,
-	# comment
-	x
+  # comment
+  x
 )
 fn(,,
-	# comment1
-	# comment2
-	x
+  # comment1
+  # comment2
+  x
 )
 
 # ------------------------------------------------------------------------
 # Trailing braced expression
 
 with(data, {
-	col
+  col
 })
 
 with(data, {
-	col
+  col
 })
 
 # User requested line break before `data` is respected
 with(
-	data,
-	{
-		col
-	}
+  data,
+  {
+    col
+  }
 )
 
 # User requested line break before `data` is respected
 with(
-	data,
-	# A comment
-	{
-		col
-	}
+  data,
+  # A comment
+  {
+    col
+  }
 )
 
 with(
-	data, # Prevents flattening
-	{
-		col
-	}
+  data, # Prevents flattening
+  {
+    col
+  }
 )
 
 with(data, expr = {
-	col
+  col
 })
 
 with(data, foo = "bar", {
-	col
+  col
 })
 
 # Not trailing, stays expanded
 with(
-	data,
-	{
-		col
-	},
-	foo = "bar"
+  data,
+  {
+    col
+  },
+  foo = "bar"
 )
 
 # Breaks and fully expands due to line length
 with(
-	my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
-	{
-		col
-	}
+  my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
+  {
+    col
+  }
 )
 
 with(data, {
 })
 
 with(data, {
-	# dangling
+  # dangling
 })
 
 fn({
 })
 
 fn({
-	# dangling
+  # dangling
 })
 
 fn({
-	1 + 1
+  1 + 1
 })
 
 fn(a = {
-	1 + 1
+  1 + 1
 })
 
 # The first argument here breaks, causing everything to fully expand
 fn(
-	{
-		1 + 1
-	},
-	{
-		1 + 1
-	}
+  {
+    1 + 1
+  },
+  {
+    1 + 1
+  }
 )
 
 # Hole prevents `{` from looking like the last expression, so everything expands
 fn(
-	x,
-	{
-		1 + 1
-	},
+  x,
+  {
+    1 + 1
+  },
 )
 
 # ------------------------------------------------------------------------
 # Trailing inline function
 
 map(xs, \(x) {
-	x + 1
+  x + 1
 })
 
 map(xs, function(x) {
-	x + 1
+  x + 1
 })
 
 # Braces expand over multiple lines
@@ -1038,10 +1038,10 @@ map(xs, function(x) x)
 
 # This form is too wide, so it fully expands
 map(
-	my_long_list_my_long_list_my_long_list_my_long_list,
-	function(my_long_argument) {
-		my_long_body_my_long_body_my_long_body_my_long_body_my_long_body
-	}
+  my_long_list_my_long_list_my_long_list_my_long_list,
+  function(my_long_argument) {
+    my_long_body_my_long_body_my_long_body_my_long_body_my_long_body
+  }
 )
 
 # Parameter names are very long, so it fully expands
@@ -1050,49 +1050,49 @@ map(
 # soft-indents allowed in the `parameters` and the fully expanded form, the
 # fully expanded form wins)
 map(
-	x,
-	function(
-		a,
-		a_really_really_long_parameter,
-		and_another_one_here_too_wow_this_is_long
-	) {
-		1
-	}
+  x,
+  function(
+    a,
+    a_really_really_long_parameter,
+    and_another_one_here_too_wow_this_is_long
+  ) {
+    1
+  }
 )
 
 # The `{ 1 }` parameter would force a hard line break. We detect this and don't
 # use best-fitting. Instead we fall back to the most expanded form.
 map(
-	x,
-	function(
-		a = {
-			1
-		}
-	) {
-		1
-	}
+  x,
+  function(
+    a = {
+      1
+    }
+  ) {
+    1
+  }
 )
 
 # Since there is only 1 argument, we want these to hug the function call even
 # though the `parameters` cause a break and would typically force full expansion
 fn(function(
-	a = {
-		1
-	}
+  a = {
+    1
+  }
 ) {
-	1
+  1
 })
 fn(function(
-	a,
-	a_really_really_long_parameter,
-	and_another_one_here_too_wow_this_is_long
+  a,
+  a_really_really_long_parameter,
+  and_another_one_here_too_wow_this_is_long
 ) {
-	1
+  1
 })
 
 # Named argument keeps name (#42)
 map(xs, .f = function(x) {
-	x + 1
+  x + 1
 })
 
 # ------------------------------------------------------------------------
@@ -1108,65 +1108,65 @@ map(xs, .f = function(x) {
 # - Comments on the `value` node of a `AnyRArgument::NamedRArgument` node
 
 with(
-	xs, # end-of-line
-	expr = {
-		x + 1
-	}
+  xs, # end-of-line
+  expr = {
+    x + 1
+  }
 )
 
 with(
-	xs,
-	# own-line
-	expr = {
-		x + 1
-	}
+  xs,
+  # own-line
+  expr = {
+    x + 1
+  }
 )
 
 with(
-	xs,
-	# end-of-line
-	expr = {
-		x + 1
-	}
+  xs,
+  # end-of-line
+  expr = {
+    x + 1
+  }
 )
 
 with(
-	xs,
-	# own-line
-	expr = {
-		x + 1
-	}
+  xs,
+  # own-line
+  expr = {
+    x + 1
+  }
 )
 
 with(
-	xs,
-	# end-of-line
-	expr = {
-		x + 1
-	}
+  xs,
+  # end-of-line
+  expr = {
+    x + 1
+  }
 )
 
 with(
-	xs,
-	# own-line
-	expr = {
-		x + 1
-	}
+  xs,
+  # own-line
+  expr = {
+    x + 1
+  }
 )
 
 with(
-	xs,
-	expr = {
-		x + 1
-	} # end-of-line
+  xs,
+  expr = {
+    x + 1
+  } # end-of-line
 )
 
 with(
-	xs,
-	expr = {
-		x + 1
-	}
-	# own-line
+  xs,
+  expr = {
+    x + 1
+  }
+  # own-line
 )
 
 # ------------------------------------------------------------------------
@@ -1181,99 +1181,99 @@ with(
 # - Comments on the `value` node of a `AnyRArgument::NamedRArgument` node
 
 fn(
-	xs, # end-of-line
-	f = function(x) {
-		x + 1
-	}
+  xs, # end-of-line
+  f = function(x) {
+    x + 1
+  }
 )
 
 fn(
-	xs,
-	# own-line
-	f = function(x) {
-		x + 1
-	}
+  xs,
+  # own-line
+  f = function(x) {
+    x + 1
+  }
 )
 
 fn(
-	xs,
-	# end-of-line
-	f = function(x) {
-		x + 1
-	}
+  xs,
+  # end-of-line
+  f = function(x) {
+    x + 1
+  }
 )
 
 fn(
-	xs,
-	# own-line
-	f = function(x) {
-		x + 1
-	}
+  xs,
+  # own-line
+  f = function(x) {
+    x + 1
+  }
 )
 
 fn(
-	xs,
-	# end-of-line
-	f = function(x) {
-		x + 1
-	}
+  xs,
+  # end-of-line
+  f = function(x) {
+    x + 1
+  }
 )
 
 fn(
-	xs,
-	# own-line
-	f = function(x) {
-		x + 1
-	}
+  xs,
+  # own-line
+  f = function(x) {
+    x + 1
+  }
 )
 
 fn(
-	xs,
-	f = function(x) {
-		x + 1
-	} # end-of-line
+  xs,
+  f = function(x) {
+    x + 1
+  } # end-of-line
 )
 
 fn(
-	xs,
-	f = function(x) {
-		x + 1
-	}
-	# own-line
+  xs,
+  f = function(x) {
+    x + 1
+  }
+  # own-line
 )
 
 # ------------------------------------------------------------------------
 # Comments: Named arguments without a RHS
 
 switch(
-	name,
-	one = , # Trailing, stays beside `one`
-	two = , # Trailing, stays beside `two`
-	three = 1,
-	stop("oh no")
+  name,
+  one = , # Trailing, stays beside `one`
+  two = , # Trailing, stays beside `two`
+  three = 1,
+  stop("oh no")
 )
 
 # This is enclosed by the `RNamedArgument` node, so it moves on top
 fn(
-	x,
-	# Moves above `one`
-	one = ,
-	two = 2
+  x,
+  # Moves above `one`
+  one = ,
+  two = 2
 )
 
 # This is not enclosed by the `RNamedArgument` node because it only contains
 # `one =` and stops at the end of the `=`. So it is considered trailing.
 fn(
-	x,
-	one = , # Trailing, stays beside `one`
-	two = 2
+  x,
+  one = , # Trailing, stays beside `one`
+  two = 2
 )
 
 # This is not enclosed by the `RNamedArgument` node because it only contains
 # `one =` and stops at the end of the `=`. So it is considered trailing.
 fn(
-	x,
-	one = # Trailing, stays beside `one`
+  x,
+  one = # Trailing, stays beside `one`
 )
 
 # ------------------------------------------------------------------------
@@ -1290,60 +1290,60 @@ fn(x, {{ var }})
 # (like with top level expressions), but empty lines right after `(`
 # and right before `)` are removed.
 fn(
-	a,
+  a,
 
-	b,
+  b,
 
-	c
+  c
 )
 
 fn(
-	a,
+  a,
 
-	# comment1
-	b,
+  # comment1
+  b,
 
-	# comment2
-	c
+  # comment2
+  c
 )
 
 # Due to holes not having tokens, we collapse full empty lines in them
 fn(
-	# comment1
-	,
-	# comment2
-	,
+  # comment1
+  ,
+  # comment2
+  ,
 
-	b
+  b
 )
 
 fn(,
-	# comment2
-	,
+  # comment2
+  ,
 
-	b
+  b
 )
 
 # ------------------------------------------------------------------------
 # Comments
 
 fn(
-	# dangling special case
+  # dangling special case
 )
 
 fn(
-	a, # on line of `a`
-	b
+  a, # on line of `a`
+  b
 )
 
 fn(
-	# top of `a`
-	a,
-	b
+  # top of `a`
+  a,
+  b
 )
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-  307: 	my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
+  307:   my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
 ```

--- a/crates/air_r_formatter/tests/specs/r/comment.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/comment.R.snap
@@ -18,8 +18,8 @@ info: r/comment.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
@@ -18,8 +18,8 @@ string"
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
@@ -23,8 +23,8 @@ function(...) {
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -35,6 +35,6 @@ Line width: 80
 ..10
 
 function(...) {
-	..1 + ..2
+  ..1 + ..2
 }
 ```

--- a/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
@@ -27,8 +27,8 @@ for (
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -37,13 +37,13 @@ Line width: 80
 for (x in y) x + y
 
 for (a_really_long_argument_name in but_we_dont_ever_break_inside_for_conditions_no_matter_how_long)
-	1
+  1
 
 # own-line comments get lifted up
 # comment1
 # comment2
 for (a in 1) # comment3
-	a
+  a
 ```
 
 # Lines exceeding max width of 80 characters

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
@@ -140,8 +140,8 @@ map(xs, function(x,
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -151,50 +151,50 @@ function() 1
 function(a, b) 1
 
 function(
-	a_really_long_argument_name_to_break_on,
-	and_here_is_another_one_please_break_me,
-	and_this
+  a_really_long_argument_name_to_break_on,
+  and_here_is_another_one_please_break_me,
+  and_this
 ) 1
 
 function(a_really_long_argument_name_to_break_on, and_this)
-	a_really_long_argument_name_to_break_on
+  a_really_long_argument_name_to_break_on
 
 function(
-	a = {
-		1
-	},
-	b
+  a = {
+    1
+  },
+  b
 ) {
-	1
+  1
 }
 
 function() {
-	# comment
+  # comment
 }
 
 function() {
-	# becomes leading on `1 + 1`
-	1 + 1
+  # becomes leading on `1 + 1`
+  1 + 1
 }
 
 function() {
-	# becomes leading on `1 + 1`
-	# an inner comment
-	1 + 1
+  # becomes leading on `1 + 1`
+  # an inner comment
+  1 + 1
 }
 
 function() {
-	# becomes dangling on the `{}`
+  # becomes dangling on the `{}`
 }
 
 function() {
-	# becomes dangling on the `{}`
-	# an inner comment but empty `{}`
+  # becomes dangling on the `{}`
+  # an inner comment but empty `{}`
 }
 
 function()
-	# becomes leading on `1 + 1`
-	1 + 1
+  # becomes leading on `1 + 1`
+  1 + 1
 
 \(x, y) 1
 
@@ -205,55 +205,55 @@ function()
 
 # So this function definition stays expanded even though it fits on one line
 fn <- function(
-	a,
-	b
+  a,
+  b
 ) {
-	body
+  body
 }
 
 # This flattens to one line
 fn <- function(a, b) {
-	body
+  body
 }
 
 # This flattens to one line
 fn <- function(a, b) {
-	body
+  body
 }
 
 # Expansion doesn't propagate to the `c(1, 2, 3)`
 fn <- function(
-	a,
-	b = c(1, 2, 3)
+  a,
+  b = c(1, 2, 3)
 ) {
-	body
+  body
 }
 
 # Dots - this expands
 fn <- function(
-	...,
-	a,
-	b
+  ...,
+  a,
+  b
 ) {
-	body
+  body
 }
 
 # Dots - this flattens
 fn <- function(..., a, b) {
-	body
+  body
 }
 
 # User requested expansion of the `c()` call forces expansion of
 # the entire function definition
 fn <- function(
-	a,
-	b = c(
-		1,
-		2,
-		3
-	)
+  a,
+  b = c(
+    1,
+    2,
+    3
+  )
 ) {
-	body
+  body
 }
 
 # ------------------------------------------------------------------------
@@ -264,25 +264,25 @@ fn <- function(
 # This user line break expands the function definition, causing the whole
 # `map()` to expand
 map(
-	xs,
-	function(
-		x,
-		option = "a"
-	) {
-		x
-	}
+  xs,
+  function(
+    x,
+    option = "a"
+  ) {
+    x
+  }
 )
 
 # This flattens the function definition, but the `map()` stays expanded
 map(
-	xs,
-	function(x, option = "a") {
-		x
-	}
+  xs,
+  function(x, option = "a") {
+    x
+  }
 )
 
 # This flattens to one line
 map(xs, function(x, option = "a") {
-	x
+  x
 })
 ```

--- a/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
@@ -67,8 +67,8 @@ if (this || this || this || this || this || this || this || this || this || this
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -83,66 +83,71 @@ if (a) 1 else if (b) 2 else 3
 
 # Line break test
 if (
-	a_really_really_long_condition_here_that_is_allowed_to_break_onto_the_next_line
+  a_really_really_long_condition_here_that_is_allowed_to_break_onto_the_next_line
 )
-	1 else 2
+  1 else 2
 
 if (a) {
-	# becomes leading on `1 + 1`
-	1 + 1
+  # becomes leading on `1 + 1`
+  1 + 1
 }
 
 if (a) {
-	# becomes dangling on `{}`
+  # becomes dangling on `{}`
 }
 
 if (a) {
-	# becomes dangling on `{}`
-	# inner comment but empty `{}`
+  # becomes dangling on `{}`
+  # inner comment but empty `{}`
 }
 
 if (a)
-	# becomes leading on `TRUE`
-	TRUE
+  # becomes leading on `TRUE`
+  TRUE
 
 if (
-	a
-	# becomes trailing on `a`
+  a
+  # becomes trailing on `a`
 ) {
-	TRUE
+  TRUE
 }
 
 if (
-	a # becomes trailing on `a`
+  a # becomes trailing on `a`
 ) {
-	TRUE
+  TRUE
 }
 
 # Breaks, but the `condition` itself fits and is not expanded
 if (
-	this || this || this || this || this || this || this || this || this || this
+  this || this || this || this || this || this || this || this || this || this
 ) {
-	1
+  1
 } else {
-	2
+  2
 }
 # Breaks, but the `condition` itself also doesn't fit and is also expanded
 if (
-	this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this ||
-		this
+  this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this ||
+    this
 ) {
-	1
+  1
 } else {
-	2
+  2
 }
+```
+
+# Lines exceeding max width of 80 characters
+```
+   10:   a_really_really_long_condition_here_that_is_allowed_to_break_onto_the_next_line
 ```

--- a/crates/air_r_formatter/tests/specs/r/keyword.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/keyword.R.snap
@@ -29,8 +29,8 @@ NA_character_
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
@@ -38,8 +38,8 @@ info: r/parenthesized_expression.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -50,25 +50,25 @@ Line width: 80
 # TODO: Should we keep it simple and say that fully expanding here (due to the
 # braced expression) is the best that we want to do?
 (
-	{
-		1 + 1
-	}
+  {
+    1 + 1
+  }
 )
 (
-	function() {
-		1 + 1
-	}
+  function() {
+    1 + 1
+  }
 )
 
 # Shouldn't automatically break in the function call
 (fn(a, b, c))
 
 (
-	fn_call_that_is_really_long(
-		with_really_long,
-		arguments_like_this,
-		and_this_one_too
-	)
+  fn_call_that_is_really_long(
+    with_really_long,
+    arguments_like_this,
+    and_this_one_too
+  )
 )
 
 ((1))
@@ -77,9 +77,9 @@ Line width: 80
 # the `body` node inside the `()`. Note `comment5` here is not enclosed by the
 # parenthesized expression node so it stays where it is.
 (
-	# comment1
-	# comment2
-	1 # comment3
-	# comment4
+  # comment1
+  # comment2
+  1 # comment3
+  # comment4
 ) # comment5
 ```

--- a/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
@@ -50,44 +50,44 @@ name = mtcars |>
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
 
 ```R
 mtcars |>
-	mutate(foo = 1) %>%
-	filter(
-		foo == 1,
-		bar == 2,
-	) |>
-	ggplot(
-		argument_that_is_quite_long = argument_that_is_quite_long,
-		argument_that_is_quite_long = argument_that_is_quite_long
-	)
+  mutate(foo = 1) %>%
+  filter(
+    foo == 1,
+    bar == 2,
+  ) |>
+  ggplot(
+    argument_that_is_quite_long = argument_that_is_quite_long,
+    argument_that_is_quite_long = argument_that_is_quite_long
+  )
 
 # RHS of assignment should stay on same line as the `<-` operator
 name <- mtcars |>
-	mutate(foo = 1) %>%
-	filter(
-		foo == 1,
-		bar == 2,
-	) |>
-	ggplot(
-		argument_that_is_quite_long = argument_that_is_quite_long,
-		argument_that_is_quite_long = argument_that_is_quite_long
-	)
+  mutate(foo = 1) %>%
+  filter(
+    foo == 1,
+    bar == 2,
+  ) |>
+  ggplot(
+    argument_that_is_quite_long = argument_that_is_quite_long,
+    argument_that_is_quite_long = argument_that_is_quite_long
+  )
 
 name = mtcars |>
-	mutate(foo = 1) %>%
-	filter(
-		foo == 1,
-		bar == 2,
-	) |>
-	ggplot(
-		argument_that_is_quite_long = argument_that_is_quite_long,
-		argument_that_is_quite_long = argument_that_is_quite_long
-	)
+  mutate(foo = 1) %>%
+  filter(
+    foo == 1,
+    bar == 2,
+  ) |>
+  ggplot(
+    argument_that_is_quite_long = argument_that_is_quite_long,
+    argument_that_is_quite_long = argument_that_is_quite_long
+  )
 ```

--- a/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
@@ -57,8 +57,8 @@ repeat # comment1
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -70,42 +70,42 @@ repeat {
 }
 
 repeat {
-	# a comment
+  # a comment
 }
 
 repeat {
-	# comment1
-	# comment2
-	1 + 1
+  # comment1
+  # comment2
+  1 + 1
 }
 
 repeat {
-	# comment1
-	# comment2
-	1 + 1
+  # comment1
+  # comment2
+  1 + 1
 }
 
 repeat {
-	# comment1
+  # comment1
 }
 
 repeat {
-	# comment1
-	# comment2
+  # comment1
+  # comment2
 }
 
 repeat {
-	# comment1
-	1 + 1
+  # comment1
+  1 + 1
 }
 
 # comment1
 repeat {
-	# comment2
-	1 + 1
+  # comment2
+  1 + 1
 }
 
 repeat
-	# comment1
-	1
+  # comment1
+  1
 ```

--- a/crates/air_r_formatter/tests/specs/r/smoke.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/smoke.R.snap
@@ -17,8 +17,8 @@ info: r/smoke.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -156,8 +156,8 @@ dt[,
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -168,25 +168,25 @@ fn[a]
 
 # Inherits call-like behavior with trailing braced expressions
 fn[a = {
-	1 + 1
+  1 + 1
 }]
 fn["description", {
-	1 + 1
+  1 + 1
 }]
 
 # Leading hole hugs `[`
 DT[,
-	{
-		# write each group to a different file
-		fwrite(.SD, "name")
-	},
-	by = x
+  {
+    # write each group to a different file
+    fwrite(.SD, "name")
+  },
+  by = x
 ]
 
 # This is pretty good
 DT[, by = x, {
-	# write each group to a different file
-	fwrite(.SD, "name")
+  # write each group to a different file
+  fwrite(.SD, "name")
 }]
 
 # ------------------------------------------------------------------------
@@ -201,42 +201,42 @@ df[a, ]
 
 fn[a, , b, , ]
 fn[
-	a_really_long_argument_here,
-	,
-	another_really_really_long_argument_to_test_this_feature,
-	,
+  a_really_long_argument_here,
+  ,
+  another_really_really_long_argument_to_test_this_feature,
+  ,
 ]
 
 # Holes are "invisible" when determining user requested expansion
 # These all expand
 fn[,
-	x = 1
+  x = 1
 ]
 fn[,
-	x = 1
+  x = 1
 ]
 fn[,
-	x = 1
+  x = 1
 ]
 fn[,,
-	x = 1
+  x = 1
 ]
 
 # ------------------------------------------------------------------------
 # Holes and trailing inline functions / braced expressions
 
 dt[, {
-	1 + 1
+  1 + 1
 }]
 dt[,, j, {
-	1 + 1
+  1 + 1
 }]
 
 dt[, function(x) {
-	1 + x
+  1 + x
 }]
 dt[,, j, function(x) {
-	1 + x
+  1 + x
 }]
 
 # ------------------------------------------------------------------------
@@ -246,10 +246,10 @@ fn[...]
 fn[..., a = 1]
 fn[a = 1, ... = 2]
 fn[
-	a = 1,
-	another_really_really_long_argument_to_test_this_feature,
-	a_really_long_argument_here,
-	...
+  a = 1,
+  another_really_really_long_argument_to_test_this_feature,
+  a_really_long_argument_here,
+  ...
 ]
 
 # ------------------------------------------------------------------------
@@ -262,7 +262,7 @@ fn[..1 = 1, ..2 = 2]
 # Comments
 
 fn[
-	# dangling special case
+  # dangling special case
 ]
 
 # ------------------------------------------------------------------------
@@ -272,8 +272,8 @@ fn[
 
 # So this data dictionary stays expanded even though it fits on one line
 df[
-	df$col > 1,
-	c(2, 3)
+  df$col > 1,
+  c(2, 3)
 ]
 
 # This flattens to one line
@@ -284,10 +284,10 @@ df[df$col > 1, c(2, 3)]
 
 # Expanding the inner subset forces expansion of the outer subset
 df[
-	df$col > 7,
-	map[
-		names(df)
-	]
+  df$col > 7,
+  map[
+    names(df)
+  ]
 ]
 
 # ------------------------------------------------------------------------
@@ -300,13 +300,13 @@ df[
 # dt[, j, by = col]
 
 dt[,
-	j,
-	by = col
+  j,
+  by = col
 ]
 
 dt[,
-	j,
-	by = col
+  j,
+  by = col
 ]
 
 # No longer user requested expansion
@@ -317,7 +317,7 @@ dt[, j, by = col]
 
 # Common in data.table world
 dt[,
-	# comment
-	x
+  # comment
+  x
 ]
 ```

--- a/crates/air_r_formatter/tests/specs/r/subset2.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R.snap
@@ -104,8 +104,8 @@ df[[,
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -116,10 +116,10 @@ fn[[a]]
 
 # Inherits call-like behavior with trailing braced expressions
 fn[[a = {
-	1 + 1
+  1 + 1
 }]]
 fn[["description", {
-	1 + 1
+  1 + 1
 }]]
 
 # ------------------------------------------------------------------------
@@ -131,25 +131,25 @@ fn[[,,]]
 
 fn[[a, , b, , ]]
 fn[[
-	a_really_long_argument_here,
-	,
-	another_really_really_long_argument_to_test_this_feature,
-	,
+  a_really_long_argument_here,
+  ,
+  another_really_really_long_argument_to_test_this_feature,
+  ,
 ]]
 
 # Holes are "invisible" when determining user requested expansion
 # These all expand
 fn[[,
-	x = 1
+  x = 1
 ]]
 fn[[,
-	x = 1
+  x = 1
 ]]
 fn[[,
-	x = 1
+  x = 1
 ]]
 fn[[,,
-	x = 1
+  x = 1
 ]]
 
 # ------------------------------------------------------------------------
@@ -159,10 +159,10 @@ fn[[...]]
 fn[[..., a = 1]]
 fn[[a = 1, ... = 2]]
 fn[[
-	a = 1,
-	another_really_really_long_argument_to_test_this_feature,
-	a_really_long_argument_here,
-	...
+  a = 1,
+  another_really_really_long_argument_to_test_this_feature,
+  a_really_long_argument_here,
+  ...
 ]]
 
 # ------------------------------------------------------------------------
@@ -175,7 +175,7 @@ fn[[..1 = 1, ..2 = 2]]
 # Comments
 
 fn[[
-	# dangling special case
+  # dangling special case
 ]]
 
 # ------------------------------------------------------------------------
@@ -185,8 +185,8 @@ fn[[
 
 # So this data dictionary stays expanded even though it fits on one line
 df[[
-	df$col > 1,
-	c(2, 3)
+  df$col > 1,
+  c(2, 3)
 ]]
 
 # This flattens to one line
@@ -197,17 +197,17 @@ df[[df$col > 1, c(2, 3)]]
 
 # Expanding the inner subset forces expansion of the outer subset
 df[[
-	df$col > 7,
-	map[[
-		names(df)
-	]]
+  df$col > 7,
+  map[[
+    names(df)
+  ]]
 ]]
 
 # ------------------------------------------------------------------------
 # Comments "after" holes
 
 df[[,
-	# comment
-	x
+  # comment
+  x
 ]]
 ```

--- a/crates/air_r_formatter/tests/specs/r/test_that.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/test_that.R.snap
@@ -50,49 +50,49 @@ test_that(identity("description that is super long and actually exceeds the line
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
 
 ```R
 test_that("description", {
-	1 + 1
+  1 + 1
 })
 
 extended_test_that("description", {
-	1 + 1
+  1 + 1
 })
 
 test_that("description that is super long and actually exceeds the line limit but we arent going to break!", {
-	1 + 1
+  1 + 1
 })
 
 test_that(desc = "description that is super long and actually exceeds the line limit but we arent going to break!", code = {
-	1 + 1
+  1 + 1
 })
 
 # Opening brace is moved back onto the first line because this is a test call
 test_that("description that is super long and actually exceeds the line limit but we arent going to break!", {
-	1 + 1
+  1 + 1
 })
 
 # Both arguments are reflowed because this is a test call
 test_that("description that is super long and actually exceeds the line limit but we arent going to break!", {
-	1 + 1
+  1 + 1
 })
 
 # The first argument isn't a string, so this isn't special cased and
 # it gets expanded
 # TODO: The expansion doesn't look right though
 test_that(
-	identity(
-		"description that is super long and actually exceeds the line limit but we arent going to break!"
-	),
-	{
-		1 + 1
-	}
+  identity(
+    "description that is super long and actually exceeds the line limit but we arent going to break!"
+  ),
+  {
+    1 + 1
+  }
 )
 ```
 
@@ -102,5 +102,5 @@ test_that(
    13: test_that(desc = "description that is super long and actually exceeds the line limit but we arent going to break!", code = {
    18: test_that("description that is super long and actually exceeds the line limit but we arent going to break!", {
    23: test_that("description that is super long and actually exceeds the line limit but we arent going to break!", {
-   32: 		"description that is super long and actually exceeds the line limit but we arent going to break!"
+   32:     "description that is super long and actually exceeds the line limit but we arent going to break!"
 ```

--- a/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
@@ -40,8 +40,8 @@ info: r/unary_expression.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -57,17 +57,17 @@ Line width: 80
 
 # FIXME: The following newlines are preserved at a weird place
 {
-	+
-		# Comment
-		1
+  +
+    # Comment
+    1
 
-	+
-		# Comment
+  +
+    # Comment
 
-		+
-			# Comment
+    +
+      # Comment
 
-			1
+      1
 }
 
 1 + ++1

--- a/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
@@ -20,8 +20,8 @@ info: r/value/complex_value.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
@@ -20,8 +20,8 @@ info: r/value/double_value.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
@@ -18,8 +18,8 @@ info: r/value/integer_value.R
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
@@ -25,8 +25,8 @@ business")"
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----

--- a/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
@@ -61,8 +61,8 @@ while(a) # comment1
 ## Output 1
 
 -----
-Indent style: Tab
-Indent width: 4
+Indent style: Space
+Indent width: 2
 Line ending: LF
 Line width: 80
 -----
@@ -74,55 +74,55 @@ while (a) {
 }
 
 while (a) {
-	1 + 1
+  1 + 1
 }
 
 # TODO: Not entirely sure how this should be formatted.
 # It's not very common though.
 while (
-	{
-		complex
-	}
+  {
+    complex
+  }
 ) {
-	1 + 1
+  1 + 1
 }
 
 while (
-	super_long_function_name_is_true_man_this_is_a_really_really_long_function()
+  super_long_function_name_is_true_man_this_is_a_really_really_long_function()
 ) {
-	1 + 1
+  1 + 1
 }
 
 while (
-	# comment
-	a
+  # comment
+  a
 ) {
-	1 + 1
+  1 + 1
 }
 
 while (
-	a
-	# comment
+  a
+  # comment
 ) {
-	1 + 1
+  1 + 1
 }
 
 while (
-	a # comment
+  a # comment
 ) {
-	1 + 1
+  1 + 1
 }
 
 while (a) {
-	# comment
+  # comment
 }
 
 while (a)
-	# comment
-	1
+  # comment
+  1
 
 while (a) {
-	# comment1
-	# comment2
+  # comment1
+  # comment2
 }
 ```

--- a/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_logical_lines-4.snap
+++ b/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_logical_lines-4.snap
@@ -4,5 +4,5 @@ expression: output
 ---
 1+1
 {
-	2 + 2
+  2 + 2
 }

--- a/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists-2.snap
+++ b/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists-2.snap
@@ -5,6 +5,6 @@ expression: output2
 0+0
 1 + 1
 {
-	2 + 2
+  2 + 2
 }
 3+3

--- a/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists-3.snap
+++ b/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists-3.snap
@@ -5,6 +5,6 @@ expression: output3
 0+0
 1 + 1
 {
-	2 + 2
+  2 + 2
 }
 3 + 3

--- a/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists-4.snap
+++ b/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists-4.snap
@@ -5,6 +5,6 @@ expression: output4
 0+0
 1+1
 {
-	2 + 2
+  2 + 2
 }
 3 + 3

--- a/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists.snap
+++ b/crates/lsp/src/snapshots/lsp__handlers_format__tests__format_range_unmatched_lists.snap
@@ -5,6 +5,6 @@ expression: output1
 0+0
 1 + 1
 {
-	2 + 2
+  2 + 2
 }
 3+3

--- a/crates/settings/src/indent_style.rs
+++ b/crates/settings/src/indent_style.rs
@@ -16,9 +16,9 @@ use std::str::FromStr;
 )]
 pub enum IndentStyle {
     /// Tab
-    #[default]
     Tab,
     /// Space
+    #[default]
     Space,
 }
 

--- a/crates/settings/src/indent_width.rs
+++ b/crates/settings/src/indent_width.rs
@@ -16,7 +16,7 @@ pub struct IndentWidth(NonZeroU8);
 
 impl IndentWidth {
     /// Default value for [IndentWidth]
-    const DEFAULT: u8 = 4;
+    const DEFAULT: u8 = 2;
 
     /// Maximum allowed value for a valid [IndentWidth]
     const MAX: u8 = 24;
@@ -158,13 +158,13 @@ mod tests {
     fn deserialize_indent_width() -> Result<()> {
         let options: Options = toml::from_str(
             r"
-indent-width = 2
+indent-width = 6
 ",
         )?;
 
         assert_eq!(
             options.indent_width,
-            Some(IndentWidth::try_from(2).unwrap())
+            Some(IndentWidth::try_from(6).unwrap())
         );
 
         Ok(())

--- a/crates/workspace/src/toml_options.rs
+++ b/crates/workspace/src/toml_options.rs
@@ -54,7 +54,8 @@ pub struct FormatTomlOptions {
 
     /// The number of spaces per indentation level (tab).
     ///
-    /// The value must be greater than or equal to `1` and less than or equal to `24`.
+    /// The value must be greater than or equal to `1` and less than or equal to `24`. The
+    /// default value is `2`.
     ///
     /// Used by the formatter to determine the visual width of a tab.
     ///
@@ -65,23 +66,24 @@ pub struct FormatTomlOptions {
 
     /// Whether to use spaces or tabs for indentation.
     ///
-    /// `indent-style = "tab"` (default):
+    /// `indent-style = "space"` (default):
     ///
     /// ```r
     /// fn <- function() {
-    ///     cat("Hello") # A tab `\t` indents the `cat()` call.
+    ///   cat("Hello") # Spaces indent the `cat()` call.
     /// }
     /// ```
     ///
-    /// `indent-style = "space"`:
+    /// `indent-style = "tab"`:
     ///
     /// ```r
     /// fn <- function() {
-    ///     cat("Hello") # Spaces indent the `cat()` call.
+    ///   cat("Hello") # A tab `\t` indents the `cat()` call.
     /// }
     /// ```
     ///
-    /// We recommend you use tabs for accessibility.
+    /// Air defaults to spaces due to the overwhelming amount of existing R code written
+    /// in this style, but consider using tabs for new projects to improve accessibility.
     ///
     /// See `indent-width` to configure the number of spaces per indentation and the tab width.
     pub indent_style: Option<IndentStyle>,


### PR DESCRIPTION
Due to:
- Overwhelming amount of existing R code written in this style
- Desire to minimize diffs when converting projects to first use air (otherwise every line is diff-ed, making it incomprehensible)
- Desire to maximize adoption by making it easy to adopt air without ever needing an `air.toml`

We still maintain that tabs are the most accessibility friendly option, and will make choices in the formatter to ensure that switching to tabs is as easy as possible (like no hanging indents).