### PR TITLE
Use the correct extension name in `editor.defaultFormatter`

### DIFF
--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Regarding minor versions (the second number), odd numbers indicate a pre-release of the extension. Even numbers are for public-facing releases.
 
+## Development version
+
+- Fixed an issue where the name of the `editor.defaultFormatter` in the
+  `configurationDefaults` was being set incorrectly.
+
+## 1.0.1
+
+- Fixed an issue where a unique `displayName` was needed in the Visual Studio
+  Marketplace.
 
 ## 1.0.0
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -94,7 +94,7 @@
 		},
 		"configurationDefaults": {
 			"[r]": {
-				"editor.defaultFormatter": "Posit.air"
+				"editor.defaultFormatter": "Posit.air-vscode"
 			}
 		},
 		"commands": [


### PR DESCRIPTION
And update the extension CHANGELOG to include a 1.0.1 bullet