### PR TITLE
Write info to stderr not stdout

### DIFF
--- a/crates/air/src/commands/format.rs
+++ b/crates/air/src/commands/format.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::io;
-use std::io::stdout;
+use std::io::stderr;
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -58,7 +58,7 @@ pub(crate) fn format(command: FormatCommand) -> anyhow::Result<ExitStatus> {
     match mode {
         FormatMode::Write => {}
         FormatMode::Check => {
-            write_changed(&actions, &mut stdout().lock())?;
+            write_changed(&actions, &mut stderr().lock())?;
         }
     }
 


### PR DESCRIPTION
I think we determined `Would reformat: <path>` should be written to stderr not stdout, which should be reserved for program output, like when we support `air format-stdin -> stdout`

This also makes the place `Would reformat: <path>` is written to (stderr) the same as the place that logs are written to by default, which seems nice.