### PR TITLE
Switch to manually downloading the binary

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
-      # macOs or Linux binary
-      # Download, unpack, move into place, and clean up
-      - if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+      - name: Download air binary (macOS or Linux)
+        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        # Download, unpack, move into place, and clean up
         run: |
           curl -LsSfO https://github.com/posit-dev/air/releases/latest/download/air-${{ matrix.target }}.tar.gz
           tar -xvzf air-${{ matrix.target }}.tar.gz
@@ -55,11 +55,10 @@ jobs:
           mv air-${{ matrix.target }}/air bundled/bin/air
           rm -R air-${{ matrix.target }}
           rm -R air-${{ matrix.target }}.tar.gz
-          ls
 
-      # Windows binary
-      # Download, unpack, move into place, and clean up
-      - if: ${{ startsWith(matrix.os, 'windows') }}
+      - name: Download air binary (Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        # Download, unpack, move into place, and clean up
         run: |
           Invoke-WebRequest -Uri https://github.com/posit-dev/air/releases/latest/download/air-${{ matrix.target }}.zip -OutFile .\air-${{ matrix.target }}.zip
           Expand-Archive -Path .\air-${{ matrix.target }}.zip -DestinationPath .\air-${{ matrix.target }} -Force
@@ -67,7 +66,6 @@ jobs:
           Move-Item -Path .\air-${{ matrix.target }}\air.exe -Destination .\bundled\bin\air.exe -Force
           Remove-Item -Path .\air-${{ matrix.target }} -Recurse -Force
           Remove-Item -Path .\air-${{ matrix.target }}.zip -Force
-          Get-ChildItem
 
       # Install Node.
       - name: Install Node.js
@@ -89,87 +87,87 @@ jobs:
           name: dist-${{ matrix.target }}
           path: ./editors/code/dist
 
-#   # Publish the built extension to the Code Marketplace.
-#   publish-code-marketplace:
-#     name: "Publish (Code Marketplace)"
-#     needs: ["build"]
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Install Nodejs
-#         uses: actions/setup-node@v4
-#         with:
-#           node-version: 22
-#
-#       # Download all built artifacts.
-#       - uses: actions/download-artifact@v4
-#         with:
-#           name: dist-aarch64-apple-darwin
-#           path: dist
-#       - uses: actions/download-artifact@v4
-#         with:
-#           name: dist-x86_64-apple-darwin
-#           path: dist
-#       # - uses: actions/download-artifact@v4
-#       #   with:
-#       #     name: dist-x86_64-unknown-linux-gnu
-#       #     path: dist
-#       # - uses: actions/download-artifact@v4
-#       #   with:
-#       #     name: dist-aarch64-unknown-linux-gnu
-#       #     path: dist
-#       - uses: actions/download-artifact@v4
-#         with:
-#           name: dist-x86_64-pc-windows-msvc
-#           path: dist
-#       # - uses: actions/download-artifact@v4
-#       #   with:
-#       #     name: dist-aarch64-pc-windows-msvc
-#       #     path: dist
-#       - run: ls -al ./dist
-#
-#       # Publish to the Code Marketplace.
-#       - name: Publish Extension (Code Marketplace, release)
-#         run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/air-*.vsix
-#
-#   # Publish the built extension to OpenVSX
-#   publish-openvsx:
-#     name: "Publish (OpenVSX)"
-#     needs: ["build"]
-#     runs-on: ubuntu-latest
-#     environment: release
-#     steps:
-#       - name: Install Nodejs
-#         uses: actions/setup-node@v4
-#         with:
-#           node-version: 22
-#
-#       # Download all built artifacts.
-#       - uses: actions/download-artifact@v4
-#         with:
-#           name: dist-aarch64-apple-darwin
-#           path: dist
-#       - uses: actions/download-artifact@v4
-#         with:
-#           name: dist-x86_64-apple-darwin
-#           path: dist
-#       # - uses: actions/download-artifact@v4
-#       #   with:
-#       #     name: dist-x86_64-unknown-linux-gnu
-#       #     path: dist
-#       # - uses: actions/download-artifact@v4
-#       #   with:
-#       #     name: dist-aarch64-unknown-linux-gnu
-#       #     path: dist
-#       - uses: actions/download-artifact@v4
-#         with:
-#           name: dist-x86_64-pc-windows-msvc
-#           path: dist
-#       # - uses: actions/download-artifact@v4
-#       #   with:
-#       #     name: dist-aarch64-pc-windows-msvc
-#       #     path: dist
-#       - run: ls -al ./dist
-#
-#       # Publish to OpenVSX.
-#       - name: Publish Extension (OpenVSX, release)
-#         run: npx ovsx publish --pat ${{ secrets.OPEN_VSX_TOKEN }} --packagePath ./dist/air-*.vsix
+  # Publish the built extension to the Code Marketplace.
+  publish-code-marketplace:
+    name: "Publish (Code Marketplace)"
+    needs: ["build"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Download all built artifacts.
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-aarch64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64-apple-darwin
+          path: dist
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: dist-x86_64-unknown-linux-gnu
+      #     path: dist
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: dist-aarch64-unknown-linux-gnu
+      #     path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64-pc-windows-msvc
+          path: dist
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: dist-aarch64-pc-windows-msvc
+      #     path: dist
+      - run: ls -al ./dist
+
+      # Publish to the Code Marketplace.
+      - name: Publish Extension (Code Marketplace, release)
+        run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/air-*.vsix
+
+  # Publish the built extension to OpenVSX
+  publish-openvsx:
+    name: "Publish (OpenVSX)"
+    needs: ["build"]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Install Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Download all built artifacts.
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-aarch64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64-apple-darwin
+          path: dist
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: dist-x86_64-unknown-linux-gnu
+      #     path: dist
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: dist-aarch64-unknown-linux-gnu
+      #     path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64-pc-windows-msvc
+          path: dist
+      # - uses: actions/download-artifact@v4
+      #   with:
+      #     name: dist-aarch64-pc-windows-msvc
+      #     path: dist
+      - run: ls -al ./dist
+
+      # Publish to OpenVSX.
+      - name: Publish Extension (OpenVSX, release)
+        run: npx ovsx publish --pat ${{ secrets.OPEN_VSX_TOKEN }} --packagePath ./dist/air-*.vsix

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -45,17 +45,29 @@ jobs:
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
-      # macOS or Linux binary
-      - run: curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
-        env:
-          XDG_BIN_HOME: ./bundled/bin
+      # macOs or Linux binary
+      # Download, unpack, move into place, and clean up
+      - if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          curl -LsSfO https://github.com/posit-dev/air/releases/latest/download/air-${{ matrix.target }}.tar.gz
+          tar -xvzf air-${{ matrix.target }}.tar.gz
+          mkdir -p bundled/bin/
+          mv air-${{ matrix.target }}/air bundled/bin/air
+          rm -R air-${{ matrix.target }}
+          rm -R air-${{ matrix.target }}.tar.gz
+          ls
 
       # Windows binary
-      - run: powershell -c "irm https://github.com/posit-dev/air/releases/latest/download/air-installer.ps1 | iex"
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        env:
-          XDG_BIN_HOME: ./bundled/bin
+      # Download, unpack, move into place, and clean up
+      - if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          Invoke-WebRequest -Uri https://github.com/posit-dev/air/releases/latest/download/air-${{ matrix.target }}.zip -OutFile .\air-${{ matrix.target }}.zip
+          Expand-Archive -Path .\air-${{ matrix.target }}.zip -DestinationPath .\air-${{ matrix.target }} -Force
+          New-Item -ItemType Directory -Path .\bundled\bin | Out-Null
+          Move-Item -Path .\air-${{ matrix.target }}\air.exe -Destination .\bundled\bin\air.exe -Force
+          Remove-Item -Path .\air-${{ matrix.target }} -Recurse -Force
+          Remove-Item -Path .\air-${{ matrix.target }}.zip -Force
+          Get-ChildItem
 
       # Install Node.
       - name: Install Node.js
@@ -77,87 +89,87 @@ jobs:
           name: dist-${{ matrix.target }}
           path: ./editors/code/dist
 
-  # Publish the built extension to the Code Marketplace.
-  publish-code-marketplace:
-    name: "Publish (Code Marketplace)"
-    needs: ["build"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Nodejs
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      # Download all built artifacts.
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-aarch64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-x86_64-apple-darwin
-          path: dist
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: dist-x86_64-unknown-linux-gnu
-      #     path: dist
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: dist-aarch64-unknown-linux-gnu
-      #     path: dist
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-x86_64-pc-windows-msvc
-          path: dist
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: dist-aarch64-pc-windows-msvc
-      #     path: dist
-      - run: ls -al ./dist
-
-      # Publish to the Code Marketplace.
-      - name: Publish Extension (Code Marketplace, release)
-        run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/air-*.vsix
-
-  # Publish the built extension to OpenVSX
-  publish-openvsx:
-    name: "Publish (OpenVSX)"
-    needs: ["build"]
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - name: Install Nodejs
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      # Download all built artifacts.
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-aarch64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-x86_64-apple-darwin
-          path: dist
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: dist-x86_64-unknown-linux-gnu
-      #     path: dist
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: dist-aarch64-unknown-linux-gnu
-      #     path: dist
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist-x86_64-pc-windows-msvc
-          path: dist
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: dist-aarch64-pc-windows-msvc
-      #     path: dist
-      - run: ls -al ./dist
-
-      # Publish to OpenVSX.
-      - name: Publish Extension (OpenVSX, release)
-        run: npx ovsx publish --pat ${{ secrets.OPEN_VSX_TOKEN }} --packagePath ./dist/air-*.vsix
+#   # Publish the built extension to the Code Marketplace.
+#   publish-code-marketplace:
+#     name: "Publish (Code Marketplace)"
+#     needs: ["build"]
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Install Nodejs
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: 22
+#
+#       # Download all built artifacts.
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: dist-aarch64-apple-darwin
+#           path: dist
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: dist-x86_64-apple-darwin
+#           path: dist
+#       # - uses: actions/download-artifact@v3
+#       #   with:
+#       #     name: dist-x86_64-unknown-linux-gnu
+#       #     path: dist
+#       # - uses: actions/download-artifact@v3
+#       #   with:
+#       #     name: dist-aarch64-unknown-linux-gnu
+#       #     path: dist
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: dist-x86_64-pc-windows-msvc
+#           path: dist
+#       # - uses: actions/download-artifact@v3
+#       #   with:
+#       #     name: dist-aarch64-pc-windows-msvc
+#       #     path: dist
+#       - run: ls -al ./dist
+#
+#       # Publish to the Code Marketplace.
+#       - name: Publish Extension (Code Marketplace, release)
+#         run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/air-*.vsix
+#
+#   # Publish the built extension to OpenVSX
+#   publish-openvsx:
+#     name: "Publish (OpenVSX)"
+#     needs: ["build"]
+#     runs-on: ubuntu-latest
+#     environment: release
+#     steps:
+#       - name: Install Nodejs
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: 22
+#
+#       # Download all built artifacts.
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: dist-aarch64-apple-darwin
+#           path: dist
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: dist-x86_64-apple-darwin
+#           path: dist
+#       # - uses: actions/download-artifact@v3
+#       #   with:
+#       #     name: dist-x86_64-unknown-linux-gnu
+#       #     path: dist
+#       # - uses: actions/download-artifact@v3
+#       #   with:
+#       #     name: dist-aarch64-unknown-linux-gnu
+#       #     path: dist
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: dist-x86_64-pc-windows-msvc
+#           path: dist
+#       # - uses: actions/download-artifact@v3
+#       #   with:
+#       #     name: dist-aarch64-pc-windows-msvc
+#       #     path: dist
+#       - run: ls -al ./dist
+#
+#       # Publish to OpenVSX.
+#       - name: Publish Extension (OpenVSX, release)
+#         run: npx ovsx publish --pat ${{ secrets.OPEN_VSX_TOKEN }} --packagePath ./dist/air-*.vsix

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -49,23 +49,30 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
         # Download, unpack, move into place, and clean up
         run: |
-          curl -LsSfO https://github.com/posit-dev/air/releases/latest/download/air-${{ matrix.target }}.tar.gz
-          tar -xvzf air-${{ matrix.target }}.tar.gz
+          ARCHIVE_NAME=air-${{ matrix.target }}
+          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+
+          curl -LsSfO https://github.com/posit-dev/air/releases/latest/download/$ARCHIVE_FILE
+          tar -xvzf $ARCHIVE_FILE
           mkdir -p bundled/bin/
-          mv air-${{ matrix.target }}/air bundled/bin/air
-          rm -R air-${{ matrix.target }}
-          rm -R air-${{ matrix.target }}.tar.gz
+          mv $ARCHIVE_NAME/air bundled/bin/air
+          rm -R $ARCHIVE_NAME
+          rm -R $ARCHIVE_FILE
 
       - name: Download air binary (Windows)
         if: ${{ startsWith(matrix.os, 'windows') }}
         # Download, unpack, move into place, and clean up
+        # Use git bash
+        shell: bash
         run: |
-          Invoke-WebRequest -Uri https://github.com/posit-dev/air/releases/latest/download/air-${{ matrix.target }}.zip -OutFile .\air-${{ matrix.target }}.zip
-          Expand-Archive -Path .\air-${{ matrix.target }}.zip -DestinationPath .\air-${{ matrix.target }} -Force
-          New-Item -ItemType Directory -Path .\bundled\bin | Out-Null
-          Move-Item -Path .\air-${{ matrix.target }}\air.exe -Destination .\bundled\bin\air.exe -Force
-          Remove-Item -Path .\air-${{ matrix.target }} -Recurse -Force
-          Remove-Item -Path .\air-${{ matrix.target }}.zip -Force
+          ARCHIVE_NAME=air-${{ matrix.target }}
+          ARCHIVE_FILE=$ARCHIVE_NAME.zip
+
+          curl -LsSfO https://github.com/posit-dev/air/releases/latest/download/$ARCHIVE_FILE
+          unzip $ARCHIVE_FILE
+          mkdir -p bundled/bin/
+          mv air.exe bundled/bin/air.exe
+          rm -R $ARCHIVE_FILE
 
       # Install Node.
       - name: Install Node.js

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -84,7 +84,7 @@ jobs:
 
       # Upload the extension.
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.target }}
           path: ./editors/code/dist
@@ -101,27 +101,27 @@ jobs:
 #           node-version: 22
 #
 #       # Download all built artifacts.
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         with:
 #           name: dist-aarch64-apple-darwin
 #           path: dist
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         with:
 #           name: dist-x86_64-apple-darwin
 #           path: dist
-#       # - uses: actions/download-artifact@v3
+#       # - uses: actions/download-artifact@v4
 #       #   with:
 #       #     name: dist-x86_64-unknown-linux-gnu
 #       #     path: dist
-#       # - uses: actions/download-artifact@v3
+#       # - uses: actions/download-artifact@v4
 #       #   with:
 #       #     name: dist-aarch64-unknown-linux-gnu
 #       #     path: dist
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         with:
 #           name: dist-x86_64-pc-windows-msvc
 #           path: dist
-#       # - uses: actions/download-artifact@v3
+#       # - uses: actions/download-artifact@v4
 #       #   with:
 #       #     name: dist-aarch64-pc-windows-msvc
 #       #     path: dist
@@ -144,27 +144,27 @@ jobs:
 #           node-version: 22
 #
 #       # Download all built artifacts.
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         with:
 #           name: dist-aarch64-apple-darwin
 #           path: dist
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         with:
 #           name: dist-x86_64-apple-darwin
 #           path: dist
-#       # - uses: actions/download-artifact@v3
+#       # - uses: actions/download-artifact@v4
 #       #   with:
 #       #     name: dist-x86_64-unknown-linux-gnu
 #       #     path: dist
-#       # - uses: actions/download-artifact@v3
+#       # - uses: actions/download-artifact@v4
 #       #   with:
 #       #     name: dist-aarch64-unknown-linux-gnu
 #       #     path: dist
-#       - uses: actions/download-artifact@v3
+#       - uses: actions/download-artifact@v4
 #         with:
 #           name: dist-x86_64-pc-windows-msvc
 #           path: dist
-#       # - uses: actions/download-artifact@v3
+#       # - uses: actions/download-artifact@v4
 #       #   with:
 #       #     name: dist-aarch64-pc-windows-msvc
 #       #     path: dist

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Development version
 
+- The extension now works properly for Intel macOS (#194).
+
 ## 0.2.0
 
 - Initial release


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/194

In theory we could use `arch -x86_64 curl` on Mac and keep using cargo-dist, but due to https://github.com/axodotdev/cargo-dist/issues/1720 this does not work. I'm not really sure https://github.com/axodotdev/cargo-dist/issues/1720 will get solved, as when I think about this more we are kind of abusing cargo-dist here. It's purpose is really to get you set up to _run_ the tool (so bypassing Rosetta does seem to make sense on their end), all we were using it for is a way to magically download the right one for this platform, but that isn't too hard to set up ourself.

This dry run shows this seems to be working right
https://github.com/posit-dev/air/actions/runs/12935503617

I downloaded the x86 mac vsix artifact it created and `file` shows that the air binary bundled in there is indeed the right architecture now. The output from the run on Windows shows that the `air.exe` still makes it into the `bundled/bin` directory correctly.