### PR TITLE
Rename `ignore-magic-line-break` to `persistent-line-breaks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Development version
 
+- Renamed `ignore-magic-line-break` to `persistent-line-breaks` (#177).
+
 - In the CLI, errors and warnings are now written to stderr. This allows you to
   see issues that occur during `air format`, such as parse errors or file not
   found errors (#155).

--- a/crates/air_r_formatter/src/context.rs
+++ b/crates/air_r_formatter/src/context.rs
@@ -13,7 +13,7 @@ use settings::IndentStyle;
 use settings::IndentWidth;
 use settings::LineEnding;
 use settings::LineWidth;
-use settings::MagicLineBreak;
+use settings::PersistentLineBreaks;
 
 use crate::comments::FormatRLeadingComment;
 use crate::comments::RCommentStyle;
@@ -79,8 +79,8 @@ pub struct RFormatOptions {
     /// The max width of a line.
     line_width: LineWidth,
 
-    /// The behavior of magic line breaks.
-    magic_line_break: MagicLineBreak,
+    /// The behavior of persistent line breaks.
+    persistent_line_breaks: PersistentLineBreaks,
 }
 
 impl RFormatOptions {
@@ -110,8 +110,11 @@ impl RFormatOptions {
         self
     }
 
-    pub fn with_magic_line_break(mut self, magic_line_break: MagicLineBreak) -> Self {
-        self.magic_line_break = magic_line_break;
+    pub fn with_persistent_line_breaks(
+        mut self,
+        persistent_line_breaks: PersistentLineBreaks,
+    ) -> Self {
+        self.persistent_line_breaks = persistent_line_breaks;
         self
     }
 
@@ -131,12 +134,12 @@ impl RFormatOptions {
         self.line_width = line_width;
     }
 
-    pub fn set_magic_line_break(&mut self, magic_line_break: MagicLineBreak) {
-        self.magic_line_break = magic_line_break;
+    pub fn set_persistent_line_breaks(&mut self, persistent_line_breaks: PersistentLineBreaks) {
+        self.persistent_line_breaks = persistent_line_breaks;
     }
 
-    pub fn magic_line_break(&self) -> MagicLineBreak {
-        self.magic_line_break
+    pub fn persistent_line_breaks(&self) -> PersistentLineBreaks {
+        self.persistent_line_breaks
     }
 }
 
@@ -178,6 +181,6 @@ impl fmt::Display for RFormatOptions {
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
-        writeln!(f, "Magic line break: {}", self.magic_line_break)
+        writeln!(f, "Persistent line breaks: {}", self.persistent_line_breaks)
     }
 }

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -79,10 +79,10 @@ fn fmt_binary_sticky(
 
 /// Assignment expressions keep LHS and RHS on the same line, separated by a single space
 ///
-/// # Magic line breaks
+/// # Persistent line breaks
 ///
 /// The one exception to this is if a newline already exists between a left assignment
-/// operator and the rhs, which is a magic line break case, like:
+/// operator and the rhs, which is a persistent line break case, like:
 ///
 /// ```r
 /// response <-
