### PR TITLE
docs: add link to GitHub repo?

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -3,6 +3,9 @@ project:
 
 website:
   title: "Air"
+  repo-url: https://github.com/posit-dev/air/
+  repo-subdir: docs
+  repo-actions: [edit, source, issue]
   navbar:
     background: primary
     search: true

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -5,7 +5,7 @@ website:
   title: "Air"
   repo-url: https://github.com/posit-dev/air/
   repo-subdir: docs
-  repo-actions: [edit, source, issue]
+  repo-actions: [source, issue]
   navbar:
     background: primary
     search: true


### PR DESCRIPTION
This would link to the docs source which might be more correct than just the repo. My initial motivation was to easily find Air source from the docs. :slightly_smiling_face: 

https://quarto.org/docs/websites/website-navigation.html#github-links