### PR TITLE
Rename `air.executableLocation` and add `air.executablePath` support

### DIFF
--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Development version
 
+- New `air.executablePath` configuration option for specifying a fixed path to an air executable. You must also set `air.executableStrategy` to `"path"` for this to have any affect. This is mostly useful for debug builds of air (#243).
+
+- `air.executableLocation` has been renamed to `air.executableStrategy`.
+
 ## 0.4.0
 
 - [Air 0.3.0](https://github.com/posit-dev/air/blob/main/CHANGELOG.md) is now bundled with the extension.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -82,12 +82,20 @@
 					"markdownDescription": "Strategy used to locate the `air` executable to start the language server with.",
 					"enum": [
 						"bundled",
-						"environment"
+						"environment",
+						"path"
 					],
 					"enumDescriptions": [
 						"Always use the bundled `air` executable.",
-						"Look for an `air` executable using the `PATH` environment variable, falling back to the bundled version."
+						"Look for an `air` executable using the `PATH` environment variable, falling back to the bundled version.",
+						"Look for an `air` executable at the fixed path provided by `air.executablePath`."
 					],
+					"scope": "window",
+					"type": "string"
+				},
+				"air.executablePath": {
+					"default": null,
+					"markdownDescription": "The path to an `air` executable. Only utilized when `air.executableStrategy` is set to \"path\".",
 					"scope": "window",
 					"type": "string"
 				}

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -77,16 +77,16 @@
 					"scope": "application",
 					"type": "boolean"
 				},
-				"air.executableLocation": {
+				"air.executableStrategy": {
 					"default": "bundled",
-					"markdownDescription": "Location of the `air` executable to start the language server with.",
+					"markdownDescription": "Strategy used to locate the `air` executable to start the language server with.",
 					"enum": [
 						"bundled",
 						"environment"
 					],
 					"enumDescriptions": [
 						"Always use the bundled `air` executable.",
-						"Look for an `air` executable on the `PATH`, falling back to the bundled version."
+						"Look for an `air` executable using the `PATH` environment variable, falling back to the bundled version."
 					],
 					"scope": "window",
 					"type": "string"

--- a/editors/code/src/binary.ts
+++ b/editors/code/src/binary.ts
@@ -5,10 +5,10 @@ import which from "which";
 import * as output from "./output";
 import { AIR_BINARY_NAME, BUNDLED_AIR_EXECUTABLE } from "./constants";
 
-export type ExecutableLocation = "environment" | "bundled";
+export type ExecutableStrategy = "bundled" | "environment";
 
 export async function resolveAirBinaryPath(
-	executableLocation: ExecutableLocation,
+	executableStrategy: ExecutableStrategy,
 ): Promise<string> {
 	if (!vscode.workspace.isTrusted) {
 		output.log(
@@ -18,10 +18,10 @@ export async function resolveAirBinaryPath(
 	}
 
 	// User requested the `"bundled"` air binary
-	if (executableLocation === "bundled") {
+	if (executableStrategy === "bundled") {
 		if (fs.existsSync(BUNDLED_AIR_EXECUTABLE)) {
 			output.log(
-				`Using bundled executable as requested by \`air.executableLocation\`: ${BUNDLED_AIR_EXECUTABLE}`,
+				`Using bundled executable as requested by \`air.executableStrategy\`: ${BUNDLED_AIR_EXECUTABLE}`,
 			);
 			return BUNDLED_AIR_EXECUTABLE;
 		}

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -98,6 +98,7 @@ export class Lsp {
 
 		const command = await resolveAirBinaryPath(
 			workspaceSettings.executableStrategy,
+			workspaceSettings.executablePath,
 		);
 
 		let serverOptions: lc.ServerOptions = {

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -97,7 +97,7 @@ export class Lsp {
 		const initializationOptions = getInitializationOptions("air");
 
 		const command = await resolveAirBinaryPath(
-			workspaceSettings.executableLocation,
+			workspaceSettings.executableStrategy,
 		);
 
 		let serverOptions: lc.ServerOptions = {

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { ExecutableLocation } from "./binary";
+import { ExecutableStrategy } from "./binary";
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
@@ -13,7 +13,7 @@ export type InitializationOptions = {
 };
 
 export type WorkspaceSettings = {
-	executableLocation: ExecutableLocation;
+	executableStrategy: ExecutableStrategy;
 };
 
 export function getInitializationOptions(
@@ -37,8 +37,8 @@ export function getWorkspaceSettings(
 	const config = getConfiguration(namespace, workspace);
 
 	return {
-		executableLocation:
-			config.get<ExecutableLocation>("executableLocation") ?? "bundled",
+		executableStrategy:
+			config.get<ExecutableStrategy>("executableStrategy") ?? "bundled",
 	};
 }
 

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -14,6 +14,7 @@ export type InitializationOptions = {
 
 export type WorkspaceSettings = {
 	executableStrategy: ExecutableStrategy;
+	executablePath?: string;
 };
 
 export function getInitializationOptions(
@@ -39,6 +40,7 @@ export function getWorkspaceSettings(
 	return {
 		executableStrategy:
 			config.get<ExecutableStrategy>("executableStrategy") ?? "bundled",
+		executablePath: config.get<string>("executablePath"),
 	};
 }
 


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/243

- Renamed `air.executableLocation` to `air.executableStrategy` and updated documentation
- Added `"path"` option to `air.executableStrategy`
- Added `air.executablePath`

Reworked `resolveAirBinaryPath()` to be a series of if/else statements so it is _extremely clear_ what all of the fallback behavior combination is. I think this dramatically improves both readability and the logging. I used Rust style `Option`s by adding helpers like `airBinaryFromBundled()` that return `string | undefined`, which I think made the main function easier to read

I tested out each of these behaviors locally and am happy with the logging and errors