### PR TITLE
quarto & rmd need "injected" for conform.nvim/air formatting to work

### DIFF
--- a/docs/editor-neovim.qmd
+++ b/docs/editor-neovim.qmd
@@ -62,8 +62,8 @@ Conform can be configured by adding the following to your `nvim/lua/plugins/conf
 ``` lua
 require("conform").setup({
     formatters_by_ft = {
-        quarto = { "injected", "prettier" },
-        rmd = { "injected", "prettier" },
+        quarto = { "injected" },
+        rmd = { "injected" },
         r = { "air" },
     },
 })

--- a/docs/editor-neovim.qmd
+++ b/docs/editor-neovim.qmd
@@ -62,6 +62,8 @@ Conform can be configured by adding the following to your `nvim/lua/plugins/conf
 ``` lua
 require("conform").setup({
     formatters_by_ft = {
+        quarto = { "injected", "prettier" },
+        rmd = { "injected", "prettier" },
         r = { "air" },
     },
 })


### PR DESCRIPTION
I believe the minimal configuration in the documentation with nvim won't actually work unless `"injected"` is used. At least it didn't work on my setup.

@PMassicotte what do you think?
