### PR TITLE
Revise `Parse` implementation for usage in `Document`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,18 +30,13 @@ dependencies = [
 name = "air"
 version = "0.5.0"
 dependencies = [
- "air_r_formatter",
- "air_r_parser",
  "anyhow",
- "biome_formatter",
- "biome_parser",
  "clap",
  "colored",
  "crates",
  "fs",
  "ignore",
  "itertools",
- "line_ending",
  "lsp",
  "tempfile",
  "thiserror 2.0.5",
@@ -2903,6 +2898,7 @@ name = "workspace"
 version = "0.1.0"
 dependencies = [
  "air_r_formatter",
+ "air_r_parser",
  "anyhow",
  "biome_formatter",
  "fs",

--- a/crates/air/Cargo.toml
+++ b/crates/air/Cargo.toml
@@ -12,18 +12,13 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-air_r_formatter = { workspace = true }
-air_r_parser = { workspace = true }
 anyhow = { workspace = true }
-biome_formatter = { workspace = true }
-biome_parser = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }
 colored = { workspace = true }
 crates = { workspace = true }
 fs = { workspace = true }
 ignore = { workspace = true }
 itertools = { workspace = true }
-line_ending = { workspace = true }
 lsp = { workspace = true }
 thiserror = { workspace = true }
 tokio = "1.41.1"

--- a/crates/air/src/commands/format.rs
+++ b/crates/air/src/commands/format.rs
@@ -185,12 +185,12 @@ pub(crate) fn format_source(
 ) -> std::result::Result<FormattedSource, FormatSourceError> {
     let parsed = air_r_parser::parse(source, RParserOptions::default());
 
-    if parsed.has_errors() {
-        let error = parsed.into_errors().into_iter().next().unwrap();
-        return Err(error.into());
-    }
+    let parsed = match parsed.into_result() {
+        Ok(parsed) => parsed,
+        Err(err) => return Err(err.into()),
+    };
 
-    let formatted = air_r_formatter::format_node(options, &parsed.syntax())?;
+    let formatted = air_r_formatter::format_node(options, &parsed)?;
     let formatted = formatted.print()?;
     let formatted = formatted.into_code();
 

--- a/crates/air_r_formatter/tests/quick_test.rs
+++ b/crates/air_r_formatter/tests/quick_test.rs
@@ -4,8 +4,6 @@ use air_r_formatter::format_node;
 use air_r_formatter::RFormatLanguage;
 use air_r_parser::parse;
 use air_r_parser::RParserOptions;
-use air_r_syntax::RRoot;
-use biome_rowan::AstNode;
 use settings::IndentStyle;
 use settings::LineWidth;
 
@@ -29,7 +27,7 @@ fn quick_test() {
         .with_indent_style(IndentStyle::Space)
         .with_line_width(LineWidth::try_from(80).unwrap());
 
-    if parse.has_errors() {
+    if parse.has_error() {
         panic!("Can't format when there are parse errors.");
     }
 
@@ -37,7 +35,7 @@ fn quick_test() {
     let result = formatted.print().unwrap();
 
     println!("---- Parser Representation ----");
-    println!("{:#?}", RRoot::unwrap_cast(parse.syntax()));
+    println!("{:#?}", parse.tree());
     println!("---- IR Representation ----");
     println!("{}", formatted.into_document());
     println!();

--- a/crates/air_r_parser/src/error.rs
+++ b/crates/air_r_parser/src/error.rs
@@ -25,7 +25,6 @@ impl ParseError {
     }
 }
 
-// Just for usage in `spec_test.rs`
 impl From<ParseError> for ParseDiagnostic {
     fn from(error: ParseError) -> Self {
         let span: Option<TextRange> = None;

--- a/crates/air_r_parser/src/error.rs
+++ b/crates/air_r_parser/src/error.rs
@@ -1,35 +1,34 @@
-use biome_diagnostics::Diagnostic;
 use biome_parser::prelude::ParseDiagnostic;
+use biome_rowan::TextRange;
 
 /// An error that occurs during parsing
 ///
-/// Simply wraps a `ParseDiagnostic`, mainly so we can implement
-/// `std::error::Error` for it, which it oddly does not implement.
+/// Replacement for [biome_parser::ParseDiagnostic], mainly so we can implement
+/// [std::error::Error], which it oddly does not implement.
 #[derive(Debug, Clone)]
 pub struct ParseError {
-    inner: ParseDiagnostic,
+    message: String,
 }
 
 impl std::error::Error for ParseError {}
 
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.diagnostic().description(f)
+        f.write_str(&self.message)
     }
 }
 
 impl ParseError {
-    pub fn diagnostic(&self) -> &ParseDiagnostic {
-        &self.inner
-    }
-
-    pub fn into_diagnostic(self) -> ParseDiagnostic {
-        self.inner
+    // Not exposed outside of this crate!
+    pub(crate) fn new(message: String) -> Self {
+        Self { message }
     }
 }
 
-impl From<ParseDiagnostic> for ParseError {
-    fn from(diagnostic: ParseDiagnostic) -> Self {
-        Self { inner: diagnostic }
+// Just for usage in `spec_test.rs`
+impl From<ParseError> for ParseDiagnostic {
+    fn from(error: ParseError) -> Self {
+        let span: Option<TextRange> = None;
+        ParseDiagnostic::new(error.message, span)
     }
 }

--- a/crates/air_r_parser/src/parse.rs
+++ b/crates/air_r_parser/src/parse.rs
@@ -1,15 +1,12 @@
-use std::marker::PhantomData;
-
-use air_r_syntax::RLanguage;
 use air_r_syntax::RRoot;
 use air_r_syntax::RSyntaxKind;
 use air_r_syntax::RSyntaxNode;
 use biome_parser::event::Event;
-use biome_parser::prelude::ParseDiagnostic;
 use biome_parser::prelude::Trivia;
 use biome_parser::AnyParse;
 use biome_rowan::AstNode;
 use biome_rowan::NodeCache;
+use biome_rowan::SendNode;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use biome_rowan::TriviaPieceKind;
@@ -24,107 +21,84 @@ use crate::RLosslessTreeSink;
 use crate::RParserOptions;
 
 /// A utility struct for managing the result of a parser job
-#[derive(Debug, Clone)]
-pub struct Parse<T> {
-    root: RSyntaxNode,
-    errors: Vec<ParseError>,
-    _ty: PhantomData<T>,
+///
+/// This struct holds a handle to the root node of the parsed syntax tree, along with a
+/// possible error emitted by the parser while generating this entry.
+///
+/// It can be dynamically downcast into a concrete [RSyntaxNode] or [RRoot].
+///
+/// It can be sent or shared between threads.
+///
+/// This type is the same as [biome_parser::AnyParse], except it uses our [ParseError]
+/// error type rather than [biome_parser::ParseDiagnostic], since oddly that doesn't
+/// implement [std::error::Error] and we need that to compose with other errors.
+#[derive(Clone, Debug)]
+pub struct Parse {
+    root: SendNode,
+    error: Option<ParseError>,
 }
 
-impl<T> Parse<T> {
-    pub fn new(root: RSyntaxNode, errors: Vec<ParseError>) -> Parse<T> {
-        Parse {
-            root,
-            errors,
-            _ty: PhantomData,
-        }
-    }
-
-    pub fn cast<N: AstNode<Language = RLanguage>>(self) -> Option<Parse<N>> {
-        if N::can_cast(self.syntax().kind()) {
-            Some(Parse::new(self.root, self.errors))
-        } else {
-            None
-        }
+impl Parse {
+    fn new(root: RSyntaxNode, error: Option<ParseError>) -> Parse {
+        // Safety: This method is not exposed, we only use it internally
+        let root = root.as_send().unwrap();
+        Parse { root, error }
     }
 
     /// The syntax node represented by this Parse result
     pub fn syntax(&self) -> RSyntaxNode {
-        self.root.clone()
+        self.root
+            .clone()
+            .into_node()
+            .unwrap_or_else(|| panic!("Could not downcast root node to R language"))
     }
 
-    /// Get the errors which occurred when parsing
-    pub fn errors(&self) -> &[ParseError] {
-        self.errors.as_slice()
+    /// Convert this parse result into a typed AST node
+    pub fn tree(&self) -> RRoot {
+        RRoot::unwrap_cast(self.syntax())
     }
 
-    /// Get the errors which occurred when parsing
-    pub fn into_errors(self) -> Vec<ParseError> {
-        self.errors
+    /// Convert this parse result into a [Result]
+    pub fn into_result(self) -> Result<RSyntaxNode, ParseError> {
+        match self.error {
+            Some(err) => Err(err),
+            None => Ok(self.syntax()),
+        }
+    }
+
+    /// Get the error which occurred when parsing
+    pub fn error(&self) -> Option<&ParseError> {
+        self.error.as_ref()
+    }
+
+    /// Get the error which occurred when parsing
+    pub fn into_error(self) -> Option<ParseError> {
+        self.error
     }
 
     /// Returns [true] if the parser encountered some errors during the parsing.
-    pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
+    pub fn has_error(&self) -> bool {
+        self.error.is_some()
     }
 }
 
-impl<T: AstNode<Language = RLanguage>> Parse<T> {
-    /// Convert this parse result into a typed AST node.
-    ///
-    /// # Panics
-    /// Panics if the node represented by this parse result mismatches.
-    pub fn tree(&self) -> T {
-        self.try_tree().unwrap_or_else(|| {
-            panic!(
-                "Expected tree to be a {} but root is:\n{:#?}",
-                std::any::type_name::<T>(),
-                self.syntax()
-            )
-        })
-    }
-
-    /// Try to convert this parse's untyped syntax node into an AST node.
-    pub fn try_tree(&self) -> Option<T> {
-        T::cast(self.syntax())
-    }
-
-    /// Convert this parse into a result
-    pub fn into_result(self) -> Result<T, Vec<ParseError>> {
-        if !self.has_errors() {
-            Ok(self.tree())
-        } else {
-            Err(self.errors)
-        }
+impl From<Parse> for AnyParse {
+    fn from(parse: Parse) -> Self {
+        let root = parse.root;
+        let diagnostics = match parse.error {
+            Some(error) => vec![error.into()],
+            None => vec![],
+        };
+        Self::new(root, diagnostics)
     }
 }
 
-impl<T> From<Parse<T>> for AnyParse {
-    fn from(parse: Parse<T>) -> Self {
-        let root = parse.syntax();
-        let errors = parse.into_errors();
-        let diagnostics = errors
-            .into_iter()
-            .map(ParseError::into_diagnostic)
-            .collect();
-        Self::new(
-            // SAFETY: the parser should always return a root node
-            root.as_send().unwrap(),
-            diagnostics,
-        )
-    }
-}
-
-pub fn parse(text: &str, options: RParserOptions) -> Parse<RRoot> {
+pub fn parse(text: &str, options: RParserOptions) -> Parse {
     let mut cache = NodeCache::default();
     parse_r_with_cache(text, options, &mut cache)
 }
 
-pub fn parse_r_with_cache(
-    text: &str,
-    options: RParserOptions,
-    cache: &mut NodeCache,
-) -> Parse<RRoot> {
+pub fn parse_r_with_cache(text: &str, options: RParserOptions, cache: &mut NodeCache) -> Parse {
     tracing::debug_span!("parse").in_scope(move || {
         let (events, tokens, errors) = parse_text(text, options);
 
@@ -145,7 +119,7 @@ pub fn parse_r_with_cache(
 pub fn parse_text(
     text: &str,
     _options: RParserOptions,
-) -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Vec<ParseError>) {
+) -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Option<ParseError>) {
     let mut parser = tree_sitter::Parser::new();
     parser
         .set_language(&tree_sitter_r::LANGUAGE.into())
@@ -163,7 +137,7 @@ pub fn parse_text(
     parse_tree(ast, text)
 }
 
-fn parse_failure() -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Vec<ParseError>) {
+fn parse_failure() -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Option<ParseError>) {
     // Must provide a root node on failures, otherwise `tree_sink.finish()` fails
     let events = vec![
         Event::Start {
@@ -176,23 +150,22 @@ fn parse_failure() -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Vec<ParseError>) {
     // No trivia
     let trivia = vec![];
 
-    // Generate a single diagnostic, wrap it in our error type
-    let span: Option<TextRange> = None;
-    let diagnostic = ParseDiagnostic::new("Failed to parse due to syntax errors.", span);
-    let error = ParseError::from(diagnostic);
-    let errors = vec![error];
+    // Single parse error for now
+    let error = ParseError::new(String::from("Failed to parse due to syntax errors."));
 
-    (events, trivia, errors)
+    (events, trivia, Some(error))
 }
 
-fn parse_tree(ast: Tree, text: &str) -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Vec<ParseError>) {
+fn parse_tree(ast: Tree, text: &str) -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Option<ParseError>) {
     let mut walker = RWalk::new(text);
 
     let root = ast.root_node();
     let mut iter = root.preorder();
     walker.walk(&mut iter);
 
-    walker.parse.drain()
+    let (events, trivia) = walker.parse.drain();
+
+    (events, trivia, None)
 }
 
 /// Given an ast with absolutely no ERROR or MISSING nodes, let's walk that tree
@@ -1065,7 +1038,6 @@ impl<'src> RWalk<'src> {
 struct RParse {
     events: Vec<Event<RSyntaxKind>>,
     trivia: Vec<Trivia>,
-    errors: Vec<ParseError>,
 }
 
 impl RParse {
@@ -1073,7 +1045,6 @@ impl RParse {
         Self {
             events: Vec::new(),
             trivia: Vec::new(),
-            errors: Vec::new(),
         }
     }
 
@@ -1100,8 +1071,8 @@ impl RParse {
         self.trivia.push(trivia);
     }
 
-    fn drain(self) -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>, Vec<ParseError>) {
-        (self.events, self.trivia, self.errors)
+    fn drain(self) -> (Vec<Event<RSyntaxKind>>, Vec<Trivia>) {
+        (self.events, self.trivia)
     }
 
     // TODO!: Need to handle comments too. It will be like `derive_trivia()`

--- a/crates/lsp/src/documents.rs
+++ b/crates/lsp/src/documents.rs
@@ -28,7 +28,7 @@ pub struct Document {
 
     /// We store the syntax tree in the document for now.
     /// We will think about laziness and incrementality in the future.
-    pub parse: biome_parser::AnyParse,
+    pub parse: air_r_parser::Parse,
 
     /// The version of the document we last synchronized with.
     /// None if the document hasn't been synchronized yet.
@@ -73,7 +73,7 @@ impl Document {
         };
 
         // Parse document immediately for now
-        let parse = air_r_parser::parse(&contents, Default::default()).into();
+        let parse = air_r_parser::parse(&contents, Default::default());
 
         Self {
             contents,
@@ -128,7 +128,7 @@ impl Document {
         );
 
         // No incrementality for now
-        let parse = air_r_parser::parse(&contents, Default::default()).into();
+        let parse = air_r_parser::parse(&contents, Default::default());
 
         self.parse = parse;
         self.contents = contents;

--- a/crates/lsp/src/handlers_ext.rs
+++ b/crates/lsp/src/handlers_ext.rs
@@ -46,7 +46,7 @@ pub(crate) fn view_file(params: ViewFileParams, state: &WorldState) -> anyhow::R
         }
 
         ViewFileKind::SyntaxTree => {
-            if doc.parse.has_errors() {
+            if doc.parse.has_error() {
                 return Ok(String::from("*Parse error*"));
             }
 
@@ -55,7 +55,7 @@ pub(crate) fn view_file(params: ViewFileParams, state: &WorldState) -> anyhow::R
         }
 
         ViewFileKind::FormatTree => {
-            if doc.parse.has_errors() {
+            if doc.parse.has_error() {
                 return Ok(String::from("*Parse error*"));
             }
 

--- a/crates/lsp/src/handlers_format.rs
+++ b/crates/lsp/src/handlers_format.rs
@@ -5,11 +5,12 @@
 //
 //
 
-use air_r_formatter::format_node;
 use air_r_syntax::{RExpressionList, RSyntaxKind, RSyntaxNode, WalkEvent};
 use biome_rowan::{AstNode, Language, SyntaxElement};
 use biome_text_size::{TextRange, TextSize};
 use tower_lsp::lsp_types;
+use workspace::format::format_source_with_parse;
+use workspace::format::FormattedSource;
 
 use crate::file_patterns::is_document_excluded_from_formatting;
 use crate::main_loop::LspState;
@@ -51,11 +52,15 @@ pub(crate) fn document_formatting(
     }
 
     let format_options = workspace_settings.to_format_options(&doc.contents, &doc.settings);
-    let formatted = format_node(format_options, &doc.parse.syntax())?;
-    let output = formatted.print()?.into_code();
 
-    let edits = to_proto::replace_all_edit(&doc.line_index, &doc.contents, &output)?;
-    Ok(Some(edits))
+    match format_source_with_parse(&doc.contents, &doc.parse, format_options)? {
+        FormattedSource::Changed(formatted) => Ok(Some(to_proto::replace_all_edit(
+            &doc.line_index,
+            &doc.contents,
+            &formatted,
+        )?)),
+        FormattedSource::Unchanged => Ok(None),
+    }
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/lsp/src/handlers_format.rs
+++ b/crates/lsp/src/handlers_format.rs
@@ -43,13 +43,10 @@ pub(crate) fn document_formatting(
         }
     }
 
-    if doc.parse.has_errors() {
+    if doc.parse.has_error() {
         // Refuse to format in the face of parse errors, but only log a warning
         // rather than returning an LSP error, as toast notifications here are distracting.
-        tracing::warn!(
-            "Failed to format {uri}. Can't format when there are parse errors.",
-            uri = params.text_document.uri
-        );
+        tracing::warn!("Failed to format {uri}. Can't format when there are parse errors.");
         return Ok(None);
     }
 
@@ -88,13 +85,10 @@ pub(crate) fn document_range_formatting(
         }
     }
 
-    if doc.parse.has_errors() {
+    if doc.parse.has_error() {
         // Refuse to format in the face of parse errors, but only log a warning
         // rather than returning an LSP error, as toast notifications here are distracting.
-        tracing::warn!(
-            "Failed to format {uri}. Can't format when there are parse errors.",
-            uri = params.text_document.uri
-        );
+        tracing::warn!("Failed to format {uri}. Can't format when there are parse errors.");
         return Ok(None);
     }
 

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -17,6 +17,7 @@ schemars = ["dep:schemars", "settings/schemars"]
 
 [dependencies]
 air_r_formatter = { workspace = true }
+air_r_parser = { workspace = true }
 anyhow = { workspace = true }
 biome_formatter = { workspace = true, features = ["serde"] }
 fs = { workspace = true }

--- a/crates/workspace/src/format.rs
+++ b/crates/workspace/src/format.rs
@@ -1,0 +1,152 @@
+use std::io;
+use std::path::Path;
+
+use air_r_formatter::context::RFormatOptions;
+use air_r_parser::Parse;
+use air_r_parser::RParserOptions;
+use thiserror::Error;
+
+use crate::settings::FormatSettings;
+
+/// Representation of a formatted file
+#[derive(Debug)]
+pub enum FormattedFile {
+    /// The file was formatted.
+    Changed(ChangedFile),
+    /// The file was unchanged.
+    Unchanged,
+}
+
+#[derive(Debug)]
+pub struct ChangedFile {
+    old: String,
+    new: String,
+}
+
+#[derive(Error, Debug)]
+pub enum FormatFileError {
+    #[error(transparent)]
+    Format(#[from] FormatSourceError),
+    #[error(transparent)]
+    Read(#[from] io::Error),
+}
+
+#[derive(Debug)]
+pub enum FormattedSource {
+    /// The source was formatted, the [`String`] contains the transformed source code.
+    Changed(String),
+    /// The source was unchanged.
+    Unchanged,
+}
+
+#[derive(Error, Debug)]
+pub enum FormatSourceError {
+    #[error(transparent)]
+    Parse(#[from] air_r_parser::ParseError),
+    #[error(transparent)]
+    Format(#[from] biome_formatter::FormatError),
+    #[error(transparent)]
+    Print(#[from] biome_formatter::PrintError),
+}
+
+#[derive(Error, Debug)]
+pub enum FormatParseError {
+    #[error(transparent)]
+    Format(#[from] biome_formatter::FormatError),
+    #[error(transparent)]
+    Print(#[from] biome_formatter::PrintError),
+}
+
+impl FormattedFile {
+    pub fn is_changed(&self) -> bool {
+        matches!(self, FormattedFile::Changed(_))
+    }
+}
+
+impl ChangedFile {
+    pub fn old(&self) -> &str {
+        &self.old
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(&self) -> &str {
+        &self.new
+    }
+}
+
+/// Formats a single file
+///
+/// Note that this does not normalize line endings! In the LSP we currently do normalize
+/// line endings in `Document::new()` and on document updates because our protocol
+/// converter functions expect them to be normalized to unix (we should look into relaxing
+/// this). If you need to format an on-disk file from the LSP, think hard about using this
+/// vs calling the pieces yourself so you can also call [line_ending::normalize()].
+pub fn format_file<P: AsRef<Path>>(
+    path: P,
+    settings: &FormatSettings,
+) -> Result<FormattedFile, FormatFileError> {
+    let old = match std::fs::read_to_string(path.as_ref()) {
+        Ok(old) => old,
+        Err(err) => {
+            return Err(FormatFileError::Read(err));
+        }
+    };
+
+    let options = settings.to_format_options(&old);
+
+    let new = match format_source(&old, options) {
+        Ok(new) => new,
+        Err(err) => return Err(FormatFileError::Format(err)),
+    };
+
+    match new {
+        FormattedSource::Changed(new) => Ok(FormattedFile::Changed(ChangedFile { old, new })),
+        FormattedSource::Unchanged => Ok(FormattedFile::Unchanged),
+    }
+}
+
+/// Formats a vector of `source` code
+pub fn format_source(
+    source: &str,
+    options: RFormatOptions,
+) -> std::result::Result<FormattedSource, FormatSourceError> {
+    let parse = air_r_parser::parse(source, RParserOptions::default());
+
+    if parse.has_error() {
+        let error = parse.into_error().unwrap();
+        return Err(error.into());
+    }
+
+    format_source_with_parse(source, &parse, options).map_err(|err| match err {
+        FormatParseError::Format(err) => FormatSourceError::Format(err),
+        FormatParseError::Print(err) => FormatSourceError::Print(err),
+    })
+}
+
+/// Formats a vector of `source` code using a preexisting `parse` result
+///
+/// # Invariants
+///
+/// It is a logic error to pass a `source` that does not exactly correspond to `parse`.
+///
+/// This function will panic if you provide a `parse` with parse errors, it is up to
+/// the caller to handle that case appropriately.
+pub fn format_source_with_parse(
+    source: &str,
+    parse: &Parse,
+    options: RFormatOptions,
+) -> std::result::Result<FormattedSource, FormatParseError> {
+    if parse.has_error() {
+        panic!("Can't supply a `parse` with known errors.");
+    }
+
+    let formatted = air_r_formatter::format_node(options, &parse.syntax())?;
+    let formatted = formatted.print()?;
+    let formatted = formatted.into_code();
+
+    if source.len() == formatted.len() && source == formatted.as_str() {
+        Ok(FormattedSource::Unchanged)
+    } else {
+        Ok(FormattedSource::Changed(formatted))
+    }
+}

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod discovery;
 pub mod file_patterns;
+pub mod format;
 pub mod resolve;
 pub mod settings;
 pub mod toml;


### PR DESCRIPTION
Extracted from https://github.com/posit-dev/air/pull/310

While working on https://github.com/posit-dev/air/pull/310 I was frustrated by the fact that `Document` uses a `biome_parser::AnyParse` rather than our `air_r_parser::Parse` value. It made it hard to write generic format tooling that can be used between the LSP and CLI.

The main thing `Document` needs is a `parse` object that can be sent between threads. `AnyParse` is quite small and lightweight, so I've merged it's implementation with our `Parse` implementation to get something that both the CLI and the LSP can be happy with.

You'll won't see the implications of this until I do one more PR that generalizes some formatting tools by moving them of the CLI and into the workspace crate.