### PR TITLE
Correct the `PathResolver` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Development version
 
+- Fixed an issue where `air.toml` settings were not being applied to the correct R files (#294).
+
+
 # 0.4.1
 
 - Language server configuration variables are now fully optional, avoiding issues in editors like Zed or Helix (#246).

--- a/crates/workspace/src/resolve.rs
+++ b/crates/workspace/src/resolve.rs
@@ -5,10 +5,6 @@
 //
 //
 
-use std::collections::btree_map::Keys;
-use std::collections::btree_map::Range;
-use std::collections::btree_map::RangeMut;
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// Resolves a [`Path`] to its associated `T`
@@ -20,28 +16,33 @@ use std::path::{Path, PathBuf};
 /// See [`PathResolver::resolve()`] for more details on the implementation.
 #[derive(Debug, Default)]
 pub struct PathResolver<T> {
-    /// Fallback value to be used when a `path` isn't associated with anything in the `map`
+    /// Fallback value to be used when a `path` isn't associated with any `items`
     fallback: T,
 
-    /// An ordered `BTreeMap` from a `path` (normally, a directory) to a `T`
-    map: BTreeMap<PathBuf, T>,
+    /// A sorted vector of `PathItem`. Sorted on the `PathBuf` in increasing order.
+    items: Vec<PathItem<T>>,
 }
 
-pub struct PathResolution<'resolver, T> {
-    /// The `path` in the tree that was closest to the path provided in [`PathResolver::resolve`]
-    path: &'resolver PathBuf,
+#[derive(Debug, Default)]
+pub struct PathItem<T> {
+    /// The `path` that is used for "starts with" matching
+    path: PathBuf,
 
-    /// The `value` in the tree that matches the path provided in [`PathResolver::resolve`]
-    value: &'resolver T,
+    /// The `value` associated with this `path`
+    value: T,
 }
 
-impl<'resolver, T> PathResolution<'resolver, T> {
-    pub fn path(&self) -> &'resolver PathBuf {
-        self.path
+impl<T> PathItem<T> {
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
     }
 
-    pub fn value(&self) -> &'resolver T {
-        self.value
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.value
     }
 }
 
@@ -50,7 +51,7 @@ impl<T> PathResolver<T> {
     pub fn new(fallback: T) -> Self {
         Self {
             fallback,
-            map: BTreeMap::new(),
+            items: Vec::new(),
         }
     }
 
@@ -58,35 +59,78 @@ impl<T> PathResolver<T> {
         &self.fallback
     }
 
-    pub fn add(&mut self, path: &Path, value: T) -> Option<T> {
-        self.map.insert(path.to_path_buf(), value)
+    /// Add a `path` and its `value` into the resolver
+    ///
+    /// The new item is inserted in such a way that the overall vector remains sorted.
+    /// Note that this can be `O(n)` due to the insertion, but we don't anticipate this
+    /// being called very often (in practice, there are very few workspaces open, and very
+    /// few `air.toml` files to look at).
+    ///
+    /// If the `path` already exists, the new `value` is inserted and the old one
+    /// is returned, otherwise `None` is returned.
+    pub fn add<P: Into<PathBuf>>(&mut self, path: P, value: T) -> Option<T> {
+        let path = path.into();
+
+        match self.items.binary_search_by(|item| item.path.cmp(&path)) {
+            Ok(index) => {
+                // `path` already exists! Swap underlying `value` for the new one, return the old one.
+                let item = &mut self.items[index];
+                let value = std::mem::replace(&mut item.value, value);
+                Some(value)
+            }
+            Err(index) => {
+                // `path` is new! Insert new `PathItem` at sorted index to retain overall
+                // ordering.
+                let item = PathItem { path, value };
+                self.items.insert(index, item);
+                None
+            }
+        }
     }
 
-    pub fn remove(&mut self, path: &Path) -> Option<T> {
-        self.map.remove(path)
+    /// Remove a `path` and its `value` from the resolver
+    ///
+    /// Returns `Some(value)` if the `path` existed, otherwise returns `None`.
+    pub fn remove<P: AsRef<Path>>(&mut self, path: P) -> Option<T> {
+        let path = path.as_ref();
+
+        match self
+            .items
+            .binary_search_by(|item| item.path.as_path().cmp(path))
+        {
+            Ok(index) => {
+                // `path` exists! Remove it and return value.
+                let item = self.items.remove(index);
+                Some(item.value)
+            }
+            Err(_) => {
+                // `path` does not exist!
+                None
+            }
+        }
+    }
+
+    pub fn items(&self) -> &[PathItem<T>] {
+        &self.items
     }
 
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.items.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
-    pub fn keys(&self) -> Keys<'_, PathBuf, T> {
-        self.map.keys()
+        self.items.is_empty()
     }
 
     pub fn clear(&mut self) {
-        self.map.clear();
+        self.items.clear();
     }
 
     /// Resolve a [`Path`] to its associated `T`
     ///
     /// This resolver works by finding the closest directory to the `path` to search for.
     ///
-    /// The [`BTreeMap`] is an ordered map, so if you do:
+    /// The internal vector of items is ordered, so if you do:
     ///
     /// ```text
     /// resolver.add("a/b", value1)
@@ -95,29 +139,146 @@ impl<T> PathResolver<T> {
     /// resolver.resolve("a/b/c/test.R")
     /// ```
     ///
-    /// Then it detects both `"a/b"` and `"a/b/c"` as being "less than" the path of
-    /// `"a/b/c/test.R"`, and then chooses `"a/b/c"` because it is at the back of
-    /// that returned sorted list (i.e. the "closest" match).
-    pub fn resolve(&self, path: &Path) -> Option<PathResolution<T>> {
-        self.matches(path)
-            .next_back()
-            .map(|(path, value)| PathResolution { path, value })
+    /// Then we iterate from the end and find the first [PathItem] that forms a prefix for
+    /// the `path` of interest. Because the vector is sorted and we start from the back,
+    /// this will give us the longest path, i.e. the "closest" one to `path`.
+    ///
+    /// The [std::path::Path::starts_with()] method knows that `a/b` is NOT a prefix for
+    /// `a/b.R`, which aligns with our needs.
+    pub fn resolve<P: AsRef<Path>>(&self, path: P) -> Option<&PathItem<T>> {
+        let path = path.as_ref();
+
+        self.items
+            .iter()
+            .rev()
+            .find(|item| path.starts_with(item.path()))
     }
 
     /// Convenience method when you don't care about manually handling the fallback
     /// case and don't need the matched path in the tree
-    pub fn resolve_or_fallback(&self, path: &Path) -> &T {
+    pub fn resolve_or_fallback<P: AsRef<Path>>(&self, path: P) -> &T {
         self.resolve(path)
-            .map_or_else(|| self.fallback(), |resolution| resolution.value())
+            .map_or_else(|| self.fallback(), |item| item.value())
     }
 
     /// Returns all matches matched by the `path` rather than just the closest one
-    pub fn matches(&self, path: &Path) -> Range<'_, PathBuf, T> {
-        self.map.range(..path.to_path_buf())
+    ///
+    /// See [PathResolver::resolve()] for implementation details.
+    ///
+    /// Requires an owned [PathBuf] on input so that we can return a lazy iterator
+    /// that uses it.
+    pub fn matches<P: Into<PathBuf>>(&self, path: P) -> impl Iterator<Item = &PathItem<T>> {
+        let path: PathBuf = path.into();
+
+        self.items
+            .iter()
+            .filter(move |item| path.starts_with(item.path()))
     }
 
     /// Returns all matches matched by the `path` rather than just the closest one
-    pub fn matches_mut(&mut self, path: &Path) -> RangeMut<'_, PathBuf, T> {
-        self.map.range_mut(..path.to_path_buf())
+    ///
+    /// See [PathResolver::resolve()] for implementation details.
+    ///
+    /// Requires an owned [PathBuf] on input so that we can return a lazy iterator
+    /// that uses it.
+    pub fn matches_mut<P: Into<PathBuf>>(
+        &mut self,
+        path: P,
+    ) -> impl Iterator<Item = &mut PathItem<T>> {
+        let path: PathBuf = path.into();
+
+        self.items
+            .iter_mut()
+            .filter(move |item| path.starts_with(item.path()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::resolve::PathResolver;
+
+    #[test]
+    fn test_items_are_added_and_removed_in_sorted_order() {
+        let mut resolver = PathResolver::new(String::from("fallback"));
+
+        resolver.add("/user/c", String::from("c"));
+        resolver.add("/user/a", String::from("a"));
+        resolver.add("/user/b", String::from("b"));
+
+        let items = resolver.items();
+        assert_eq!(items[0].value(), &String::from("a"));
+        assert_eq!(items[1].value(), &String::from("b"));
+        assert_eq!(items[2].value(), &String::from("c"));
+
+        resolver.remove("/user/b");
+
+        let items = resolver.items();
+        assert_eq!(items[0].value(), &String::from("a"));
+        assert_eq!(items[1].value(), &String::from("c"));
+    }
+
+    #[test]
+    fn test_matches_must_be_strict_prefixes() {
+        let mut resolver = PathResolver::new(String::from("fallback"));
+        resolver.add("/user/a", String::from("a"));
+        resolver.add("/user/b", String::from("b"));
+        resolver.add("/user/b/c", String::from("c"));
+
+        // Even though `"/user/a" < "/user/b/c/foo.R"` lexicographically, we should not
+        // return it as a match
+        let mut matches = resolver.matches("/user/b/c/foo.R");
+
+        let item = matches.next().unwrap();
+        assert_eq!(item.value, String::from("b"));
+
+        let item = matches.next().unwrap();
+        assert_eq!(item.value, String::from("c"));
+
+        assert!(matches.next().is_none());
+    }
+
+    #[test]
+    fn test_starts_with_strategy_only_matches_full_components() {
+        let mut resolver = PathResolver::new(0);
+        resolver.add("/user/a", 1);
+
+        // Technically `/user/a.R` "starts with" `/user/a`, but `path.starts_with()`
+        // is smart enough to only look at full components
+        assert!(resolver.resolve("/user/a.R").is_none());
+    }
+
+    #[test]
+    fn test_can_resolve_in_simple_cases() {
+        let mut resolver = PathResolver::new(0);
+        resolver.add("/user/a", 1);
+        resolver.add("/user/b", 2);
+
+        let item = resolver.resolve("/user/a/foo.R").unwrap();
+        assert_eq!(item.path(), PathBuf::from("/user/a").as_path());
+        assert_eq!(item.value(), &1);
+
+        let item = resolver.resolve("/user/b/foo.R").unwrap();
+        assert_eq!(item.path(), PathBuf::from("/user/b").as_path());
+        assert_eq!(item.value(), &2);
+    }
+
+    #[test]
+    fn test_resolves_to_closest_path() {
+        let mut resolver = PathResolver::new(0);
+        resolver.add("/user/b", 1);
+        resolver.add("/user/b/a", 2);
+
+        let item = resolver.resolve("/user/b/foo.R").unwrap();
+        assert_eq!(item.path(), PathBuf::from("/user/b").as_path());
+
+        let item = resolver.resolve("/user/b/b/foo.R").unwrap();
+        assert_eq!(item.path(), PathBuf::from("/user/b").as_path());
+
+        let item = resolver.resolve("/user/b/a/foo.R").unwrap();
+        assert_eq!(item.path(), PathBuf::from("/user/b/a").as_path());
+
+        assert!(resolver.resolve("/user/a/a/foo.R").is_none());
     }
 }


### PR DESCRIPTION
Closes #294 

The problem in #294 is as follows:

I had an `air.toml` in my workspace at `~/files/r/packages/dplyr/air.toml` containing:

```toml
[format]
exclude = ["dummy"]
```

- `~/Desktop/test.R` exists
- `~/files/scratch/test.R` exists
- `~/files/r/packages/dplyr/` was my workspace

Note that lexicographically (C locale) if you sort these you'd get this ordering:

```
~/Desktop/test.R
~/files/r/packages/dplyr/  <- this is the workspace where the settings live
~/files/scratch/test.R
```

If you open the `~/files/r/packages/dplyr/` workspace, and then open these files and save, then `~/files/scratch/test.R` would cause a crash / hang, but `~/Desktop/test.R` would not.

Our path resolver had a bug where it was relying on lexicographical ordering, so when it resolved the settings for `~/files/scratch/test.R` it would compute "give me all settings contained in directories less than `~/files/scratch/test.R` lexicographically", and then it would pop off the last one of those because they were in sorted order and the last would be the longest (and therefore closest) path. This would inadvertently return `~/files/r/packages/dplyr/` as a path match, because `r` is lexicographically less than `scratch`, so we ended up using settings for `~/files/scratch/test.R` from a workspace that isn't actually nested "above" it.

Using the wrong settings confused some other code related to `exclude` that relied on the assumption that the file associated with the settings should be nested under the settings path and we got a crash.

The fix is to rip out the `BTreeMap` underlying the `PathResolver` and replace it with a simpler `Vec` that we keep in sorted order, sorted by the `Path` where the settings are. When we call `resolver.resolve(path)`, this now iterates backwards over the sorted `Vec` until it finds the first instance where `path.starts_with(settings.path())`, i.e. the settings path now has to be a strict ancestor of the file in question for it to get chosen, and iterating backwards again ensures we still pick the "closest" path.

So if you have

```
# These workspaces open
a/b
a/b/c

# This path
a/b/c/d.R

# It will still select `a/b/c`
```

and if you have

```
# This workspace open
a/b

# This path
a/c/d.R

# It will no longer select `a/b` because it is not an ancestor path
```

Also of note, `path.starts_with()` is smart enough to know that `a/b.R` does NOT "start with" `a/b`. It only checks against full path "components". So that's nice.

I've added a full suite of `PathResolver` tests and a new LSP integration test that failed before this change. 