### PR TITLE
Support `MagicLineBreak` in the formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "settings",
  "tests_macros",
  "tracing",
+ "workspace",
 ]
 
 [[package]]

--- a/crates/air_formatter_test/src/spec.rs
+++ b/crates/air_formatter_test/src/spec.rs
@@ -5,7 +5,7 @@ use biome_formatter::{FormatLanguage, FormatOptions, Printed};
 use biome_parser::AnyParse;
 use biome_rowan::{TextRange, TextSize};
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct SpecTestFile<'a> {
@@ -78,7 +78,6 @@ where
     L: TestFormatLanguage,
 {
     test_file: SpecTestFile<'a>,
-    test_directory: PathBuf,
     language: L,
     format_language: L::FormatLanguage,
 }
@@ -89,15 +88,11 @@ where
 {
     pub fn new(
         test_file: SpecTestFile<'a>,
-        test_directory: &str,
         language: L,
         format_language: L::FormatLanguage,
     ) -> Self {
-        let test_directory = PathBuf::from(test_directory);
-
         SpecSnapshot {
             test_file,
-            test_directory,
             language,
             format_language,
         }
@@ -196,60 +191,6 @@ where
             )
             .with_unimplemented(&printed)
             .with_lines_exceeding_max_width(&output_code, max_width);
-
-        let options_path = self.test_directory.join("options.json");
-        if options_path.exists() {
-            // TODO:! It would be very cool if we could support this `options.json` file!
-            // It's going to require a way to merge deserialized partial options
-            // with `RFormatOptions::default()`, and fleshing out `to_format_language()`.
-            panic!("`options.json` is not currently supported.");
-
-            //             let mut options_path = BiomePath::new(&options_path);
-            //
-            //             let mut settings = Settings::default();
-            //             // SAFETY: we checked its existence already, we assume we have rights to read it
-            //             let (test_options, diagnostics) = deserialize_from_str::<PartialConfiguration>(
-            //                 options_path.get_buffer_from_file().as_str(),
-            //             )
-            //             .consume();
-            //             settings
-            //                 .merge_with_configuration(test_options.unwrap_or_default(), None, None, &[])
-            //                 .unwrap();
-            //
-            //             if !diagnostics.is_empty() {
-            //                 for diagnostic in diagnostics {
-            //                     println!("{:?}", print_diagnostic_to_string(&diagnostic));
-            //                 }
-            //
-            //                 panic!("Configuration is invalid");
-            //             }
-            //
-            //             let format_language = self
-            //                 .language
-            //                 .to_format_language(&settings, &DocumentFileSource::from_path(input_file));
-            //
-            //             let (mut output_code, printed) = self.formatted(&parsed, format_language.clone());
-            //
-            //             let max_width = format_language.options().line_width().value() as usize;
-            //
-            //             // There are some logs that print different line endings, and we can't snapshot those
-            //             // otherwise we risk automatically having them replaced with LF by git.
-            //             //
-            //             // This is a workaround, and it might not work for all cases.
-            //             const CRLF_PATTERN: &str = "\r\n";
-            //             const CR_PATTERN: &str = "\r";
-            //             output_code = output_code
-            //                 .replace(CRLF_PATTERN, "<CRLF>\n")
-            //                 .replace(CR_PATTERN, "<CR>\n");
-            //
-            //             snapshot_builder = snapshot_builder
-            //                 .with_output_and_options(
-            //                     SnapshotOutput::new(&output_code).with_index(1),
-            //                     format_language.options(),
-            //                 )
-            //                 .with_unimplemented(&printed)
-            //                 .with_lines_exceeding_max_width(&output_code, max_width);
-        }
 
         snapshot_builder.finish(self.test_file.relative_file_name());
     }

--- a/crates/air_r_formatter/Cargo.toml
+++ b/crates/air_r_formatter/Cargo.toml
@@ -27,6 +27,7 @@ air_r_parser = { workspace = true }
 biome_parser = { workspace = true }
 line_ending = { workspace = true }
 tests_macros = { workspace = true }
+workspace = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/air_r_formatter/src/context.rs
+++ b/crates/air_r_formatter/src/context.rs
@@ -76,10 +76,9 @@ pub struct RFormatOptions {
     /// The type of line ending.
     line_ending: LineEnding,
 
-    /// The max width of a line. Defaults to 80.
+    /// The max width of a line.
     line_width: LineWidth,
 
-    // TODO: Actually use this internally!
     /// The behavior of magic line breaks.
     magic_line_break: MagicLineBreak,
 }
