### PR TITLE
Fix indentation of assigned pipelines - review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Development version
 
+- Assigned pipelines no longer double-indent (#220).
+
+
 # 0.3.0
 
 - Air has gained support for excluding files and folders (#128).
@@ -20,6 +23,7 @@
   support glibc 2.31+ for the binary to work (#71).
 
 - ARM Windows binaries are now available (#170).
+
 
 # 0.2.0
 

--- a/crates/air_r_formatter/src/either.rs
+++ b/crates/air_r_formatter/src/either.rs
@@ -1,0 +1,22 @@
+use biome_formatter::{prelude::Formatter, Format, FormatResult};
+
+/// An owned value that generically represents two `Format` types
+///
+/// Can be chained.
+pub enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<L, R, Context> Format<Context> for Either<L, R>
+where
+    L: Format<Context>,
+    R: Format<Context>,
+{
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        match self {
+            Either::Left(left) => left.fmt(f),
+            Either::Right(right) => right.fmt(f),
+        }
+    }
+}

--- a/crates/air_r_formatter/src/lib.rs
+++ b/crates/air_r_formatter/src/lib.rs
@@ -21,6 +21,7 @@ use crate::cst::FormatRSyntaxNode;
 pub mod comments;
 pub mod context;
 mod cst;
+pub mod either;
 mod prelude;
 mod r;
 pub(crate) mod separated;

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -41,19 +41,19 @@ pub(crate) struct FormatRBinaryExpression {
     /// ```
     ///
     /// See https://github.com/posit-dev/air/issues/220.
-    pub(crate) indent: ChainAlignment,
+    pub(crate) alignment: ChainAlignment,
 }
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct FormatRBinaryExpressionOptions {
-    pub(crate) indent: ChainAlignment,
+    pub(crate) alignment: ChainAlignment,
 }
 
 impl FormatRuleWithOptions<RBinaryExpression> for FormatRBinaryExpression {
     type Options = FormatRBinaryExpressionOptions;
 
     fn with_options(mut self, options: Self::Options) -> Self {
-        self.indent = options.indent;
+        self.alignment = options.alignment;
         self
     }
 }
@@ -86,7 +86,7 @@ impl FormatNodeRule<RBinaryExpression> for FormatRBinaryExpression {
             | RSyntaxKind::SUPER_ASSIGN_RIGHT => fmt_binary_assignment(left, operator, right, f),
 
             // Chainable (pipes, logical, arithmetic)
-            kind if is_chainable_binary_operator(kind)  => fmt_binary_chain(left, operator, right, self.indent, f),
+            kind if is_chainable_binary_operator(kind)  => fmt_binary_chain(left, operator, right, self.alignment, f),
 
             // Not chainable
             // Formulas (debatable)
@@ -193,7 +193,7 @@ fn fmt_binary_assignment(
         if binary_assignment_has_persistent_line_break(&operator, &right, f.options()) {
             let right = if let AnyRExpression::RBinaryExpression(ref binary_expr) = right {
                 let options = FormatRBinaryExpressionOptions {
-                    indent: rhs_alignment(binary_expr)?,
+                    alignment: rhs_alignment(binary_expr)?,
                 };
                 Either::Left(binary_expr.format().with_options(options))
             } else {

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -25,7 +25,9 @@ pub(crate) enum ChainAlignment {
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct FormatRBinaryExpression {
-    /// Whether to indent the pipeline. Used to prevent "double-indenting" an
+    /// Alignment to use with chained expressions
+    ///
+    /// Left alignment is used to prevent "double-indenting" an
     /// assigned pipeline, e.g.:
     ///
     /// ```r

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -193,7 +193,7 @@ fn fmt_binary_assignment(
         if binary_assignment_has_persistent_line_break(&operator, &right, f.options()) {
             let right = if let AnyRExpression::RBinaryExpression(ref binary_expr) = right {
                 let options = FormatRBinaryExpressionOptions {
-                    alignment: rhs_alignment(binary_expr)?,
+                    alignment: ChainAlignment::LeftAligned,
                 };
                 Either::Left(binary_expr.format().with_options(options))
             } else {
@@ -235,19 +235,6 @@ fn binary_assignment_has_persistent_line_break(
     }
 
     right.syntax().has_leading_newline()
-}
-
-// Should this be implemented in an extension trait of `RBinaryExpression` owned
-// by the formatter?
-fn rhs_alignment(expr: &RBinaryExpression) -> FormatResult<ChainAlignment> {
-    let RBinaryExpressionFields { operator, .. } = expr.as_fields();
-    let operator = operator?;
-
-    Ok(if is_chainable_binary_operator(operator.kind()) {
-        ChainAlignment::LeftAligned
-    } else {
-        ChainAlignment::Indented
-    })
 }
 
 /// Format a binary expression

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -593,10 +593,9 @@ fn fmt_binary_chain(
         Ok(())
     });
 
-    let chain = if let ChainAlignment::Indented = alignment {
-        Either::Left(indent(&chain))
-    } else {
-        Either::Right(chain)
+    let chain = match alignment {
+        ChainAlignment::Indented => Either::Left(indent(&chain)),
+        ChainAlignment::LeftAligned => Either::Right(chain),
     };
 
     write!(

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -191,19 +191,18 @@ fn fmt_binary_assignment(
 ) -> FormatResult<()> {
     let right = format_with(|f| {
         if binary_assignment_has_persistent_line_break(&operator, &right, f.options()) {
-            let right = if let AnyRExpression::RBinaryExpression(ref binary_expr) = right {
-                let options = FormatRBinaryExpressionOptions {
-                    alignment: ChainAlignment::LeftAligned,
-                };
-                Either::Left(binary_expr.format().with_options(options))
-            } else {
-                Either::Right(right.format())
+            let right = match &right {
+                AnyRExpression::RBinaryExpression(right) => {
+                    Either::Left(right.format().with_options(FormatRBinaryExpressionOptions {
+                        alignment: ChainAlignment::LeftAligned,
+                    }))
+                }
+                right => Either::Right(right.format()),
             };
-
-            return write!(f, [indent(&format_args![hard_line_break(), right])]);
+            write!(f, [indent(&format_args![hard_line_break(), right])])
+        } else {
+            write!(f, [space(), right.format()])
         }
-
-        write!(f, [space(), right.format()])
     });
 
     write!(

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R
@@ -508,3 +508,26 @@ base_version <-
   b_get(brand, "defaults", "shiny", "theme", "version") %||%
   b_get(brand, "defaults", "bootstrap", "version") %||%
   version_default()
+
+
+# https://github.com/posit-dev/air/issues/220
+data <-
+  starwars |>
+  filter(height > 172) |>
+  select(1:3)
+
+plot <-
+  ggplot() +
+  geom_point()
+
+foo <-
+  1 +
+  2
+
+foo <-
+  TRUE ||
+  FALSE
+
+# Persistent assign-newline and unbroken pipeline
+data <-
+  ggplot() + geom_point()

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
@@ -516,6 +516,29 @@ base_version <-
   b_get(brand, "defaults", "bootstrap", "version") %||%
   version_default()
 
+
+# https://github.com/posit-dev/air/issues/220
+data <-
+  starwars |>
+  filter(height > 172) |>
+  select(1:3)
+
+plot <-
+  ggplot() +
+  geom_point()
+
+foo <-
+  1 +
+  2
+
+foo <-
+  TRUE ||
+  FALSE
+
+# Persistent assign-newline and unbroken pipeline
+data <-
+  ggplot() + geom_point()
+
 ```
 
 
@@ -1161,9 +1184,31 @@ is_condition_true <-
 # https://github.com/posit-dev/air/issues/91
 base_version <-
   version %||%
-    b_get(brand, "defaults", "shiny", "theme", "version") %||%
-    b_get(brand, "defaults", "bootstrap", "version") %||%
-    version_default()
+  b_get(brand, "defaults", "shiny", "theme", "version") %||%
+  b_get(brand, "defaults", "bootstrap", "version") %||%
+  version_default()
+
+# https://github.com/posit-dev/air/issues/220
+data <-
+  starwars |>
+  filter(height > 172) |>
+  select(1:3)
+
+plot <-
+  ggplot() +
+  geom_point()
+
+foo <-
+  1 +
+  2
+
+foo <-
+  TRUE ||
+  FALSE
+
+# Persistent assign-newline and unbroken pipeline
+data <-
+  ggplot() + geom_point()
 ```
 
 # Lines exceeding max width of 80 characters


### PR DESCRIPTION
Merges into https://github.com/posit-dev/air/pull/227

@lionel- mostly just tweaking some consistency things I noticed, feel free to cherry pick

The biggest tweak is the removal of `rhs_alignment()`, which I think we don't need? I'm almost certain we can just inline `LeftAligned`, because if we:
- Are in binary assignment
- And we have a binary expression on the RHS

Then we can just unconditionally set `LeftAligned` and as we circle back around into `fmt_fields()` for `RBinaryExpression`, the `is_chainable_binary_operator()` check that we already have in `fmt_fields()` handles whether or not we use `LeftAligned` at all.