### PR TITLE
Add config instructions for Helix (#181)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -25,6 +25,7 @@ website:
           - editor-rstudio.qmd
           - editor-vscode.qmd
           - editor-neovim.qmd
+          - editor-helix.qmd
 
       - text: "Configuration"
         href: configuration.qmd

--- a/docs/editor-helix.qmd
+++ b/docs/editor-helix.qmd
@@ -7,14 +7,16 @@ editor:
 ---
 
 [Helix](https://helix-editor.com/) is a modal editor with builtin support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
-Adding support for new language servers is relatively easy via a .toml configuration file.
 
 # Installation
 
-First, install the Air [command line tool](https://posit-dev.github.io/air/cli.html).
-Version `≥0.4.1` of Air is needed for proper Helix support ([#246](https://github.com/posit-dev/air/issues/246)).
+::: callout-note
+## Air ≥0.4.1 is needed for proper Helix support.
+:::
 
-Add the following to your `languages.toml` file:
+First, install the Air [command line tool](https://posit-dev.github.io/air/cli.html).
+
+Add the following to your Helix [languages.toml](https://docs.helix-editor.com/languages.html):
 
 ``` toml
 [language-server.air]
@@ -28,9 +30,9 @@ language-servers = ["air"]
 
 ## `languageserver`
 
-Currently Air only supports formatting.
+Currently, Air only supports formatting.
 It's possible to use Air and [`languageserver`](https://github.com/REditorSupport/languageserver) simultaneously for a better editing experience.
-Use the following configuration to enable both language servers (make sure that `languageserver` is installed, Helix is able to use it without any additional configuration).
+Use the following configuration to enable both language servers (make sure that the `languageserver` R package is installed, Helix is able to use it without any additional configuration).
 
 ``` toml
 [[language]]
@@ -42,7 +44,7 @@ language-servers = ["air", "r"]
 
 ## Format on save
 
-Add `auto-format = true` to your R language configuration block.
+Add `auto-format = true` to your R language configuration block to enable formatting on save.
 
 ``` toml
 [[language]]

--- a/docs/editor-helix.qmd
+++ b/docs/editor-helix.qmd
@@ -6,11 +6,13 @@ editor:
     canonical: true
 ---
 
-[Helix](https://helix-editor.com/) is a modal editor with builtin support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). Adding support for new language servers is relatively easy via a .toml configuration file. 
+[Helix](https://helix-editor.com/) is a modal editor with builtin support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
+Adding support for new language servers is relatively easy via a .toml configuration file.
 
 # Installation
 
-First, install the Air [command line tool](https://posit-dev.github.io/air/cli.html). Version `≥0.4.1` of Air is needed for proper Helix support ([#246](https://github.com/posit-dev/air/issues/246)). 
+First, install the Air [command line tool](https://posit-dev.github.io/air/cli.html).
+Version `≥0.4.1` of Air is needed for proper Helix support ([#246](https://github.com/posit-dev/air/issues/246)).
 
 Add the following to your `languages.toml` file:
 
@@ -26,7 +28,10 @@ language-servers = ["air"]
 
 ## `languageserver`
 
-Currently Air only supports formatting. It's possible to use Air and [`languageserver`](https://github.com/REditorSupport/languageserver) simultaneously for a better editing experience. Use the following configuration to enable both language servers (make sure that `languageserver` is installed, Helix is able to use it without any additional configuration).
+Currently Air only supports formatting.
+It's possible to use Air and [`languageserver`](https://github.com/REditorSupport/languageserver) simultaneously for a better editing experience.
+Use the following configuration to enable both language servers (make sure that `languageserver` is installed, Helix is able to use it without any additional configuration).
+
 ``` toml
 [[language]]
 name = "r"
@@ -39,7 +44,7 @@ language-servers = ["air", "r"]
 
 Add `auto-format = true` to your R language configuration block.
 
-```toml 
+``` toml
 [[language]]
 name = "r"
 language-servers = ["air"]

--- a/docs/editor-helix.qmd
+++ b/docs/editor-helix.qmd
@@ -1,0 +1,47 @@
+---
+title: "Helix"
+editor:
+  markdown:
+    wrap: sentence
+    canonical: true
+---
+
+[Helix](https://helix-editor.com/) is a modal editor with builtin support for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). Adding support for new language servers is relatively easy via a .toml configuration file. 
+
+# Installation
+
+First, install the Air [command line tool](https://posit-dev.github.io/air/cli.html). Version `≥0.4.1` of Air is needed for proper Helix support ([#246](https://github.com/posit-dev/air/issues/246)). 
+
+Add the following to your `languages.toml` file:
+
+``` toml
+[language-server.air]
+command = "air"
+args = ["language-server"]
+
+[[language]]
+name = "r"
+language-servers = ["air"]
+```
+
+## `languageserver`
+
+Currently Air only supports formatting. It's possible to use Air and [`languageserver`](https://github.com/REditorSupport/languageserver) simultaneously for a better editing experience. Use the following configuration to enable both language servers (make sure that `languageserver` is installed, Helix is able to use it without any additional configuration).
+``` toml
+[[language]]
+name = "r"
+language-servers = ["air", "r"]
+```
+
+# Features
+
+## Format on save
+
+Add `auto-format = true` to your R language configuration block.
+
+```toml 
+[[language]]
+name = "r"
+language-servers = ["air"]
+auto-format = true
+```

--- a/docs/editor-neovim.qmd
+++ b/docs/editor-neovim.qmd
@@ -31,7 +31,7 @@ require("lspconfig").air.setup({
 
 While not required, the `BufWritePre` command ensures that Air automatically formats your R code when you save a file.
 
-## languageserver
+## `languageserver`
 
 If both Air and `languageserver` are installed, you can use the following configuration to disable `languageserver` formatting, ensuring that only Air handles formatting:
 

--- a/docs/editors.qmd
+++ b/docs/editors.qmd
@@ -18,3 +18,5 @@ Follow one of our editor specific guides to get set up with Air in your preferre
 -   [RStudio](editor-rstudio.qmd)
 
 -   [Neovim](editor-neovim.qmd)
+
+-   [Helix](editor-helix.qmd)


### PR DESCRIPTION
I've made a simple guide for Helix. It should cover the basic use cases. 

I haven't tested Helix + Air with .qmd files. As far as I know, Helix can't (yet) be configured to be aware of different blocks of code outside of syntax highlighting, so it's a bit uncomfortable to use with language servers, at least for me. Maybe someone else with more experience can comment on this. There's a plugin system in development for Helix that will probably help a lot when it's ready.

Let me know if I missed something!