@@ -99,7 +99,7 @@ fn fmt_binary_sticky(
 ///     default()
 /// ```
 ///
-/// Walrus assignment is not considered when looking for magic line breaks because we
+/// Walrus assignment is not considered when looking for persistent line breaks because we
 /// don't want the `:=` case below to look like a request for expansion. While `:=` is
 /// technically parsed as a binary operator, we format it more like a named argument with
 /// a simple `space()` between the operator and the right hand side.
@@ -119,7 +119,7 @@ fn fmt_binary_sticky(
 /// )
 /// ```
 ///
-/// Comment handling with magic line breaks here is a bit tricky. Consider this example:
+/// Comment handling with persistent line breaks here is a bit tricky. Consider this example:
 ///
 /// ```r
 /// x <-
@@ -146,7 +146,7 @@ fn fmt_binary_assignment(
     f: &mut Formatter<RFormatContext>,
 ) -> FormatResult<()> {
     let right = format_with(|f| {
-        if binary_assignment_has_magic_line_break(&operator, &right, f.options()) {
+        if binary_assignment_has_persistent_line_break(&operator, &right, f.options()) {
             write!(
                 f,
                 [indent(&format_args![hard_line_break(), right.format()])]
@@ -167,12 +167,12 @@ fn fmt_binary_assignment(
     )
 }
 
-fn binary_assignment_has_magic_line_break(
+fn binary_assignment_has_persistent_line_break(
     operator: &SyntaxToken<RLanguage>,
     right: &AnyRExpression,
     options: &RFormatOptions,
 ) -> bool {
-    if options.magic_line_break().is_ignore() {
+    if options.persistent_line_breaks().is_ignore() {
         return false;
     }
 
@@ -289,7 +289,7 @@ struct TailPiece {
 ///     d
 ///
 /// # Also allowed, since it fits on one line
-/// # (depends on magic line breaks and object lengths)
+/// # (depends on persistent line breaks and object lengths)
 /// a +
 ///   b -
 ///   c * d
@@ -532,7 +532,7 @@ fn fmt_binary_chain(
     write!(
         f,
         [group(&format_args![left.format(), indent(&chain)])
-            .should_expand(has_magic_line_break(&tail, f.options()))]
+            .should_expand(has_persistent_line_break(&tail, f.options()))]
     )
 }
 
@@ -575,7 +575,7 @@ fn is_chainable_binary_operator(kind: RSyntaxKind) -> bool {
     }
 }
 
-/// Check if the user has inserted a magic line break before the very first `right`.
+/// Check if the user has inserted a persistent line break before the very first `right`.
 /// If so, we respect that and treat it as a request to break ALL of the binary operators
 /// in the chain. Note this is a case of irreversible formatting!
 ///
@@ -624,8 +624,8 @@ fn is_chainable_binary_operator(kind: RSyntaxKind) -> bool {
 /// # Output
 /// (df %>% mutate(x = 1) %>% filter(x == y))
 /// ```
-fn has_magic_line_break(tail: &[TailPiece], options: &RFormatOptions) -> bool {
-    if options.magic_line_break().is_ignore() {
+fn has_persistent_line_break(tail: &[TailPiece], options: &RFormatOptions) -> bool {
+    if options.persistent_line_breaks().is_ignore() {
         return false;
     }
 

--- a/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
@@ -175,9 +175,9 @@ impl Format<RFormatContext> for RCallLikeArguments {
             );
         }
 
-        // Special case where a magic line break exists between the `l_token` and the
+        // Special case where a persistent line break exists between the `l_token` and the
         // first non-hole argument. Treat this as a user request to expand.
-        if has_magic_line_break(&leading_holes, &arguments, f.options()) {
+        if has_persistent_line_break(&leading_holes, &arguments, f.options()) {
             return write!(
                 f,
                 [FormatAllArgsBrokenOut {
@@ -207,7 +207,7 @@ impl Format<RFormatContext> for RCallLikeArguments {
     }
 }
 
-/// Check if the user has inserted a magic line break before the very first non-hole
+/// Check if the user has inserted a persistent line break before the very first non-hole
 /// `argument`. If so, we respect that and treat it as a request to break ALL of the
 /// arguments. Note this is a case of irreversible formatting!
 ///
@@ -244,8 +244,8 @@ impl Format<RFormatContext> for RCallLikeArguments {
 /// dictionary <- list(bob = "burger", dina = "dairy", john = "juice")
 /// ```
 ///
-/// The magic line break check is done on the first non-hole argument, so this
-/// is considered a magic line break and stays as is because there
+/// The persistent line break check is done on the first non-hole argument, so this
+/// is considered a persistent line break and stays as is because there
 /// is a leading newline before the `j` argument node.
 ///
 /// ```r
@@ -255,10 +255,10 @@ impl Format<RFormatContext> for RCallLikeArguments {
 /// ]
 /// ```
 ///
-/// This is also considered a magic line break. We treat holes as
+/// This is also considered a persistent line break. We treat holes as
 /// "invisible" for this check, so if you squint and remove the leading `,`
 /// and there are any leading lines before the first non-hole argument,
-/// that is still considered a magic line break, but the `,`s attached
+/// that is still considered a persistent line break, but the `,`s attached
 /// to the hole will get moved to hug the `[`.
 ///
 /// ```r
@@ -267,12 +267,12 @@ impl Format<RFormatContext> for RCallLikeArguments {
 ///   by = col
 /// ]
 /// ```
-fn has_magic_line_break(
+fn has_persistent_line_break(
     leading_holes: &[FormatCallArgumentHole],
     arguments: &[FormatCallArgument],
     options: &RFormatOptions,
 ) -> bool {
-    if options.magic_line_break().is_ignore() {
+    if options.persistent_line_breaks().is_ignore() {
         return false;
     }
 

--- a/crates/air_r_formatter/src/r/auxiliary/parameters.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/parameters.rs
@@ -23,12 +23,12 @@ impl FormatNodeRule<RParameters> for FormatRParameters {
                 soft_block_indent(&items.format()),
                 r_paren_token.format()
             ])
-            .should_expand(has_magic_line_break(&items, f.options()))]
+            .should_expand(has_persistent_line_break(&items, f.options()))]
         )
     }
 }
 
-/// Check if the user has inserted a magic line break before the very first `parameter`.
+/// Check if the user has inserted a persistent line break before the very first `parameter`.
 /// If so, we respect that and treat it as a request to break ALL of the parameters in
 /// this function definition. Note this is a case of irreversible formatting!
 ///
@@ -77,8 +77,8 @@ impl FormatNodeRule<RParameters> for FormatRParameters {
 ///   body
 /// }
 /// ```
-fn has_magic_line_break(items: &RParameterList, options: &RFormatOptions) -> bool {
-    if options.magic_line_break().is_ignore() {
+fn has_persistent_line_break(items: &RParameterList, options: &RFormatOptions) -> bool {
+    if options.persistent_line_breaks().is_ignore() {
         return false;
     }
 

--- a/crates/air_r_formatter/tests/spec_test.rs
+++ b/crates/air_r_formatter/tests/spec_test.rs
@@ -28,7 +28,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, _test_directory: &str, _
 /// ```r
 /// #' [format]
 /// #' indent-width = 4
-/// #' ignore-magic-line-break = true
+/// #' persistent-line-breaks = false
 /// ```
 fn format_options_from_code(code: &str) -> RFormatOptions {
     let lines = code.lines();

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R
@@ -274,7 +274,7 @@ bar() |> baz()
 df |> foo() |> bar() |>
 baz()
 
-# Flattened, removing just this first magic line break is how users can
+# Flattened, removing just this first persistent line break is how users can
 # easily request flattened pipe chains if one is possible (as opposed
 # to having to flatten every pipe element to keep it flat)
 df |> foo() |>
@@ -334,7 +334,7 @@ and() |> this() }
 
 # Inside parentheses, subset, or, subset2, you can put a newline before
 # the `|>`, which isn't valid R code at top level. This doesn't result
-# in a break because we strictly require the magic line break to come
+# in a break because we strictly require the persistent line break to come
 # AFTER the first binary operator in the chain.
 (df
 |> foo())
@@ -463,9 +463,9 @@ identity(1) -> x
 identity(1) ->> x
 
 # -----------------------------------------------------------------------------
-# Assignment with magic line breaks
+# Assignment with persistent line breaks
 
-# Magic line break after the left assignment
+# Persistent line break after the left assignment
 fn =
   value
 fn <-
@@ -478,17 +478,17 @@ fn <- # comment1
   # comment2
   value # comment3
 
-# No magic line break after walrus operator
+# No persistent line break after walrus operator
 fn :=
   value
 
-# We want these to match, neither support magic line breaks
+# We want these to match, neither support persistent line breaks
 call(fn :=
   value)
 call(fn =
   value)
 
-# No magic line break after right assignment
+# No persistent line break after right assignment
 fn ->
   value
 fn ->>

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
@@ -281,7 +281,7 @@ bar() |> baz()
 df |> foo() |> bar() |>
 baz()
 
-# Flattened, removing just this first magic line break is how users can
+# Flattened, removing just this first persistent line break is how users can
 # easily request flattened pipe chains if one is possible (as opposed
 # to having to flatten every pipe element to keep it flat)
 df |> foo() |>
@@ -341,7 +341,7 @@ and() |> this() }
 
 # Inside parentheses, subset, or, subset2, you can put a newline before
 # the `|>`, which isn't valid R code at top level. This doesn't result
-# in a break because we strictly require the magic line break to come
+# in a break because we strictly require the persistent line break to come
 # AFTER the first binary operator in the chain.
 (df
 |> foo())
@@ -470,9 +470,9 @@ identity(1) -> x
 identity(1) ->> x
 
 # -----------------------------------------------------------------------------
-# Assignment with magic line breaks
+# Assignment with persistent line breaks
 
-# Magic line break after the left assignment
+# Persistent line break after the left assignment
 fn =
   value
 fn <-
@@ -485,17 +485,17 @@ fn <- # comment1
   # comment2
   value # comment3
 
-# No magic line break after walrus operator
+# No persistent line break after walrus operator
 fn :=
   value
 
-# We want these to match, neither support magic line breaks
+# We want these to match, neither support persistent line breaks
 call(fn :=
   value)
 call(fn =
   value)
 
-# No magic line break after right assignment
+# No persistent line break after right assignment
 fn ->
   value
 fn ->>
@@ -530,7 +530,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R
@@ -925,7 +925,7 @@ df |> foo() |> bar() |> baz()
 # Flattened, line break is not after the first pipe!
 df |> foo() |> bar() |> baz()
 
-# Flattened, removing just this first magic line break is how users can
+# Flattened, removing just this first persistent line break is how users can
 # easily request flattened pipe chains if one is possible (as opposed
 # to having to flatten every pipe element to keep it flat)
 df |> foo() |> bar() |> baz()
@@ -992,7 +992,7 @@ df |> ggplot() + geom_line() + geom_bar()
 
 # Inside parentheses, subset, or, subset2, you can put a newline before
 # the `|>`, which isn't valid R code at top level. This doesn't result
-# in a break because we strictly require the magic line break to come
+# in a break because we strictly require the persistent line break to come
 # AFTER the first binary operator in the chain.
 (df |> foo())
 
@@ -1124,9 +1124,9 @@ identity(1) -> x
 identity(1) ->> x
 
 # -----------------------------------------------------------------------------
-# Assignment with magic line breaks
+# Assignment with persistent line breaks
 
-# Magic line break after the left assignment
+# Persistent line break after the left assignment
 fn =
   value
 fn <-
@@ -1139,14 +1139,14 @@ fn <- # comment1
   # comment2
   value # comment3
 
-# No magic line break after walrus operator
+# No persistent line break after walrus operator
 fn := value
 
-# We want these to match, neither support magic line breaks
+# We want these to match, neither support persistent line breaks
 call(fn := value)
 call(fn = value)
 
-# No magic line break after right assignment
+# No persistent line break after right assignment
 fn -> value
 fn ->> value
 

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
@@ -64,7 +64,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
@@ -93,7 +93,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -663,7 +663,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/comment.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/comment.R.snap
@@ -22,7 +22,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
@@ -22,7 +22,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
@@ -27,7 +27,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
@@ -31,7 +31,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
@@ -144,7 +144,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
@@ -71,7 +71,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/keyword.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/keyword.R.snap
@@ -33,7 +33,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
@@ -42,7 +42,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/binary_expression.R
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/binary_expression.R
@@ -1,5 +1,5 @@
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
 x |>

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/binary_expression.R.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/air_formatter_test/src/snapshot_builder.rs
-info: r/ignore-magic-line-breaks/binary_expression.R
+info: r/persistent-line-breaks/binary_expression.R
 ---
 # Input
 
 ```R
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
 x |>
@@ -31,12 +31,12 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Ignore
+Persistent line breaks: Ignore
 -----
 
 ```R
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
 x |> foo() |> bar()

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/call.R
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/call.R
@@ -1,5 +1,5 @@
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
 fn(

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/call.R.snap
@@ -1,20 +1,28 @@
 ---
 source: crates/air_formatter_test/src/snapshot_builder.rs
-info: r/ignore-magic-line-breaks/function_definition.R
+info: r/persistent-line-breaks/call.R
 ---
 # Input
 
 ```R
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
-fn <- function(
+fn(
   a,
-  b
-) {
-  body
-}
+  b,
+  c
+)
+
+# Fits on one line, flatten
+fn(
+  ,
+  ,
+  a,
+  b,
+  c
+)
 
 ```
 
@@ -30,15 +38,16 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Ignore
+Persistent line breaks: Ignore
 -----
 
 ```R
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
-fn <- function(a, b) {
-  body
-}
+fn(a, b, c)
+
+# Fits on one line, flatten
+fn(,, a, b, c)
 ```

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/function_definition.R
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/function_definition.R
@@ -1,5 +1,5 @@
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
 fn <- function(

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/function_definition.R.snap
@@ -1,28 +1,20 @@
 ---
 source: crates/air_formatter_test/src/snapshot_builder.rs
-info: r/ignore-magic-line-breaks/call.R
+info: r/persistent-line-breaks/function_definition.R
 ---
 # Input
 
 ```R
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
-fn(
+fn <- function(
   a,
-  b,
-  c
-)
-
-# Fits on one line, flatten
-fn(
-  ,
-  ,
-  a,
-  b,
-  c
-)
+  b
+) {
+  body
+}
 
 ```
 
@@ -38,16 +30,15 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Ignore
+Persistent line breaks: Ignore
 -----
 
 ```R
 #' [format]
-#' ignore-magic-line-break = true
+#' persistent-line-breaks = false
 
 # Fits on one line, flatten
-fn(a, b, c)
-
-# Fits on one line, flatten
-fn(,, a, b, c)
+fn <- function(a, b) {
+  body
+}
 ```

--- a/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
@@ -54,7 +54,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
@@ -61,7 +61,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/smoke.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/smoke.R.snap
@@ -21,7 +21,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -160,7 +160,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/subset2.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R.snap
@@ -108,7 +108,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/test_that.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/test_that.R.snap
@@ -54,7 +54,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
@@ -44,7 +44,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
@@ -24,7 +24,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
@@ -24,7 +24,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
@@ -22,7 +22,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
@@ -29,7 +29,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
@@ -65,7 +65,7 @@ Indent style: Space
 Indent width: 2
 Line ending: LF
 Line width: 80
-Magic line break: Respect
+Persistent line breaks: Respect
 -----
 
 ```R

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -2,10 +2,10 @@ mod indent_style;
 mod indent_width;
 mod line_ending;
 mod line_width;
-mod magic_line_break;
+mod persistent_line_breaks;
 
 pub use indent_style::*;
 pub use indent_width::*;
 pub use line_ending::*;
 pub use line_width::*;
-pub use magic_line_break::*;
+pub use persistent_line_breaks::*;

--- a/crates/settings/src/persistent_line_breaks.rs
+++ b/crates/settings/src/persistent_line_breaks.rs
@@ -1,5 +1,5 @@
 //
-// magic_line_break.rs
+// persistent_line_breaks.rs
 //
 // Copyright (C) 2025 Posit Software, PBC. All rights reserved.
 //
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 #[derive(Debug, Default, Clone, Copy, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum MagicLineBreak {
+pub enum PersistentLineBreaks {
     /// Respect
     #[default]
     Respect,
@@ -18,19 +18,19 @@ pub enum MagicLineBreak {
     Ignore,
 }
 
-impl MagicLineBreak {
-    /// Returns `true` if magic line breaks should be respected.
+impl PersistentLineBreaks {
+    /// Returns `true` if persistent line breaks should be respected.
     pub const fn is_respect(&self) -> bool {
-        matches!(self, MagicLineBreak::Respect)
+        matches!(self, PersistentLineBreaks::Respect)
     }
 
-    /// Returns `true` if magic line breaks should be ignored.
+    /// Returns `true` if persistent line breaks should be ignored.
     pub const fn is_ignore(&self) -> bool {
-        matches!(self, MagicLineBreak::Ignore)
+        matches!(self, PersistentLineBreaks::Ignore)
     }
 }
 
-impl FromStr for MagicLineBreak {
+impl FromStr for PersistentLineBreaks {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -42,11 +42,11 @@ impl FromStr for MagicLineBreak {
     }
 }
 
-impl Display for MagicLineBreak {
+impl Display for PersistentLineBreaks {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            MagicLineBreak::Respect => std::write!(f, "Respect"),
-            MagicLineBreak::Ignore => std::write!(f, "Ignore"),
+            PersistentLineBreaks::Respect => std::write!(f, "Respect"),
+            PersistentLineBreaks::Ignore => std::write!(f, "Ignore"),
         }
     }
 }

--- a/crates/workspace/src/settings.rs
+++ b/crates/workspace/src/settings.rs
@@ -13,7 +13,7 @@ use air_r_formatter::context::RFormatOptions;
 use settings::IndentStyle;
 use settings::IndentWidth;
 use settings::LineWidth;
-use settings::MagicLineBreak;
+use settings::PersistentLineBreaks;
 
 /// Resolved configuration settings used within air
 ///
@@ -31,7 +31,7 @@ pub struct FormatSettings {
     pub indent_width: IndentWidth,
     pub line_ending: LineEnding,
     pub line_width: LineWidth,
-    pub magic_line_break: MagicLineBreak,
+    pub persistent_line_breaks: PersistentLineBreaks,
 }
 
 impl FormatSettings {
@@ -42,6 +42,6 @@ impl FormatSettings {
             .with_indent_width(self.indent_width)
             .with_line_ending(self.line_ending.finalize(source))
             .with_line_width(self.line_width)
-            .with_magic_line_break(self.magic_line_break)
+            .with_persistent_line_breaks(self.persistent_line_breaks)
     }
 }

--- a/crates/workspace/src/toml.rs
+++ b/crates/workspace/src/toml.rs
@@ -151,21 +151,21 @@ line-ending = "auto"
             toml,
             r#"
 [format]
-ignore-magic-line-break = true
+persistent-line-breaks = false
 "#,
         )?;
 
         let toml = find_air_toml(tempdir.path()).context("Failed to find air.toml")?;
         let options = parse_air_toml(toml)?;
 
-        let ignore_magic_line_break = options
+        let persistent_line_breaks = options
             .format
             .as_ref()
             .context("Expected to find [format] table")?
-            .ignore_magic_line_break
-            .context("Expected to find `ignore-magic-line-break` field")?;
+            .persistent_line_breaks
+            .context("Expected to find `persistent-line-breaks` field")?;
 
-        assert!(ignore_magic_line_break);
+        assert!(!persistent_line_breaks);
 
         Ok(())
     }

--- a/crates/workspace/src/toml_options.rs
+++ b/crates/workspace/src/toml_options.rs
@@ -11,7 +11,7 @@ use crate::settings::Settings;
 use settings::IndentStyle;
 use settings::IndentWidth;
 use settings::LineWidth;
-use settings::MagicLineBreak;
+use settings::PersistentLineBreaks;
 
 /// The Rust representation of `air.toml`
 ///
@@ -96,13 +96,13 @@ pub struct FormatTomlOptions {
     /// * `native`: Line endings will be converted to `\n` on Unix and `\r\n` on Windows.
     pub line_ending: Option<LineEnding>,
 
-    /// Air respects a small set of magic line breaks as an indication that certain
+    /// Air respects a small set of persistent line breaks as an indication that certain
     /// function calls or function signatures should be left expanded. If this option
-    /// is set to `true`, magic line breaks are ignored.
+    /// is set to `false`, persistent line breaks are ignored.
     ///
-    /// It may be preferable to ignore magic line breaks if you prefer that `line-width`
+    /// It may be preferable to ignore persistent line breaks if you prefer that `line-width`
     /// should be the only value that influences line breaks.
-    pub ignore_magic_line_break: Option<bool>,
+    pub persistent_line_breaks: Option<bool>,
 }
 
 impl TomlOptions {
@@ -114,15 +114,15 @@ impl TomlOptions {
             indent_width: format.indent_width.unwrap_or_default(),
             line_ending: format.line_ending.unwrap_or_default(),
             line_width: format.line_width.unwrap_or_default(),
-            magic_line_break: match format.ignore_magic_line_break {
-                Some(ignore_magic_line_break) => {
-                    if ignore_magic_line_break {
-                        MagicLineBreak::Ignore
+            persistent_line_breaks: match format.persistent_line_breaks {
+                Some(persistent_line_breaks) => {
+                    if persistent_line_breaks {
+                        PersistentLineBreaks::Respect
                     } else {
-                        MagicLineBreak::Respect
+                        PersistentLineBreaks::Ignore
                     }
                 }
-                None => MagicLineBreak::Respect,
+                None => PersistentLineBreaks::Respect,
             },
         };
 

--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -19,7 +19,7 @@ line-width = 80
 indent-width = 2
 indent-style = "space"
 line-ending = "auto"
-ignore-magic-line-break = false
+persistent-line-breaks = true
 ```
 
 ## Configuration recommendations
@@ -134,14 +134,14 @@ One of the following values, with a default of `"auto"`:
 
 -   `"native"`: Line endings will be converted to `\n` on Unix and `\r\n` on Windows.
 
-### ignore-magic-line-break
+### persistent-line-breaks
 
-Whether or not magic line breaks should be ignored.
+Whether or not persistent line breaks are allowed.
 
-Either `true` to ignore magic line breaks, or `false` to respect them, with a default of `false`.
+Either `true` to respect persistent line breaks, or `false` to ignore them, with a default of `true`.
 
-Air respects a small set of magic line breaks as an indication that certain function calls or function signatures should be left expanded.
-For example, the following list could be flattened to one line and would still fit within a `line-width` of 80, however, it remains expanded due to the magic line break between the opening `(` and the first argument, `apple`.
+Air respects a small set of persistent line breaks as an indication that certain function calls or function signatures should be left expanded.
+For example, the following list could be flattened to one line and would still fit within a `line-width` of 80, however, it remains expanded due to the persistent line break between the opening `(` and the first argument, `apple`.
 
 ``` r
 dictionary <- list(
@@ -151,7 +151,7 @@ dictionary <- list(
 )
 ```
 
-Similarly, this function signature could also be flattened, but is not, due to the magic line break between the opening `(` and the first parameter, `...`.
+Similarly, this function signature could also be flattened, but is not, due to the persistent line break between the opening `(` and the first parameter, `...`.
 
 ``` r
 case_when <- function(
@@ -164,7 +164,7 @@ case_when <- function(
 }
 ```
 
-To request flattening in these cases, just remove the magic line break.
+To request flattening in these cases, just remove the persistent line break.
 For example:
 
 ``` r
@@ -185,6 +185,6 @@ dictionary <- list(apple = 0.75,
 dictionary <- list(apple = 0.75, banana = 0.25, cherry = 0.50)
 ```
 
-Alternatively, use a tool such as [codegrip](https://github.com/lionel-/codegrip) bound to a keyboard shortcut to flatten the code, and air will keep it flattened as long as it fits within the `line-width`.
+Alternatively, use a tool such as [codegrip](https://github.com/lionel-/codegrip) bound to a keyboard shortcut to flatten the code, and Air will keep it flattened as long as it fits within the `line-width`.
 
-It may be preferable to ignore magic line breaks if you prefer that `line-width` should be the only value that influences line breaks.
+It may be preferable to ignore persistent line breaks if you prefer that `line-width` should be the only value that influences line breaks.


### PR DESCRIPTION
Closes #177 