### PR TITLE
Remove top level `air.toml` for now

### DIFF
--- a/air.toml
+++ b/air.toml
@@ -1,5 +1,0 @@
-[format]
-exclude = [
-    "crates/air_r_formatter/tests/specs/**/*.R",
-    "crates/air_r_parser/tests/snapshots/**/*.R",
-]


### PR DESCRIPTION
As it currently breaks VS Code extension forward propagation tests that assume there is no `air.toml` to use

Once we have https://github.com/posit-dev/air/issues/110, we should go back and add 2 `air.toml`s nested in the project, one at `crates/air_r_formatter/tests` and one at `crates/air_r_parser/tests`, because excluding the R files in those subfolders would be great for when you are writing formatter tests with intentionally badly styled R code. Doing it that way would mean that the VS Code extension never "sees" those config files.