### PR TITLE
Implement `Format Workspace Folder` command 

### DIFF
--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -66,7 +66,7 @@ If you run `air format` with a working directory of `~/packages/dplyr` or open y
 Air also supports walking up the directory tree from the project root.
 For example, if you ran `air format` from within `~/packages/dplyr/R`, then Air would look "up" one directory and would find and use `~/packages/dplyr/air.toml`.
 
-## Settings synchronization
+## Settings synchronization {#configuration-settings-synchronization}
 
 In IDEs that support synchronization (VS Code and Positron currently), Air does its best to ensure that the formatter and the IDE are in agreement.
 This is supported by two mechanisms:

--- a/docs/editor-vscode.qmd
+++ b/docs/editor-vscode.qmd
@@ -40,6 +40,14 @@ Formatting a selection may *expand* that selection to find the nearest complete 
 
 <!--# Come back and add video -->
 
+## Format workspace folder
+
+Air ships with a special `Air: Format Workspace Folder` command to format all R files within a workspace folder.
+This is particularly useful when transitioning an existing project over to Air, where you need to perform a project-wide format before utilizing the per-file format on save feature.
+
+Note that if you don't have an `air.toml` in your project, then this command will use Air's default settings rather than the IDE [settings synchronization mechanism](configuration.qmd#configuration-settings-synchronization).
+We recommend using `usethis::use_air()` to set up an `air.toml` (among other things) before running this command.
+
 ## Quarto
 
 Quarto can automatically invoke Air on R code cells when the [Quarto extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) is active.

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Development version
 
+- New `Air: Format Workspace Folder` command to format an entire project (similar to running `air format {folder}` at the command line). Combined with `usethis::use_air()`, this is the easiest way to transition an existing project to use Air (#312)!
+
 
 ## 0.10.0
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -117,6 +117,11 @@
 				"command": "air.restart"
 			},
 			{
+				"title": "Format Workspace Folder",
+				"category": "Air",
+				"command": "air.workspaceFolderFormatting"
+			},
+			{
 				"title": "View Tree Sitter",
 				"category": "Air",
 				"command": "air.viewTreeSitter"

--- a/editors/code/src/command/workspace-folder-formatting.ts
+++ b/editors/code/src/command/workspace-folder-formatting.ts
@@ -199,16 +199,12 @@ async function saveAllDirtyWorkspaceTextDocuments(
 		return false;
 	}
 
-	for (const textDocument of textDocuments) {
-		const saved = await textDocument.save();
-
-		if (!saved) {
-			// Somehow a document failed to save, bail
-			return false;
-		}
-	}
-
-	return true;
+	// Save all documents, and ensure that all successfully saved
+	const savedPromises = textDocuments.map((textDocument) =>
+		textDocument.save(),
+	);
+	const saved = await Promise.all(savedPromises);
+	return saved.every((save) => save);
 }
 
 function dirtyWorkspaceTextDocuments(

--- a/editors/code/src/command/workspace-folder-formatting.ts
+++ b/editors/code/src/command/workspace-folder-formatting.ts
@@ -1,0 +1,228 @@
+import * as cp from "child_process";
+import * as vscode from "vscode";
+
+import { Cmd, Ctx } from "../context";
+import * as output from "../output";
+
+/**
+ * Format a workspace folder
+ *
+ * # Workspace folder selection
+ *
+ * - If 0 workspace folders are open, errors
+ * - If 1 workspace folder is open, automatically uses it
+ * - If >1 workspace folders are open, asks the user to choose
+ *
+ * # Tab closing
+ *
+ * Because we use the embedded Air CLI to perform the formatting, we force all
+ * relevant tabs to be saved and closed before proceeding. This has two main
+ * benefits:
+ *
+ * - The Air CLI can't know about any in-memory changes that may have occurred
+ *   in "dirty" editors. Forcing them to save and close causes any changes
+ *   to be written to disk first, syncing VS Code with the CLI.
+ *
+ * - The LSP server part of Air needs to perfectly track changes for any open
+ *   files. Closing the tabs first switches the server's "source of truth" from
+ *   the client version of the file to the on-disk version of the file, which
+ *   should ensure the LSP server won't have any chance of getting out of sync.
+ *   This may be overkill, since the LSP server seems to handle git branch
+ *   changes well, but it's still not a bad idea.
+ *
+ * # Forward propagation of settings
+ *
+ * If no `air.toml` is tied to a document, then typically in the LSP document
+ * settings are forward propagated from the client to the server, and those are
+ * used during formatting when that document is open. If an `air.toml` does
+ * exist, those settings override document settings.
+ *
+ * Because we go through the Air CLI here, forward propagated document settings
+ * are ignored, so even if you don't have an `air.toml`, you will get Air's
+ * default indentation settings.
+ *
+ * We can't simply require an `air.toml` at the workspace folder root to avoid
+ * confusion here, because you may instead have an `air.toml` at
+ * `{root}/R/air.toml` that would handle any R files in your project. Instead,
+ * we hope this isn't common enough to come up much in practice.
+ */
+export function workspaceFolderFormatting(ctx: Ctx): Cmd {
+	return async () => {
+		const binaryPath = ctx.lsp.getBinaryPath();
+
+		const workspaceFolder = await selectWorkspaceFolder();
+		if (!workspaceFolder) {
+			return;
+		}
+
+		const allTabsClosed = await closeAllTabs(workspaceFolder);
+		if (!allTabsClosed) {
+			return;
+		}
+
+		const workspaceFolderPath = workspaceFolder.uri.fsPath;
+
+		let stderr = "";
+		let anyErrors = false;
+
+		// i.e., `air format {workspaceFolderPath} --no-color`
+		const args = ["format", workspaceFolderPath, "--no-color"];
+
+		// This should not matter since the path is explicitly supplied, but better to be safe
+		const options = {
+			cwd: workspaceFolderPath,
+		};
+
+		// A promise that resolves when the spawned process closes or errors
+		const finishedFormatting = new Promise<void>((resolve) => {
+			// Use spawn instead of exec to avoid maxBufferExceeded error
+			const p = cp.spawn(binaryPath, args, options);
+
+			p.stderr.setEncoding("utf8");
+			p.stderr.on("data", (data) => (stderr += data));
+
+			p.on("error", () => {
+				anyErrors = true;
+				return resolve();
+			});
+
+			p.on("close", (code) => {
+				if (code !== 0) {
+					anyErrors = true;
+				}
+				return resolve();
+			});
+		});
+
+		await finishedFormatting;
+
+		if (anyErrors) {
+			output.log(
+				`Errors occurred while formatting the ${workspaceFolder.name} workspace folder.\n${stderr}`,
+			);
+
+			const answer = await vscode.window.showInformationMessage(
+				`Errors occurred while formatting the ${workspaceFolder.name} workspace folder. View the logs?`,
+				{ modal: true },
+				"Yes",
+				"No",
+			);
+
+			if (answer === "Yes") {
+				output.show();
+			}
+
+			return;
+		}
+
+		vscode.window.showInformationMessage(
+			`Successfully formatted the ${workspaceFolder.name} workspace folder.`,
+		);
+	};
+}
+
+async function selectWorkspaceFolder(): Promise<
+	vscode.WorkspaceFolder | undefined
+> {
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		vscode.window.showErrorMessage(
+			"You must be inside a workspace to format a workspace folder.",
+		);
+		return undefined;
+	}
+
+	if (workspaceFolders.length === 1) {
+		return workspaceFolders[0];
+	}
+
+	// Let the user select a workspace folder if >1 are open, may be
+	// `undefined` if user bails from quick pick!
+	const workspaceFolder =
+		await selectWorkspaceFolderFromQuickPick(workspaceFolders);
+
+	return workspaceFolder;
+}
+
+async function selectWorkspaceFolderFromQuickPick(
+	workspaceFolders: readonly vscode.WorkspaceFolder[],
+): Promise<vscode.WorkspaceFolder | undefined> {
+	// Show the workspace names
+	const workspaceFolderNames = workspaceFolders.map(
+		(workspaceFolder) => workspaceFolder.name,
+	);
+
+	const workspaceFolderName = await vscode.window.showQuickPick(
+		workspaceFolderNames,
+		{
+			canPickMany: false,
+			title: "Which workspace folder should be formatted?",
+		},
+	);
+
+	if (!workspaceFolderName) {
+		// User bailed from the quick pick
+		return undefined;
+	}
+
+	// Match selected name back to the workspace folder
+	for (let workspaceFolder of workspaceFolders) {
+		if (workspaceFolder.name === workspaceFolderName) {
+			return workspaceFolder;
+		}
+	}
+
+	// Should never get here
+	output.log(
+		`Matched a workspace folder name, but unexpectedly can't find corresponding workspace folder. Folder name: ${workspaceFolderName}.`,
+	);
+	return undefined;
+}
+
+/**
+ * Close all open editor tabs relevant to the workspace folder
+ *
+ * - Filters to only tabs living under the chosen workspace folder
+ * - Asks the user if they are okay with us closing the editor tabs
+ * - Asks the user to save or discard any dirty editor tabs
+ */
+async function closeAllTabs(
+	workspaceFolder: vscode.WorkspaceFolder,
+): Promise<boolean> {
+	// Collect all tabs from all tab groups
+	const allTabs = vscode.window.tabGroups.all.flatMap((group) => group.tabs);
+
+	// Filter down to only tabs containing a text based resource who's uri
+	// prefix matches the workspace folder we are going to format. This way
+	// we don't have to close anything outside the workspace folder.
+	const allRelevantTabs = allTabs.filter((tab) => {
+		const input = tab.input;
+
+		if (!(input instanceof vscode.TabInputText)) {
+			return false;
+		}
+
+		return input.uri.fsPath.startsWith(workspaceFolder.uri.fsPath);
+	});
+
+	if (allRelevantTabs.length === 0) {
+		// Nothing to close!
+		return true;
+	}
+
+	const answer = await vscode.window.showInformationMessage(
+		`All editors within the ${workspaceFolder.name} workspace folder must be closed before formatting. Proceed with closing these editors?`,
+		{ modal: true },
+		"Yes",
+		"No",
+	);
+
+	if (answer !== "Yes") {
+		// User said `"No"` or bailed from the menu
+		return false;
+	}
+
+	// Close all tabs at once, each dirty tab will prompt the user to save or discard any changes
+	return await vscode.window.tabGroups.close(allRelevantTabs);
+}

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -5,12 +5,20 @@ import AdmZip from "adm-zip";
 import { Cmd, Ctx } from "./context";
 import { viewFileUsingTextDocumentContentProvider } from "./request/viewFile";
 import { VIEW_FILE } from "./request/viewFile";
+import { workspaceFolderFormatting } from "./command/workspace-folder-formatting";
 
 export function registerCommands(ctx: Ctx) {
 	ctx.extension.subscriptions.push(
 		vscode.commands.registerCommand(
 			"air.restart",
 			async () => await ctx.lsp.restart(),
+		),
+	);
+
+	ctx.extension.subscriptions.push(
+		vscode.commands.registerCommand(
+			"air.workspaceFolderFormatting",
+			workspaceFolderFormatting(ctx),
 		),
 	);
 

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -22,11 +22,11 @@ enum State {
 }
 
 export class Lsp {
-	public client: lc.LanguageClient | null = null;
+	private client: lc.LanguageClient | null = null;
 
 	// We've received and processed an `air.toml` settings synchronization
 	// notification. Used to synchronize unit tests with the LSP.
-	public onSettingsNotification: vscode.Event<SyncFileSettingsParams>;
+	private onSettingsNotification: vscode.Event<SyncFileSettingsParams>;
 
 	// We use the same output channel for all LSP instances (e.g. a new instance
 	// after a restart) to avoid having multiple channels in the Output viewpane.

--- a/editors/code/src/output.ts
+++ b/editors/code/src/output.ts
@@ -8,6 +8,10 @@ class OutputChannelLogger {
 	public log(...data: Arguments): void {
 		this.channel.appendLine(util.format(...data));
 	}
+
+	public show() {
+		this.channel.show();
+	}
 }
 
 let channel: OutputChannelLogger | undefined;
@@ -20,7 +24,7 @@ export function registerLogger(logChannel: OutputChannel): Disposable {
 	};
 }
 
-/*
+/**
  * Free function for logging to the global output channel shared with the server
  *
  * Adapted from:
@@ -31,4 +35,11 @@ export function log(...args: Arguments): void {
 		console.log(...args);
 	}
 	channel?.log(...args);
+}
+
+/**
+ * Free function for showing the global output channel shared with the server
+ */
+export function show() {
+	channel?.show();
 }

--- a/editors/code/src/process.ts
+++ b/editors/code/src/process.ts
@@ -1,0 +1,71 @@
+import * as cp from "child_process";
+
+export interface CommandResult {
+	type: "result";
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+export interface CommandError {
+	type: "error";
+	error: Error;
+}
+
+export function isResult(
+	result: CommandResult | CommandError,
+): result is CommandResult {
+	return result.type == "result";
+}
+
+export function isError(
+	result: CommandResult | CommandError,
+): result is CommandError {
+	return result.type == "error";
+}
+
+/**
+ * Spawns a process and runs a command
+ *
+ * Collects stdout and stderr emitted along the way.
+ *
+ * @returns Returns a promise that results when the process exits or errors
+ */
+export async function runCommand(
+	command: string,
+	args?: readonly string[],
+	options?: cp.SpawnOptionsWithoutStdio,
+): Promise<CommandResult | CommandError> {
+	return new Promise<CommandResult | CommandError>((resolve) => {
+		let stdout = "";
+		let stderr = "";
+
+		// Use spawn instead of exec to avoid maxBufferExceeded error
+		const p = cp.spawn(command, args, options);
+
+		p.stdout.setEncoding("utf8");
+		p.stdout.on("data", (data) => (stdout += data));
+
+		p.stderr.setEncoding("utf8");
+		p.stderr.on("data", (data) => (stderr += data));
+
+		// `error` should fire before `close` in the event both fire.
+		// `error` should also fire no matter what.
+		p.on("error", (error) => {
+			return resolve({
+				type: "error",
+				error: error,
+			});
+		});
+
+		// Use `close` to wait for stdio streams to close too
+		p.on("close", (code) => {
+			return resolve({
+				type: "result",
+				code: code,
+				stdout: stdout,
+				stderr: stderr,
+			});
+		});
+	});
+}


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/274

This PR implements a new VS Code / Positron specific command - `Format Workspace Folder`

The goal of this feature is to allow existing projects to adopt Air without having to leave the IDE or download a separate binary. The upcoming way to adopt Air in a project in Positron (where the extension will be already installed!!) looks like:
- `usethis::use_air()`
- `Air: Format Workspace Folder`
- Commit and push

Compare that with what we've been recommending:
- **Terminal:** Install Air CLI (ugh)
- Install Air OpenVSX Extension
- `usethis::use_air()`
- **Terminal:** `air format .` one time using the Air CLI to get the whole project in order
- Commit and push

Removing the terminal from the equation is a big win IMO. And removing the unnecessary separate binary install is also a big win, especially for first adoption where it should be insanely simple to get going.


https://github.com/user-attachments/assets/a09b07fc-34f1-4b32-b0cb-fd9be884ee44



## A CLI based approach

We've landed on using the embedded Air CLI as the engine for this feature. Notably we must first save and close all editors that live under the chosen workspace folder before calling the CLI, which ensures that any "dirty" editor contents are written to disk before calling the CLI. Ideally this means that the CLI, the LSP client, and the Air LSP server all stay in sync and use the on-disk contents as their "source of truth".

## Alternative 1 - UI open / format / save / close

There are extensions out there that "format a whole directory" for you. But those:
- Are extremely slow with large projects
- Will format non-R related files as well

Ultimately they just use vs code typescript apis to do:

```
for file in directory {
  openFile(file)
  formatFile(file)
  saveFile(file)
  closeFile(file)
}
```

This results in a very bad user experience IMO.

## Alternative 2 - Why not use a `WorkspaceEdit`?

While the LSP does not have official support for "Format a whole workspace folder", there is a concept of a multi-file `WorkspaceEdit`. Think of it as being able to supply `Vec<(Uri, TextEdit[])>` all at once as a bulk change.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit

I explored that in great depth in this PR https://github.com/posit-dev/air/pull/310, specifically in:

https://github.com/posit-dev/air/compare/535b5bfe00adbd4f3142b421875a07fd8dcf849a..8cd4a69d5b007aaa13063f0fc980e2c6a4639069

This does have the benefit of being fully in spec, but the actual implementation of it made me too nervous:

- It requires setting the metadata `isRefactoring: true` to avoid _opened_ all unsaved changed files for the user to manually review and save and close. While `WorkspaceEdit` is old, `WorkspaceEditMetadata` is only a [proposed feature of 3.18](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspaceEditMetadata) right now. I worked around this by calling the VS Code extension API of `vscode.workspace.applyEdit()` directly, which is the extension API equivalent of the LSP command, but it's still annoying.

- Even with `isRefactoring: true`, if you change exactly 1 file it will still open in a "dirty" state due to https://github.com/microsoft/vscode/issues/246720, meh.

- I think `WorkspaceEdit` is intended for large scale _refactoring_ but not necessarily _formatting_. Unfortunately when it applies the edit it performs a save action that _triggers formatting a second time_, because it has no way to know the edit itself was already a formatting edit. https://github.com/microsoft/vscode/issues/246720#issuecomment-2813296884

- It's just slow. Running it on `r-svn` which changes ~800 files at once will sometimes cause the editor to hang entirely. I couldn't figure out if it was because our diff algorithm was slow (which the CLI doesn't use at all), or if VS Code was having trouble processing such a huge batch of edits. It's entirely possible this is Air's fault, but it was enough to put me off the idea.