### PR TITLE
Generalize formatting tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,18 +30,13 @@ dependencies = [
 name = "air"
 version = "0.5.0"
 dependencies = [
- "air_r_formatter",
- "air_r_parser",
  "anyhow",
- "biome_formatter",
- "biome_parser",
  "clap",
  "colored",
  "crates",
  "fs",
  "ignore",
  "itertools",
- "line_ending",
  "lsp",
  "tempfile",
  "thiserror 2.0.5",
@@ -2903,6 +2898,7 @@ name = "workspace"
 version = "0.1.0"
 dependencies = [
  "air_r_formatter",
+ "air_r_parser",
  "anyhow",
  "biome_formatter",
  "fs",

--- a/crates/air/Cargo.toml
+++ b/crates/air/Cargo.toml
@@ -12,18 +12,13 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-air_r_formatter = { workspace = true }
-air_r_parser = { workspace = true }
 anyhow = { workspace = true }
-biome_formatter = { workspace = true }
-biome_parser = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }
 colored = { workspace = true }
 crates = { workspace = true }
 fs = { workspace = true }
 ignore = { workspace = true }
 itertools = { workspace = true }
-line_ending = { workspace = true }
 lsp = { workspace = true }
 thiserror = { workspace = true }
 tokio = "1.41.1"

--- a/crates/lsp/src/handlers_format.rs
+++ b/crates/lsp/src/handlers_format.rs
@@ -5,11 +5,12 @@
 //
 //
 
-use air_r_formatter::format_node;
 use air_r_syntax::{RExpressionList, RSyntaxKind, RSyntaxNode, WalkEvent};
 use biome_rowan::{AstNode, Language, SyntaxElement};
 use biome_text_size::{TextRange, TextSize};
 use tower_lsp::lsp_types;
+use workspace::format::format_source_with_parse;
+use workspace::format::FormattedSource;
 
 use crate::file_patterns::is_document_excluded_from_formatting;
 use crate::main_loop::LspState;
@@ -51,11 +52,15 @@ pub(crate) fn document_formatting(
     }
 
     let format_options = workspace_settings.to_format_options(&doc.contents, &doc.settings);
-    let formatted = format_node(format_options, &doc.parse.syntax())?;
-    let output = formatted.print()?.into_code();
 
-    let edits = to_proto::replace_all_edit(&doc.line_index, &doc.contents, &output)?;
-    Ok(Some(edits))
+    match format_source_with_parse(&doc.contents, &doc.parse, format_options)? {
+        FormattedSource::Changed(formatted) => Ok(Some(to_proto::replace_all_edit(
+            &doc.line_index,
+            &doc.contents,
+            &formatted,
+        )?)),
+        FormattedSource::Unchanged => Ok(None),
+    }
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -17,6 +17,7 @@ schemars = ["dep:schemars", "settings/schemars"]
 
 [dependencies]
 air_r_formatter = { workspace = true }
+air_r_parser = { workspace = true }
 anyhow = { workspace = true }
 biome_formatter = { workspace = true, features = ["serde"] }
 fs = { workspace = true }

--- a/crates/workspace/src/format.rs
+++ b/crates/workspace/src/format.rs
@@ -1,0 +1,152 @@
+use std::io;
+use std::path::Path;
+
+use air_r_formatter::context::RFormatOptions;
+use air_r_parser::Parse;
+use air_r_parser::RParserOptions;
+use thiserror::Error;
+
+use crate::settings::FormatSettings;
+
+/// Representation of a formatted file
+#[derive(Debug)]
+pub enum FormattedFile {
+    /// The file was formatted.
+    Changed(ChangedFile),
+    /// The file was unchanged.
+    Unchanged,
+}
+
+#[derive(Debug)]
+pub struct ChangedFile {
+    old: String,
+    new: String,
+}
+
+#[derive(Error, Debug)]
+pub enum FormatFileError {
+    #[error(transparent)]
+    Format(#[from] FormatSourceError),
+    #[error(transparent)]
+    Read(#[from] io::Error),
+}
+
+#[derive(Debug)]
+pub enum FormattedSource {
+    /// The source was formatted, the [`String`] contains the transformed source code.
+    Changed(String),
+    /// The source was unchanged.
+    Unchanged,
+}
+
+#[derive(Error, Debug)]
+pub enum FormatSourceError {
+    #[error(transparent)]
+    Parse(#[from] air_r_parser::ParseError),
+    #[error(transparent)]
+    Format(#[from] biome_formatter::FormatError),
+    #[error(transparent)]
+    Print(#[from] biome_formatter::PrintError),
+}
+
+#[derive(Error, Debug)]
+pub enum FormatParseError {
+    #[error(transparent)]
+    Format(#[from] biome_formatter::FormatError),
+    #[error(transparent)]
+    Print(#[from] biome_formatter::PrintError),
+}
+
+impl FormattedFile {
+    pub fn is_changed(&self) -> bool {
+        matches!(self, FormattedFile::Changed(_))
+    }
+}
+
+impl ChangedFile {
+    pub fn old(&self) -> &str {
+        &self.old
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(&self) -> &str {
+        &self.new
+    }
+}
+
+/// Formats a single file
+///
+/// Note that this does not normalize line endings! In the LSP we currently do normalize
+/// line endings in `Document::new()` and on document updates because our protocol
+/// converter functions expect them to be normalized to unix (we should look into relaxing
+/// this). If you need to format an on-disk file from the LSP, think hard about using this
+/// vs calling the pieces yourself so you can also call [line_ending::normalize()].
+pub fn format_file<P: AsRef<Path>>(
+    path: P,
+    settings: &FormatSettings,
+) -> Result<FormattedFile, FormatFileError> {
+    let old = match std::fs::read_to_string(path.as_ref()) {
+        Ok(old) => old,
+        Err(err) => {
+            return Err(FormatFileError::Read(err));
+        }
+    };
+
+    let options = settings.to_format_options(&old);
+
+    let new = match format_source(&old, options) {
+        Ok(new) => new,
+        Err(err) => return Err(FormatFileError::Format(err)),
+    };
+
+    match new {
+        FormattedSource::Changed(new) => Ok(FormattedFile::Changed(ChangedFile { old, new })),
+        FormattedSource::Unchanged => Ok(FormattedFile::Unchanged),
+    }
+}
+
+/// Formats a vector of `source` code
+pub fn format_source(
+    source: &str,
+    options: RFormatOptions,
+) -> std::result::Result<FormattedSource, FormatSourceError> {
+    let parse = air_r_parser::parse(source, RParserOptions::default());
+
+    if parse.has_error() {
+        let error = parse.into_error().unwrap();
+        return Err(error.into());
+    }
+
+    format_source_with_parse(source, &parse, options).map_err(|err| match err {
+        FormatParseError::Format(err) => FormatSourceError::Format(err),
+        FormatParseError::Print(err) => FormatSourceError::Print(err),
+    })
+}
+
+/// Formats a vector of `source` code using a preexisting `parse` result
+///
+/// # Invariants
+///
+/// It is a logic error to pass a `source` that does not exactly correspond to `parse`.
+///
+/// This function will panic if you provide a `parse` with parse errors, it is up to
+/// the caller to handle that case appropriately.
+pub fn format_source_with_parse(
+    source: &str,
+    parse: &Parse,
+    options: RFormatOptions,
+) -> std::result::Result<FormattedSource, FormatParseError> {
+    if parse.has_error() {
+        panic!("Can't supply a `parse` with known errors.");
+    }
+
+    let formatted = air_r_formatter::format_node(options, &parse.syntax())?;
+    let formatted = formatted.print()?;
+    let formatted = formatted.into_code();
+
+    if source.len() == formatted.len() && source == formatted.as_str() {
+        Ok(FormattedSource::Unchanged)
+    } else {
+        Ok(FormattedSource::Changed(formatted))
+    }
+}

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod discovery;
 pub mod file_patterns;
+pub mod format;
 pub mod resolve;
 pub mod settings;
 pub mod toml;


### PR DESCRIPTION
Branched from #316 
Last PR extracted from https://github.com/posit-dev/air/pull/310

Extracts out 3 very nice format helpers that we can use across the CLI and LSP. From lower->higher level (each one calls the previous):
- `format_source_with_parse(source: &str, parse: &Parse, ...)`, used in the LSP where we parse on every did-change event, so we've already got it ready to go
- `format_source(source: &str, ...)`, used in `format_file()`, but is a meaningful intermediate helper
- `format_file(source: &str, ...)`, used in the CLI

The new `format_source_with_parse()` is the reason for #316, where now the LSP contains a standard `Parse` result in the `Document` rather than an `AnyParse`.

At the end of the day, all of the changes for https://github.com/posit-dev/air/pull/312 were on the Typescript side, so these changes aren't strictly necessary. But they were extremely useful when exploring the `WorkspaceEdit` solution there and I really like the resulting API!