### PR TITLE
Downgrade from Rust 1.85 to 1.83 for cargo-xwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/posit-dev/air"
 keywords = ["parser", "formatter"]
 license = "MIT"
 repository = "https://github.com/posit-dev/air"
-rust-version = "1.85"
+rust-version = "1.83"
 
 [profile.release-with-debug]
 debug = true


### PR DESCRIPTION
When building aarch64-pc-windows-msvc through cargo-xwin I see:

```
building artifacts:
  air-aarch64-pc-windows-msvc.zip
  air-aarch64-pc-windows-msvc.zip.sha256

running rustup to ensure you have aarch64-pc-windows-msvc installed
info: component 'rust-std' for target 'aarch64-pc-windows-msvc' is up to date
building aarch64-pc-windows-msvc target, from x86_64-unknown-linux-gnu host, via cargo-xwin, using cargo profile dist --package=air)
⏬ Downloading MSVC CRT...
✅ Downloaded MSVC CRT in 1m [13](https://github.com/posit-dev/air/actions/runs/14338545513/job/40191874344#step:9:14)s.
error: rustc 1.83.0 is not supported by the following packages:
  air@0.5.0 requires rustc 1.85
  air@0.5.0 requires rustc 1.85
  air_r_factory@0.0.0 requires rustc 1.85
  air_r_formatter@0.0.0 requires rustc 1.85
  air_r_parser@0.0.0 requires rustc 1.85
  air_r_syntax@0.0.0 requires rustc 1.85
  crates@0.0.0 requires rustc 1.85
  crates@0.0.0 requires rustc 1.85
  crates@0.0.0 requires rustc 1.85
  fs@0.0.0 requires rustc 1.85
  lsp@0.0.0 requires rustc 1.85
  workspace@0.1.0 requires rustc 1.85
```

The cargo-xwin docker container is specified here, note how the rust version is set 1.83:
https://github.com/rust-cross/cargo-xwin/blob/618af8308aa24257a8946334a553d24fde11180c/Dockerfile#L1

Now, technically that is a docker ARG, so you can specify the rust version if you are the one calling `docker build`, but cargo-dist sets this up using GitHub Action's built in `container:` support, and that does not have a way for us to specify the docker build arg:
https://github.com/actions/runner/discussions/2019

Here is where the container is actually set (this is a weird github actions ternary arg where the thing right after the `&&` is used if it is truthy, i.e. we end up with `container: matrix.container.image` but no way to set the build arg to use an updated rust version)
https://github.com/posit-dev/air/blob/9fa3c163262d9acc3fd32232e35f2c01567f8a9e/.github/workflows/release.yml#L113

There are a number of options for us:
- Just downgrade the Air Rust version to 1.83 (we are now stuck here until cargo-xwin updates)
- Drop ARM Windows support (Ark and Positron don't have it yet) until we have a github actions arm windows runner
- Find a way to have a custom build job just for ARM Windows (where we'd call `docker build` directly with an arg of rust 1.85). After closer reading of the cargo-dist docs, I think we can actually do this by removing `aarch64-pc-windows-msvc` from dist's known target matrix and instead building it ourselves with something like:

```
# Whether CI should include auto-generated code to build local artifacts dist knows about
build-local-artifacts = true
# Local artifacts jobs to run in CI (in addition to the ones above)
local-artifacts-jobs = ["./build-arm-windows"]
```