### PR TITLE
Don't set ourselves as the default formatter

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -58,11 +58,6 @@
 				}
 			}
 		},
-		"configurationDefaults": {
-			"[r]": {
-				"editor.defaultFormatter": "Posit.air"
-			}
-		},
 		"commands": [
 			{
 				"title": "Restart Server",


### PR DESCRIPTION
Closes #162 

This is a user setting

---

I believe this currently messes up Positron unless you set `"editor.defaultFormatter": "Posit.air"` due to Positron's `positron-r` extension also shipping a formatter by implementing `vscode.DocumentFormattingEditProvider`. I'm not sure how to resolve that in the very short term other than suggesting that people set `editor.defaultFormatter`, but I don't think we should release with this override in there.

Definitely open to hearing ideas about what the best approach here is.