### PR TITLE
Disable hugging when the argument is named

### DIFF
--- a/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/call_arguments.rs
@@ -991,8 +991,15 @@ fn is_hugging_call(
         return Ok(false);
     }
 
-    // Unwrap the value to get the `AnyRExpression`
-    let Some(arg) = item.element().node()?.value() else {
+    let arg = item.element().node()?;
+
+    // We only consider hugging for an unnamed argument
+    // (Particularly meaningful for `mutate(key = value)` where you don't expect hugging)
+    if arg.name_clause().is_some() {
+        return Ok(false);
+    }
+
+    let Some(arg) = arg.value() else {
         return Ok(false);
     };
 

--- a/crates/air_r_formatter/tests/specs/r/call.R
+++ b/crates/air_r_formatter/tests/specs/r/call.R
@@ -672,6 +672,19 @@ c(list(foobar(
   2
 )))
 
+# Named arguments prevent hugging
+fn(name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(1, 2))
+
+# Named arguments prevent hugging - motivating example
+# - With the `mutate()`, we expect multiple key/value pairs so hugging
+#   after the first one doesn't feel quite right, and actually makes it
+#   a little difficult to add additional key/value pairs
+# - With the `filter()`, we accept hugging here and justify it by saying
+#   that you end up reading this as `filterany`, which is kind of nice
+storms <- storms %>%
+  mutate(name = if_else(str_sub(name, 1, 3) %in% c("AL0", "AL1"), name, str_to_title(name))) %>%
+  filter(any(status %in% c("hurricane", "tropical storm", "tropical depression")))
+
 # Sanity checks for comments
 
 c(

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -679,6 +679,19 @@ c(list(foobar(
   2
 )))
 
+# Named arguments prevent hugging
+fn(name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(1, 2))
+
+# Named arguments prevent hugging - motivating example
+# - With the `mutate()`, we expect multiple key/value pairs so hugging
+#   after the first one doesn't feel quite right, and actually makes it
+#   a little difficult to add additional key/value pairs
+# - With the `filter()`, we accept hugging here and justify it by saying
+#   that you end up reading this as `filterany`, which is kind of nice
+storms <- storms %>%
+  mutate(name = if_else(str_sub(name, 1, 3) %in% c("AL0", "AL1"), name, str_to_title(name))) %>%
+  filter(any(status %in% c("hurricane", "tropical storm", "tropical depression")))
+
 # Sanity checks for comments
 
 c(
@@ -1524,6 +1537,32 @@ c(list(foobar(
   2
 )))
 
+# Named arguments prevent hugging
+fn(
+  name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
+    1,
+    2
+  )
+)
+
+# Named arguments prevent hugging - motivating example
+# - With the `mutate()`, we expect multiple key/value pairs so hugging
+#   after the first one doesn't feel quite right, and actually makes it
+#   a little difficult to add additional key/value pairs
+# - With the `filter()`, we accept hugging here and justify it by saying
+#   that you end up reading this as `filterany`, which is kind of nice
+storms <- storms %>%
+  mutate(
+    name = if_else(
+      str_sub(name, 1, 3) %in% c("AL0", "AL1"),
+      name,
+      str_to_title(name)
+    )
+  ) %>%
+  filter(any(
+    status %in% c("hurricane", "tropical storm", "tropical depression")
+  ))
+
 # Sanity checks for comments
 
 c(
@@ -1652,4 +1691,5 @@ foo(bar[
   701:   foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz
   705: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz()))
   708: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
+  721:   name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
 ```


### PR DESCRIPTION
Follow up to #228 after running this on dplyr code and talking to @lionel- about it

We remain confident that hugging is extremely useful in general, but we think that hugging is mostly useful when the argument in question is _not_ named. For example:

```r
# Very useful - and you almost read this in your head as `abort_paste0()`
abort(paste0(
  "bullet",
  "info"
))

# Feels a bit awkward - the `message` is in the way.
# The presence of `message` somewhat implies that you plan to add >1 arguments, so the naming of them would be useful,
# and if >1 arguments are present then hugging would be invalid anyways.
abort(message = paste0(
  "bullet",
  "info"
))
```

Hugging becomes particularly not-useful in functions that accept 1 or more key/value pairs, like `mutate()`

```r
# before
storms <- storms %>%
  mutate(name = if_else(str_sub(name, 1, 3) %in% c("AL0", "AL1"), name, str_to_title(name))) %>%
  mutate(
    name2 = some_thing(),
    name3 = some_other_thing()
  ) 

# after, with hugging
storms <- storms %>%
  mutate(name = if_else(
    str_sub(name, 1, 3) %in% c("AL0", "AL1"), 
    name, 
    str_to_title(name)
  )) %>%
  mutate(
    name2 = some_thing(),
    name3 = some_other_thing()
  ) 

# after, without hugging
storms <- storms %>%
  mutate(
    name = if_else(
      str_sub(name, 1, 3) %in% c("AL0", "AL1"), 
      name, 
      str_to_title(name)
    )
  ) %>%
  mutate(
    name2 = some_thing(),
    name3 = some_other_thing()
  ) 
```

Hugging takes away from the symmetry a little bit, making it hard to scan down the pipeline and see the new variable names of `name =`, `name2 =`, and `name3 =`. It also makes it a little harder to add a 2nd column expression to that first `mutate()` call, because you have to place your cursor between the `))` and then add the `,` there.

We do think that hugging can be somewhat nice in other dplyr verbs, like `filter()`, where named arguments are not used

```r
# before
storms <- storms %>%
  filter(any(status %in% c("hurricane", "tropical storm", "tropical depression")))

# after with hugging - in this case you read it like `filter_any()` which is kind of nice
storms <- storms %>%
  filter(any(
    status %in% c("hurricane", "tropical storm", "tropical depression")
  ))
```