@@ -134,6 +133,10 @@ impl RFormatOptions {
 
     pub fn set_magic_line_break(&mut self, magic_line_break: MagicLineBreak) {
         self.magic_line_break = magic_line_break;
+    }
+
+    pub fn magic_line_break(&self) -> MagicLineBreak {
+        self.magic_line_break
     }
 }
 

--- a/crates/air_r_formatter/src/context.rs
+++ b/crates/air_r_formatter/src/context.rs
@@ -174,6 +174,7 @@ impl fmt::Display for RFormatOptions {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
-        writeln!(f, "Line width: {}", self.line_width.value())
+        writeln!(f, "Line width: {}", self.line_width.value())?;
+        writeln!(f, "Magic line break: {}", self.magic_line_break)
     }
 }

--- a/crates/air_r_formatter/src/r/auxiliary/parameters.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/parameters.rs
@@ -1,3 +1,4 @@
+use crate::context::RFormatOptions;
 use crate::prelude::*;
 use air_r_syntax::RParameterList;
 use air_r_syntax::RParameters;
@@ -22,12 +23,12 @@ impl FormatNodeRule<RParameters> for FormatRParameters {
                 soft_block_indent(&items.format()),
                 r_paren_token.format()
             ])
-            .should_expand(needs_user_requested_expansion(&items))]
+            .should_expand(has_magic_line_break(&items, f.options()))]
         )
     }
 }
 
-/// Check if the user has inserted a leading newline before the very first `parameter`.
+/// Check if the user has inserted a magic line break before the very first `parameter`.
 /// If so, we respect that and treat it as a request to break ALL of the parameters in
 /// this function definition. Note this is a case of irreversible formatting!
 ///
