### PR TITLE
Refine activation events

### DIFF
--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Development version
 
+- The extension now activates automatically when an `air.toml`, `DESCRIPTION`, or `.Rproj` file is detected at the workspace root. Previously, the extension only activated after an R file was opened (#285).
+
 
 ## 0.8.0
 

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Development version
 
-- The extension now activates automatically when an `air.toml`, `DESCRIPTION`, or `.Rproj` file is detected at the workspace root. Previously, the extension only activated after an R file was opened (#285).
+- The extension now activates automatically when an `air.toml`, `DESCRIPTION`, or `.Rproj` file is detected at the workspace root. Previously, the extension only activated after an R file was opened or when an R file was detected at the workspace root level (but not recursively within any subfolder) (#285).
 
 
 ## 0.8.0

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -27,7 +27,7 @@
 	"icon": "air.png",
 	"activationEvents": [
 		"onLanguage:r",
-        "workspaceContains:*.r",
+		"workspaceContains:*.r",
 		"workspaceContains:*.R",
 		"workspaceContains:air.toml",
 		"workspaceContains:.air.toml",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -27,8 +27,10 @@
 	"icon": "air.png",
 	"activationEvents": [
 		"onLanguage:r",
-		"workspaceContains:*.r",
-		"workspaceContains:*.R"
+		"workspaceContains:air.toml",
+		"workspaceContains:.air.toml",
+		"workspaceContains:DESCRIPTION",
+		"workspaceContains:*.Rproj"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -27,6 +27,8 @@
 	"icon": "air.png",
 	"activationEvents": [
 		"onLanguage:r",
+        "workspaceContains:*.r",
+		"workspaceContains:*.R",
 		"workspaceContains:air.toml",
 		"workspaceContains:.air.toml",
 		"workspaceContains:DESCRIPTION",


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/285

I didn't end up adding anything renv related, but I did add `*.Rproj` with the assumption that if you are opening a project that you previously used to open in RStudio, then you probably want Air to activate.