### PR TITLE
Ensure all `Vsc` config is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Development version
 
+- Language server configuration variables are now fully optional, avoiding issues in editors like Zed or Helix (#246).
+
 
 # 0.4.0
 


### PR DESCRIPTION
Closes #246 

I'm _pretty_ sure this fixes the Helix issue, and it also makes similar warnings disappear in Zed's logs (although it didn't crash there...).

I'm unsure if we want to do the "all or nothing" approach or not, but it seems to make sense to me