### PR TITLE
Add support for `# fmt: skip` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@
 
 - Assigned pipelines no longer double-indent (#220).
 
+- Added support for special "skip" comments.
+
+  Use `# fmt: skip` to avoid formatting the following node and all of its
+  children. In this case, the `tribble()` call and all of its arguments (#52).
+
+  ```r
+  # fmt: skip
+  tribble(
+    ~a, ~b,
+     1,  2
+  )
+  ```
+
+  Use `# fmt: skip file` to avoid formatting an entire file. This comment must
+  appear at the top of the file before any non-comment R code (#219).
 
 # 0.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "biome_formatter",
  "biome_parser",
  "biome_rowan",
+ "comments",
  "itertools",
  "line_ending",
  "settings",
@@ -614,6 +615,10 @@ checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "comments"
+version = "0.0.0"
 
 [[package]]
 name = "console"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ air_r_formatter = { path = "./crates/air_r_formatter" }
 air_r_parser = { path = "./crates/air_r_parser" }
 air_r_syntax = { path = "./crates/air_r_syntax" }
 biome_ungrammar = { path = "./crates/biome_ungrammar" }
+comments = { path = "./crates/comments" }
 crates = { path = "./crates/crates" }
 fs = { path = "./crates/fs" }
 line_ending = { path = "./crates/line_ending" }

--- a/crates/air_r_formatter/Cargo.toml
+++ b/crates/air_r_formatter/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.0.0"
 air_r_syntax = { workspace = true }
 biome_formatter = { workspace = true }
 biome_rowan = { workspace = true }
+comments = { workspace = true }
 itertools = { workspace = true }
 settings = { workspace = true, features = ["biome", "serde"] }
 tracing = { workspace = true }

--- a/crates/air_r_formatter/src/comments.rs
+++ b/crates/air_r_formatter/src/comments.rs
@@ -17,6 +17,8 @@ use biome_formatter::comments::DecoratedComment;
 use biome_formatter::comments::SourceComment;
 use biome_formatter::write;
 use biome_rowan::SyntaxTriviaPieceComments;
+use comments::Directive;
+use comments::FormatDirective;
 
 pub type RComments = Comments<RLanguage>;
 
@@ -43,9 +45,9 @@ pub struct RCommentStyle;
 impl CommentStyle for RCommentStyle {
     type Language = RLanguage;
 
-    fn is_suppression(_text: &str) -> bool {
-        // TODO: Implement ark format suppression
-        false
+    fn is_suppression(text: &str) -> bool {
+        comments::parse_comment_directive(text)
+            .is_some_and(|directive| matches!(directive, Directive::Format(FormatDirective::Skip)))
     }
 
     fn get_comment_kind(_comment: &SyntaxTriviaPieceComments<RLanguage>) -> CommentKind {

--- a/crates/air_r_formatter/tests/specs/r/directives/skip.R
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip.R
@@ -1,0 +1,133 @@
+# -----------------------------------------------------------------------------
+# Basic positioning
+
+# This should be formatted
+1+1
+
+# fmt: skip
+1+1
+
+1+1 # fmt: skip
+
+# This should be formatted
+1+1
+# fmt: skip
+NULL
+
+# fmt: skip
+# Interleaving comment
+1+1
+
+# fmt: skip
+
+1+1
+
+# This should be formatted
+1+1
+
+# -----------------------------------------------------------------------------
+# Calls
+
+# fmt: skip
+fn(
+  1+1, 2+2
+)
+
+fn(
+  1+1, 2+2
+) # fmt: skip
+
+# Just this argument
+fn(
+    # fmt: skip
+    1+1,
+    2+2
+)
+
+# Just this argument
+fn(
+    1+1, # fmt: skip
+    2+2
+)
+
+# Just this argument, which should be moved to its own line but left unformatted
+fn(
+  1+1, 2+2 # fmt: skip
+)
+
+# Aligned lists
+# fmt: skip
+list(
+  this      = 1,
+  that      = 2,
+  thisthing = 3,
+  thatthing = 4,
+  andthis   = 5
+)
+
+# -----------------------------------------------------------------------------
+# Tribble
+
+# Important test case
+
+# fmt: skip
+tribble(
+  ~a, ~b,
+   1,  2
+)
+
+# -----------------------------------------------------------------------------
+# Binary expression chains
+
+# Skips everything in the chain
+# fmt: skip
+foo |>
+  bar() |> baz()
+
+foo |>
+  # Just `bar()`, but `baz()` moves to its own line and is formatted
+  # fmt: skip
+  bar(a = 1,
+    b = 2
+  ) |> baz(a = 1,
+    b = 2
+  )
+
+# -----------------------------------------------------------------------------
+# Functions
+
+# fmt: skip
+# Everything in the function
+function(){
+    1+1
+}
+
+# fmt: skip
+# Everything within the assignment expression of `<-`
+fn<-function(){
+    1+1
+}
+
+function(){
+    # fmt: skip
+    # Just this line
+    1+1
+    2+2
+}
+
+# -----------------------------------------------------------------------------
+# Braced expressions
+
+# fmt: skip
+# Everything inside
+{
+    1+1
+    2+2
+}
+
+{
+    # fmt: skip
+    # Just this line
+    1+1
+    2+2
+}

--- a/crates/air_r_formatter/tests/specs/r/directives/skip.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip.R.snap
@@ -1,0 +1,293 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/directives/skip.R
+---
+# Input
+
+```R
+# -----------------------------------------------------------------------------
+# Basic positioning
+
+# This should be formatted
+1+1
+
+# fmt: skip
+1+1
+
+1+1 # fmt: skip
+
+# This should be formatted
+1+1
+# fmt: skip
+NULL
+
+# fmt: skip
+# Interleaving comment
+1+1
+
+# fmt: skip
+
+1+1
+
+# This should be formatted
+1+1
+
+# -----------------------------------------------------------------------------
+# Calls
+
+# fmt: skip
+fn(
+  1+1, 2+2
+)
+
+fn(
+  1+1, 2+2
+) # fmt: skip
+
+# Just this argument
+fn(
+    # fmt: skip
+    1+1,
+    2+2
+)
+
+# Just this argument
+fn(
+    1+1, # fmt: skip
+    2+2
+)
+
+# Just this argument, which should be moved to its own line but left unformatted
+fn(
+  1+1, 2+2 # fmt: skip
+)
+
+# Aligned lists
+# fmt: skip
+list(
+  this      = 1,
+  that      = 2,
+  thisthing = 3,
+  thatthing = 4,
+  andthis   = 5
+)
+
+# -----------------------------------------------------------------------------
+# Tribble
+
+# Important test case
+
+# fmt: skip
+tribble(
+  ~a, ~b,
+   1,  2
+)
+
+# -----------------------------------------------------------------------------
+# Binary expression chains
+
+# Skips everything in the chain
+# fmt: skip
+foo |>
+  bar() |> baz()
+
+foo |>
+  # Just `bar()`, but `baz()` moves to its own line and is formatted
+  # fmt: skip
+  bar(a = 1,
+    b = 2
+  ) |> baz(a = 1,
+    b = 2
+  )
+
+# -----------------------------------------------------------------------------
+# Functions
+
+# fmt: skip
+# Everything in the function
+function(){
+    1+1
+}
+
+# fmt: skip
+# Everything within the assignment expression of `<-`
+fn<-function(){
+    1+1
+}
+
+function(){
+    # fmt: skip
+    # Just this line
+    1+1
+    2+2
+}
+
+# -----------------------------------------------------------------------------
+# Braced expressions
+
+# fmt: skip
+# Everything inside
+{
+    1+1
+    2+2
+}
+
+{
+    # fmt: skip
+    # Just this line
+    1+1
+    2+2
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Persistent line breaks: Respect
+-----
+
+```R
+# -----------------------------------------------------------------------------
+# Basic positioning
+
+# This should be formatted
+1 + 1
+
+# fmt: skip
+1+1
+
+1+1 # fmt: skip
+
+# This should be formatted
+1 + 1
+# fmt: skip
+NULL
+
+# fmt: skip
+# Interleaving comment
+1+1
+
+# fmt: skip
+
+1+1
+
+# This should be formatted
+1 + 1
+
+# -----------------------------------------------------------------------------
+# Calls
+
+# fmt: skip
+fn(
+  1+1, 2+2
+)
+
+fn(
+  1+1, 2+2
+) # fmt: skip
+
+# Just this argument
+fn(
+  # fmt: skip
+  1+1,
+  2 + 2
+)
+
+# Just this argument
+fn(
+  1+1, # fmt: skip
+  2 + 2
+)
+
+# Just this argument, which should be moved to its own line but left unformatted
+fn(
+  1 + 1,
+  2+2 # fmt: skip
+)
+
+# Aligned lists
+# fmt: skip
+list(
+  this      = 1,
+  that      = 2,
+  thisthing = 3,
+  thatthing = 4,
+  andthis   = 5
+)
+
+# -----------------------------------------------------------------------------
+# Tribble
+
+# Important test case
+
+# fmt: skip
+tribble(
+  ~a, ~b,
+   1,  2
+)
+
+# -----------------------------------------------------------------------------
+# Binary expression chains
+
+# Skips everything in the chain
+# fmt: skip
+foo |>
+  bar() |> baz()
+
+foo |>
+  # Just `bar()`, but `baz()` moves to its own line and is formatted
+  # fmt: skip
+  bar(a = 1,
+    b = 2
+  ) |>
+  baz(a = 1, b = 2)
+
+# -----------------------------------------------------------------------------
+# Functions
+
+# fmt: skip
+# Everything in the function
+function(){
+    1+1
+}
+
+# fmt: skip
+# Everything within the assignment expression of `<-`
+fn<-function(){
+    1+1
+}
+
+function() {
+  # fmt: skip
+  # Just this line
+  1+1
+  2 + 2
+}
+
+# -----------------------------------------------------------------------------
+# Braced expressions
+
+# fmt: skip
+# Everything inside
+{
+    1+1
+    2+2
+}
+
+{
+  # fmt: skip
+  # Just this line
+  1+1
+  2 + 2
+}
+```

--- a/crates/comments/Cargo.toml
+++ b/crates/comments/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "comments"
+description = "Utilities for working with comments"
+version = "0.0.0"
+publish = false
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true

--- a/crates/comments/src/directive.rs
+++ b/crates/comments/src/directive.rs
@@ -1,0 +1,96 @@
+#[derive(Debug, PartialEq)]
+pub enum Directive {
+    Format(FormatDirective),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FormatDirective {
+    Skip,
+    SkipFile,
+}
+
+/// Parse a comment directive
+///
+/// These take the form:
+///
+/// ```text
+/// # <category>: <command> <optional-argument>
+/// ```
+///
+/// Such as:
+///
+/// ```text
+/// # fmt: skip
+/// # fmt: skip file
+/// # fmt: tabular
+/// # fmt: align-right
+/// # lint: skip
+/// # lint: skip rule
+/// ```
+///
+/// Note that directives are applied to the node they are attached to.
+pub fn parse_comment_directive(text: &str) -> Option<Directive> {
+    let text = text.strip_prefix('#')?;
+    let text = text.trim_start();
+    let (category, text) = text.split_once(':')?;
+    let text = text.trim();
+
+    match category {
+        "fmt" => parse_format_directive(text),
+        _ => None,
+    }
+}
+
+#[inline]
+fn parse_format_directive(text: &str) -> Option<Directive> {
+    match text {
+        "skip" => Some(Directive::Format(FormatDirective::Skip)),
+        "skip file" => Some(Directive::Format(FormatDirective::SkipFile)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parse_comment_directive;
+    use crate::Directive;
+
+    #[test]
+    fn test_format_directive() {
+        let format_skip = Some(Directive::Format(crate::FormatDirective::Skip));
+        let format_skip_file = Some(Directive::Format(crate::FormatDirective::SkipFile));
+
+        // Must have leading `#`
+        assert!(parse_comment_directive("fmt: skip").is_none());
+
+        // Must have `:`
+        assert!(parse_comment_directive("# fmt skip").is_none());
+
+        // `:` must be right after `fmt`
+        assert!(parse_comment_directive("# fmt : skip").is_none());
+
+        // Can't have extra spaces between `skip file`
+        assert!(parse_comment_directive("# fmt: skip  file").is_none());
+
+        // Can't have unrelated leading text
+        assert!(parse_comment_directive("# please fmt: skip").is_none());
+
+        // Can't have unrelated trailing text
+        assert!(parse_comment_directive("# fmt: skip please").is_none());
+        assert!(parse_comment_directive("# fmt: skip file please").is_none());
+
+        assert_eq!(parse_comment_directive("# fmt: skip"), format_skip);
+        assert_eq!(parse_comment_directive("#fmt:skip"), format_skip);
+        assert_eq!(parse_comment_directive("#  fmt:  skip  "), format_skip);
+
+        assert_eq!(
+            parse_comment_directive("# fmt: skip file"),
+            format_skip_file
+        );
+        assert_eq!(parse_comment_directive("#fmt:skip file"), format_skip_file);
+        assert_eq!(
+            parse_comment_directive("#  fmt:  skip file"),
+            format_skip_file
+        );
+    }
+}

--- a/crates/comments/src/lib.rs
+++ b/crates/comments/src/lib.rs
@@ -1,0 +1,5 @@
+mod directive;
+
+pub use directive::parse_comment_directive;
+pub use directive::Directive;
+pub use directive::FormatDirective;

--- a/crates/crates/src/snapshots/crates__tests__crate_names.snap
+++ b/crates/crates/src/snapshots/crates__tests__crate_names.snap
@@ -10,6 +10,7 @@ expression: AIR_CRATE_NAMES
     "air_r_parser",
     "air_r_syntax",
     "biome_ungrammar",
+    "comments",
     "crates",
     "fs",
     "line_ending",

--- a/docs/formatter.qmd
+++ b/docs/formatter.qmd
@@ -6,7 +6,8 @@ editor:
     canonical: true
 ---
 
-Air is first and foremost a formatter of R code. On this page, you'll find details about what a formatter is, why you'd want to use one, and you'll learn about how Air makes decisions on how to format your R code.
+Air is first and foremost a formatter of R code.
+On this page, you'll find details about what a formatter is, why you'd want to use one, and you'll learn about how Air makes decisions on how to format your R code.
 
 # What's a formatter?
 
@@ -172,6 +173,48 @@ list(foo, bar)
 ```
 
 The goal of this feature is to strike a balance between being opinionated and recognizing that users often know when taking up more vertical space results in more readable output.
+
+# Disabling formatting
+
+Air supports two special comments to disable formatting, `# fmt: skip` and `# fmt: skip file`.
+
+`# fmt: skip` skips formatting for the following syntax node (including all of its children).
+
+``` r
+# This skips formatting for `list()` and its arguments, retaining the manual alignment
+# fmt: skip
+list(
+  dollar = "USA",
+  yen    = "Japan",
+  yuan   = "China"
+)
+
+# This skips formatting for `tribble()` and its arguments
+# fmt: skip
+tribble(
+  ~x, ~y,
+   1,  2,
+)
+```
+
+`# fmt: skip file` skips the entire file.
+This must be placed at the top of the file before the first non-comment R code, otherwise the comment is ignored.
+Use this for generated files, or as an alternative to `exclude` for individual files that you know you'd like to exclude from formatting.
+
+``` r
+# Generated file - Don't modify by hand!
+# fmt: skip file
+
+# This won't be formatted
+generated_function_signature <- function(which, might, overflow, the, line, width, but, we, dont, really, care) {
+    body
+}
+
+# Neither will this
+another_generated_function_signature <- function(which, might, overflow, the, line, width, but, we, dont, really, care) {
+    body
+}
+```
 
 # When does a formatter run?
 

--- a/docs/formatter.qmd
+++ b/docs/formatter.qmd
@@ -199,7 +199,7 @@ tribble(
 
 `# fmt: skip file` skips the entire file.
 This must be placed at the top of the file before the first non-comment R code, otherwise the comment is ignored.
-Use this for generated files, or as an alternative to `exclude` for individual files that you know you'd like to exclude from formatting.
+This is useful for generated files, or as an alternative to `exclude` for individual files that you know you'd like to exclude from formatting.
 
 ``` r
 # Generated file - Don't modify by hand!


### PR DESCRIPTION
Closes #52 

Motivating examples, until we add "official" support for these with `fmt: tabular` or `fmt: align-right` or something:

```r
# fmt: skip
list(
  this      = 1,
  that      = 2,
  thisthing = 3,
  thatthing = 4,
  andthis   = 5
)

# fmt: skip
tribble(
  ~a, ~b,
   1,  2
)
```

Note that format directives are applied at the _node_ level, meaning they are applied to whatever node the comment gets attached to (as determined by `place_comment()` in the formatter). If a node is skipped, all of its children are also skipped.

@lionel- I'm definitely open to more tests cases if you can think of any

@lionel- I went ahead and added a changelog bullet and some docs on `# fmt: skip file`, it felt weird to talk about just `# fmt skip` knowing we are about to add this too. I've also gone ahead and added `FormatDirective::SkipFile`. In the end it felt like a separate directive than `FormatDirective::Skip` rather than an argument to that one. I'd also be open to `# fmt: skip-file` if you like that better. 