### PR TITLE
Release air 1.0.1 and air-vscode 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "air_r_formatter",
  "air_r_parser",

--- a/crates/air/Cargo.toml
+++ b/crates/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air"
-version = "1.0.0"
+version = "1.0.1"
 publish = true
 authors.workspace = true
 categories.workspace = true

--- a/docs-old/release.md
+++ b/docs-old/release.md
@@ -1,6 +1,6 @@
 # CLI
 
-The release process of the air cli has some manual steps. One complication is that for each release of the CLI binary, we create a new release of the extension as this is our primary way of distributing Air.
+The release process of the air cli has some manual steps. One complication is that for each release of the CLI binary, we create a new release of the extension as this is our primary way of distributing Air. The version numbers between the CLI binary and the extension are not required to be the same.
 
 When you want to cut a release:
 
@@ -14,7 +14,7 @@ When you want to cut a release:
 
     - In `editors/code/package.json`, bump the minor version to the next even number for standard releases, or to the next odd number for odd releases.
 
-    - Do a PR and merge the release branch.
+    - Open a PR with these changes.
 
 - Manually run the [release workflow](https://github.com/posit-dev/air/actions/workflows/release.yml)
 
@@ -32,6 +32,8 @@ When you want to cut a release:
 
 - Manually run the [extension release workflow](https://github.com/posit-dev/air/actions/workflows/release-vscode.yml)
 
-  It runs on `workflow_dispatch`, and automatically pulls in the latest release binary of Air from the binary release workflow above.
+    - It runs on `workflow_dispatch`, and automatically pulls in the latest release binary of Air from the binary release workflow above.
 
-There is no need to bump to an intermediate "dev version" after a release.
+- Merge the release branch
+
+    - There is no need to bump to an intermediate "dev version" after a release.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
 	"name": "air-vscode",
 	"displayName": "Air - R Language Support",
 	"description": "R formatter and language server",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"publisher": "Posit",
 	"license": "MIT",
 	"homepage": "https://posit-dev.github.io/air",


### PR DESCRIPTION
- [ ] Trigger `release.yml` with 1.0.1 to create air binaries
- [ ] Trigger `release-vscode.yml` to release extensions