@@ -76,9 +77,10 @@ impl FormatNodeRule<RParameters> for FormatRParameters {
 ///   body
 /// }
 /// ```
-fn needs_user_requested_expansion(items: &RParameterList) -> bool {
-    // TODO: This should be configurable by an option, since it is a case of
-    // irreversible formatting
+fn has_magic_line_break(items: &RParameterList, options: &RFormatOptions) -> bool {
+    if options.magic_line_break().is_ignore() {
+        return false;
+    }
 
     // Dig down to the first parameter
     // (Could be an empty parameter list, and first element could be a syntax error)

--- a/crates/air_r_formatter/tests/spec_test.rs
+++ b/crates/air_r_formatter/tests/spec_test.rs
@@ -6,21 +6,55 @@ mod language {
     include!("language.rs");
 }
 
-pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, _file_type: &str) {
+pub fn run(spec_input_file: &str, _expected_file: &str, _test_directory: &str, _file_type: &str) {
     let root_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/"));
 
     let spec_input_file = Path::new(spec_input_file);
     let test_file = SpecTestFile::try_from_file(spec_input_file, root_path);
 
-    let options = RFormatOptions::default();
+    let options = format_options_from_code(test_file.input_code());
     let language = language::RTestFormatLanguage::default();
 
-    let snapshot = SpecSnapshot::new(
-        test_file,
-        test_directory,
-        language,
-        RFormatLanguage::new(options),
-    );
+    let snapshot = SpecSnapshot::new(test_file, language, RFormatLanguage::new(options));
 
     snapshot.test()
+}
+
+/// Parse inlined format options provided in a snapshot test
+///
+/// At the very top of an R file, provide format options of the form (don't include
+/// the backticks):
+///
+/// ```r
+/// #' [format]
+/// #' indent-width = 4
+/// #' ignore-magic-line-break = true
+/// ```
+fn format_options_from_code(code: &str) -> RFormatOptions {
+    let lines = code.lines();
+
+    // Skip blank lines, then collect all leading lines that start with `#'`
+    let lines: Vec<&str> = lines
+        .skip_while(|line| line.is_empty())
+        .take_while(|line| line.starts_with("#'"))
+        .collect();
+
+    if lines.is_empty() {
+        // No file specific configuration
+        return RFormatOptions::default();
+    }
+
+    // Strip off the `#'` and any leading whitespace, that leaves a TOML file left
+    let lines: Vec<&str> = lines
+        .into_iter()
+        .map(|line| line.strip_prefix("#'").unwrap().trim_start())
+        .collect();
+
+    let contents = lines.join("\n");
+
+    let settings = workspace::toml::parse_air_inline_toml(&contents)
+        .expect("Can parse inline TOML")
+        .into_settings();
+
+    settings.format.to_format_options(code)
 }

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
@@ -530,6 +530,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
@@ -64,6 +64,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
@@ -93,6 +93,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -663,6 +663,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/comment.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/comment.R.snap
@@ -22,6 +22,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
@@ -22,6 +22,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
@@ -27,6 +27,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
@@ -31,6 +31,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
@@ -144,6 +144,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
@@ -71,6 +71,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/binary_expression.R
+++ b/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/binary_expression.R
@@ -1,0 +1,11 @@
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+x |>
+  foo() |>
+  bar()
+
+# Fits on one line, flatten
+x <-
+  1 + 1

--- a/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/binary_expression.R.snap
@@ -1,0 +1,46 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/ignore-magic-line-breaks/binary_expression.R
+---
+# Input
+
+```R
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+x |>
+  foo() |>
+  bar()
+
+# Fits on one line, flatten
+x <-
+  1 + 1
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Magic line break: Ignore
+-----
+
+```R
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+x |> foo() |> bar()
+
+# Fits on one line, flatten
+x <- 1 + 1
+```

--- a/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/call.R
+++ b/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/call.R
@@ -1,0 +1,18 @@
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+fn(
+  a,
+  b,
+  c
+)
+
+# Fits on one line, flatten
+fn(
+  ,
+  ,
+  a,
+  b,
+  c
+)

--- a/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/call.R.snap
@@ -1,0 +1,53 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/ignore-magic-line-breaks/call.R
+---
+# Input
+
+```R
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+fn(
+  a,
+  b,
+  c
+)
+
+# Fits on one line, flatten
+fn(
+  ,
+  ,
+  a,
+  b,
+  c
+)
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Magic line break: Ignore
+-----
+
+```R
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+fn(a, b, c)
+
+# Fits on one line, flatten
+fn(,, a, b, c)
+```

--- a/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/function_definition.R
+++ b/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/function_definition.R
@@ -1,0 +1,10 @@
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+fn <- function(
+  a,
+  b
+) {
+  body
+}

--- a/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/ignore-magic-line-breaks/function_definition.R.snap
@@ -1,0 +1,44 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/ignore-magic-line-breaks/function_definition.R
+---
+# Input
+
+```R
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+fn <- function(
+  a,
+  b
+) {
+  body
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Magic line break: Ignore
+-----
+
+```R
+#' [format]
+#' ignore-magic-line-break = true
+
+# Fits on one line, flatten
+fn <- function(a, b) {
+  body
+}
+```

--- a/crates/air_r_formatter/tests/specs/r/keyword.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/keyword.R.snap
@@ -33,6 +33,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
@@ -42,6 +42,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
@@ -54,6 +54,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
@@ -61,6 +61,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/smoke.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/smoke.R.snap
@@ -21,6 +21,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -160,6 +160,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/subset2.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R.snap
@@ -108,6 +108,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/test_that.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/test_that.R.snap
@@ -54,6 +54,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
@@ -44,6 +44,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
@@ -24,6 +24,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
@@ -24,6 +24,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
@@ -22,6 +22,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
@@ -29,6 +29,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
@@ -65,6 +65,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
+Magic line break: Respect
 -----
 
 ```R

--- a/crates/workspace/src/toml.rs
+++ b/crates/workspace/src/toml.rs
@@ -18,8 +18,13 @@ pub fn parse_air_toml<P: AsRef<Path>>(path: P) -> Result<TomlOptions, ParseTomlE
     let contents = std::fs::read_to_string(path.as_ref())
         .map_err(|err| ParseTomlError::Read(path.as_ref().to_path_buf(), err))?;
 
-    toml::from_str(&contents)
+    parse_air_inline_toml(&contents)
         .map_err(|err| ParseTomlError::Deserialize(path.as_ref().to_path_buf(), err))
+}
+
+/// Parse inline toml
+pub fn parse_air_inline_toml(contents: &str) -> Result<TomlOptions, toml::de::Error> {
+    toml::from_str(contents)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #112 

With some cool new infrastructure for tweaking formatter settings on a per-file basis by providing inline TOML in the R file!