### PR TITLE
docs: Repeatable install commands

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Build the extension.
       - name: Package Extension (release)
-        run: npx vsce package -o "./dist/air-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+        run: npx @vscode/vsce package -o "./dist/air-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
 
       # Upload the extension.
       - name: Upload artifacts
@@ -117,7 +117,7 @@ jobs:
 
       # Publish to the Code Marketplace.
       - name: Publish Extension (Code Marketplace, release)
-        run: npx vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/air-*.vsix
+        run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/air-*.vsix
 
   # Publish the built extension to OpenVSX
   publish-openvsx:

--- a/docs-old/developer.md
+++ b/docs-old/developer.md
@@ -49,14 +49,11 @@ This installs it to `~/.cargo/bin` (which must be on your `PATH`), and can be re
 Install the dev version of the VS Code extension:
 
 ```sh
-# The first time
-npm install --global vsce
-
 # Install for Positron
-cd editors/code && rm -rf *.vsix && vsce package && positron --install-extension *.vsix
+(cd editors/code && (rm -rf *.vsix || true) && npx @vscode/vsce package && positron --install-extension *.vsix)
 
 # Install for VS Code
-cd editors/code && rm -rf *.vsix && vsce package && code --install-extension *.vsix
+(cd editors/code && (rm -rf *.vsix || true) && npx @vscode/vsce package && code --install-extension *.vsix)
 ```
 
 The CLI tools for Positron or VS Code need to be installed on your path using the command palette command `Shell Command: Install 'code'/'positron' command in PATH`.


### PR DESCRIPTION
* Use `(<code>)` which calls a subshell to run the code, allowing `cd` to not change the callers working directory.
* Use `|| true` as the first time ran, there are no files to remove and `zsh` throws an error. (I saw SO answers saying `-f` should resolve the error I'm seeing, but it did not work as is. I'm happy to adjust this if there is a better code option.)
* Use `npx @vscode/vsce` to auto install `vsce`. When calling `npx vsce` directly, a warning is displayed asking to upgrade to `@vscode/vsce`.