### PR TITLE
Add Linux binary support

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -18,12 +18,12 @@ jobs:
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-            # - os: ubuntu-20.04
-            #   target: x86_64-unknown-linux-gnu
-            #   code-target: linux-x64
-            # - os: ubuntu-20.04
-            #   target: aarch64-unknown-linux-gnu
-            #   code-target: linux-arm64
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
             arch: aarch64
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -114,14 +114,14 @@ jobs:
         with:
           name: dist-x86_64-apple-darwin
           path: dist
-      # - uses: actions/download-artifact@v4
-      #   with:
-      #     name: dist-x86_64-unknown-linux-gnu
-      #     path: dist
-      # - uses: actions/download-artifact@v4
-      #   with:
-      #     name: dist-aarch64-unknown-linux-gnu
-      #     path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-aarch64-unknown-linux-gnu
+          path: dist
       - uses: actions/download-artifact@v4
         with:
           name: dist-x86_64-pc-windows-msvc
@@ -157,14 +157,14 @@ jobs:
         with:
           name: dist-x86_64-apple-darwin
           path: dist
-      # - uses: actions/download-artifact@v4
-      #   with:
-      #     name: dist-x86_64-unknown-linux-gnu
-      #     path: dist
-      # - uses: actions/download-artifact@v4
-      #   with:
-      #     name: dist-aarch64-unknown-linux-gnu
-      #     path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-aarch64-unknown-linux-gnu
+          path: dist
       - uses: actions/download-artifact@v4
         with:
           name: dist-x86_64-pc-windows-msvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Development version
 
+- Linux binaries are now available. Note that your Linux distribution must
+  support glibc 2.31+ for the binary to work (#71).
+
 - ARM Windows binaries are now available (#170).
 
 # 0.2.0

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,6 +25,7 @@ targets = [
     "aarch64-pc-windows-msvc",
     # Linux
     "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
 ]
 # Tell dist to only build `crates/air` rather than every crate in the workspace,
 # which it does by default to be conservative but would include some heavier test-only
@@ -40,3 +41,12 @@ dispatch-releases = true
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
 # Whether to install an updater program
 install-updater = false
+
+[dist.github-custom-runners]
+# Use ARM Mac runner to build ARM binary (not strictly required, but nice).
+# dist uses `macos-13` by default and cross-compiles.
+aarch64-apple-darwin = "macos-14"
+# Lock Linux to minimum supported Ubuntu version (glibc 2.31).
+# For ARM Linux dist actually uses an x86_64 host and uses cargo-zigbuild to cross compile.
+x86_64-unknown-linux-gnu = "ubuntu-20.04"
+aarch64-unknown-linux-gnu = "ubuntu-20.04"

--- a/docs/editor-rstudio.qmd
+++ b/docs/editor-rstudio.qmd
@@ -10,10 +10,6 @@ RStudio does not support the [Language Server Protocol](https://microsoft.github
 
 # Installation
 
-::: callout-note
-## Air is currently only supported on macOS and Windows. Linux support is coming soon!
-:::
-
 Ensure you have at least RStudio version 2024.12.0, which you can download from [here](https://posit.co/download/rstudio-desktop/).
 Additionally, you'll need to install the Air [command line tool](cli.qmd).
 

--- a/docs/editor-vscode.qmd
+++ b/docs/editor-vscode.qmd
@@ -10,10 +10,6 @@ Air provides first class support for both VS Code and Positron, which both suppo
 
 # Installation
 
-::: callout-note
-## Air is currently only supported on macOS and Windows. Linux support is coming soon!
-:::
-
 Air is available [as an Extension](https://marketplace.visualstudio.com/items?itemName=Posit.air-vscode) for both VS Code and Positron.
 The extension comes pre-bundled with an Air binary, so you don't need anything else to get going!
 The Air extension is hosted in the VS Code Marketplace and on OpenVSX.

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Development version
 
+- The extension is now available on Linux (#71).
+
 - The extension is now available on ARM Windows (#170).
 
 - The extension now works properly for Intel macOS (#194).


### PR DESCRIPTION
Closes #71 
Closes #203 

This release workflow shows that the ARM and x86_64 Linux binaries built successfully:
https://github.com/posit-dev/air/actions/runs/13035329063

## glibc

Linux binaries are compiled against glibc 2.31, which is old enough to support RHEL 9 and Ubuntu 20.04. We do this by compiling on Ubuntu 20.04. On RHEL 9 and other Linux flavors there is not a separate binary, you should just be able to use the one compiled on Ubuntu 20.04 with no issues.

We do not currently feel pressure to target an older glibc version. Positron (https://positron.posit.co/download) currently requires Ubuntu 22+ and RHEL 9+, so we are good to go there. Positron _may_ explore supporting RHEL 8 and Ubuntu 20+, making its minimum glibc version glibc 2.28 (due to RHEL 8). Those are currently the minimum supported versions for VS Code itself. We should not make any decisions based on this hypothetical scenario yet though.

## ARM

We build for both x86_64 and ARM Linux. There is no GitHub runner for ARM Ubuntu 20.04, so dist auto detects what you want and uses a host runner of x86_64 Ubuntu 20.04 and cross compiles to ARM using cargo-zigbuild.

## Extension distribution

We build 2 additional VS Code extension versions, with code targets of `linux-arm64` and `linux-x64`. Should "just work" when you download these on Linux.

## MUSL

VS Code extensions can target 2 additional Linux flavors of note, `alpine-x64` and `alpine-arm64`. Alpine Linux is built using MUSL rather than glibc, so there is simply no glibc to dynamically link against on those flavors.

It is not out of the question for us to build _fully static_ binaries for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` specifically for these platforms, and then ship them in the VS Code extension. This would also be how we could support _anyone else_ on some random flavor of Linux that doesn't seem to work with our dynamically linked standard binaries.

