### PR TITLE
Never expand empty `{}` across multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 # Development version
 
+- Empty `{}` are no longer ever expanded (#43).
+
+  This allows for syntax like:
+
+  ```r
+  dummy <- function() {}
+
+  while (waiting()) {}
+
+  switch(x, a = {}, b = 2)
+
+  function(
+    expr = {}
+  ) {
+    this_first()
+    expr
+  }
+  ```
+
 - Autobracing is a new feature applied to if statements, for loops, while loops,
   repeat loops, and function definitions. This feature will automatically add
   `{}` around the body of these code elements in certain cases to maximize

--- a/crates/air_r_formatter/tests/specs/r/braced_expressions.R
+++ b/crates/air_r_formatter/tests/specs/r/braced_expressions.R
@@ -1,17 +1,121 @@
-# Hard line break between `{}` tokens
-function() {}
-for (i in x) {}
-if (a) {}
-
-{}
-
 {
   1
 }
 
+{ 1 }
+
+# ------------------------------------------------------------------------
+# Empty `{}`
+
+{}
+{} # comment
+
+# Dangling comment forces it to expand
 {
   # comment
 }
+
+# Dangling comment forces it to expand
+{ # comment
+}
+
+({})
+
+# Some people use `{}` as an alternative to `NULL`
+switch(x, a = {}, b = 2, c = {}, d = 4)
+
+# ------------------------------------------------------------------------
+# Empty `{}` - function definition
+
+# Motivating case
+function() {}
+
+stub <- function() {}
+
+list(
+  a = function() {},
+  b = function() {}
+)
+
+# Even when parameters break, we don't expand the `{}`
+function(a_really_long_argument, another_really_long_argument, another_longgg) {}
+
+function() {} # comment
+
+function() # comment
+  {}
+
+function()
+  # comment
+  {}
+
+# ------------------------------------------------------------------------
+# Empty `{}` - loops
+
+# Want all these to be consistent
+for (x in xs) {}
+while (waiting()) {}
+repeat {}
+
+for (x in xs) {} # comment
+while (waiting()) {} # comment
+repeat {} # comment
+
+for (x in xs) # comment
+  {}
+while (waiting()) # comment
+  {}
+repeat # comment
+  {}
+
+for (x in xs)
+  # comment
+  {}
+while (waiting())
+  # comment
+  {}
+repeat
+  # comment
+  {}
+
+# ------------------------------------------------------------------------
+# Empty `{}` - if statement
+
+# These are a bit weird, but we deal with it for consistency reasons
+if (a) {}
+if (a) {} else {}
+
+if (a) {} # comment
+
+if (a) # comment
+  {}
+
+if (a)
+  # comment
+  {}
+
+{
+  if (a) {}
+  else {}
+}
+
+{
+  if (a) {} # comment1
+  else {} # comment2
+}
+
+{
+  if (a) {}
+  # comment
+  else {}
+}
+
+# Autobracing kicks in around `2` and spans multiple lines,
+# while the `{}` is left uncollapsed. It's weird, but it
+# is supposed to be so the user fixes it, because this is
+# almost certainly a programming mistake.
+if (a) {} else 2
+if (a) 2 else {}
 
 # ------------------------------------------------------------------------
 # Curly-curly

--- a/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
@@ -5,20 +5,124 @@ info: r/braced_expressions.R
 # Input
 
 ```R
-# Hard line break between `{}` tokens
-function() {}
-for (i in x) {}
-if (a) {}
-
-{}
-
 {
   1
 }
 
+{ 1 }
+
+# ------------------------------------------------------------------------
+# Empty `{}`
+
+{}
+{} # comment
+
+# Dangling comment forces it to expand
 {
   # comment
 }
+
+# Dangling comment forces it to expand
+{ # comment
+}
+
+({})
+
+# Some people use `{}` as an alternative to `NULL`
+switch(x, a = {}, b = 2, c = {}, d = 4)
+
+# ------------------------------------------------------------------------
+# Empty `{}` - function definition
+
+# Motivating case
+function() {}
+
+stub <- function() {}
+
+list(
+  a = function() {},
+  b = function() {}
+)
+
+# Even when parameters break, we don't expand the `{}`
+function(a_really_long_argument, another_really_long_argument, another_longgg) {}
+
+function() {} # comment
+
+function() # comment
+  {}
+
+function()
+  # comment
+  {}
+
+# ------------------------------------------------------------------------
+# Empty `{}` - loops
+
+# Want all these to be consistent
+for (x in xs) {}
+while (waiting()) {}
+repeat {}
+
+for (x in xs) {} # comment
+while (waiting()) {} # comment
+repeat {} # comment
+
+for (x in xs) # comment
+  {}
+while (waiting()) # comment
+  {}
+repeat # comment
+  {}
+
+for (x in xs)
+  # comment
+  {}
+while (waiting())
+  # comment
+  {}
+repeat
+  # comment
+  {}
+
+# ------------------------------------------------------------------------
+# Empty `{}` - if statement
+
+# These are a bit weird, but we deal with it for consistency reasons
+if (a) {}
+if (a) {} else {}
+
+if (a) {} # comment
+
+if (a) # comment
+  {}
+
+if (a)
+  # comment
+  {}
+
+{
+  if (a) {}
+  else {}
+}
+
+{
+  if (a) {} # comment1
+  else {} # comment2
+}
+
+{
+  if (a) {}
+  # comment
+  else {}
+}
+
+# Autobracing kicks in around `2` and spans multiple lines,
+# while the `{}` is left uncollapsed. It's weird, but it
+# is supposed to be so the user fixes it, because this is
+# almost certainly a programming mistake.
+if (a) {} else 2
+if (a) 2 else {}
 
 # ------------------------------------------------------------------------
 # Curly-curly
@@ -98,24 +202,140 @@ Skip: None
 -----
 
 ```R
-# Hard line break between `{}` tokens
-function() {
-}
-for (i in x) {
-}
-if (a) {
-}
-
 {
+  1
 }
 
 {
   1
 }
 
+# ------------------------------------------------------------------------
+# Empty `{}`
+
+{}
+{} # comment
+
+# Dangling comment forces it to expand
 {
   # comment
 }
+
+# Dangling comment forces it to expand
+{
+  # comment
+}
+
+({})
+
+# Some people use `{}` as an alternative to `NULL`
+switch(x, a = {}, b = 2, c = {}, d = 4)
+
+# ------------------------------------------------------------------------
+# Empty `{}` - function definition
+
+# Motivating case
+function() {}
+
+stub <- function() {}
+
+list(
+  a = function() {},
+  b = function() {}
+)
+
+# Even when parameters break, we don't expand the `{}`
+function(
+  a_really_long_argument,
+  another_really_long_argument,
+  another_longgg
+) {}
+
+function() {} # comment
+
+function() {
+  # comment
+}
+
+function() {
+  # comment
+}
+
+# ------------------------------------------------------------------------
+# Empty `{}` - loops
+
+# Want all these to be consistent
+for (x in xs) {}
+while (waiting()) {}
+repeat {}
+
+for (x in xs) {} # comment
+while (waiting()) {} # comment
+repeat {} # comment
+
+for (x in xs) {
+  # comment
+}
+while (waiting()) {
+  # comment
+}
+repeat {
+  # comment
+}
+
+for (x in xs) {
+  # comment
+}
+while (waiting()) {
+  # comment
+}
+repeat {
+  # comment
+}
+
+# ------------------------------------------------------------------------
+# Empty `{}` - if statement
+
+# These are a bit weird, but we deal with it for consistency reasons
+if (a) {}
+if (a) {} else {}
+
+if (a) {} # comment
+
+if (a) {
+  # comment
+}
+
+if (a) {
+  # comment
+}
+
+{
+  if (a) {} else {}
+}
+
+{
+  if (a) {
+    # comment1
+  } else {} # comment2
+}
+
+{
+  if (a) {} else {
+    # comment
+  }
+}
+
+# Autobracing kicks in around `2` and spans multiple lines,
+# while the `{}` is left uncollapsed. It's weird, but it
+# is supposed to be so the user fixes it, because this is
+# almost certainly a programming mistake.
+if (a) {} else {
+  2
+}
+if (a) {
+  2
+} else {}
 
 # ------------------------------------------------------------------------
 # Curly-curly
@@ -179,8 +399,7 @@ function(
       var
     }
   }
-) {
-}
+) {}
 
 # Not curly-curly, 2 inner expressions
 fn({
@@ -200,8 +419,7 @@ fn({
 
 # Not curly-curly, 0 inner expressions
 fn({
-  {
-  }
+  {}
 })
 
 # Not curly-curly, 0 inner expressions (important, even with dangling comment!)
@@ -214,5 +432,5 @@ fn({
 
 # Lines exceeding max width of 80 characters
 ```
-   32:     var_that_is_extremely_long_and_eventually_forces_a_line_break_once_we_eventually_get_to_the_end
+  148:     var_that_is_extremely_long_and_eventually_forces_a_line_break_once_we_eventually_get_to_the_end
 ```

--- a/crates/air_r_formatter/tests/specs/r/call.R
+++ b/crates/air_r_formatter/tests/specs/r/call.R
@@ -68,7 +68,7 @@ df |> foo(
 # (test-like check comes first and seems more relevant)
 test_that(
   "description", {
-
+    body
 })
 
 # ------------------------------------------------------------------------
@@ -298,6 +298,7 @@ with(my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_lon
   }
 )
 
+# Collapses with empty braces
 with(data, {
 })
 
@@ -305,6 +306,7 @@ with(data, {
   # dangling
 })
 
+# Collapses with empty braces
 fn({
 })
 
@@ -337,8 +339,15 @@ map(xs, function(x) {
   x + 1
 })
 
-# Braces expand over multiple lines
-map(xs, function(x) { })
+# Best fitting is not used, the empty `{}` would never be expanded, so we don't
+# require best fitting
+map(xs, function(x) {})
+map(xs_that_is_really_long_to_just_barely_pass_the_line_lengthhh, function(x) {})
+
+# Best fitting is not used, the empty `{}` would (typically) never be expanded,
+# so we don't require best fitting
+map(xs, function(x) {{ x }})
+map(xs_that_is_long_to_just_barely_pass_the_line_lengthhhhh, function(x) {{ x }})
 
 # Best fitting is used to choose the most flat variant, and this stays
 # as is

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -75,7 +75,7 @@ df |> foo(
 # (test-like check comes first and seems more relevant)
 test_that(
   "description", {
-
+    body
 })
 
 # ------------------------------------------------------------------------
@@ -305,6 +305,7 @@ with(my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_lon
   }
 )
 
+# Collapses with empty braces
 with(data, {
 })
 
@@ -312,6 +313,7 @@ with(data, {
   # dangling
 })
 
+# Collapses with empty braces
 fn({
 })
 
@@ -344,8 +346,15 @@ map(xs, function(x) {
   x + 1
 })
 
-# Braces expand over multiple lines
-map(xs, function(x) { })
+# Best fitting is not used, the empty `{}` would never be expanded, so we don't
+# require best fitting
+map(xs, function(x) {})
+map(xs_that_is_really_long_to_just_barely_pass_the_line_lengthhh, function(x) {})
+
+# Best fitting is not used, the empty `{}` would (typically) never be expanded,
+# so we don't require best fitting
+map(xs, function(x) {{ x }})
+map(xs_that_is_long_to_just_barely_pass_the_line_lengthhhhh, function(x) {{ x }})
 
 # Best fitting is used to choose the most flat variant, and this stays
 # as is
@@ -963,6 +972,7 @@ df |>
 # Test-like call overrides user requested line break
 # (test-like check comes first and seems more relevant)
 test_that("description", {
+  body
 })
 
 # ------------------------------------------------------------------------
@@ -1187,15 +1197,15 @@ with(
   }
 )
 
-with(data, {
-})
+# Collapses with empty braces
+with(data, {})
 
 with(data, {
   # dangling
 })
 
-fn({
-})
+# Collapses with empty braces
+fn({})
 
 fn({
   # dangling
@@ -1238,9 +1248,21 @@ map(xs, function(x) {
   x + 1
 })
 
-# Braces expand over multiple lines
-map(xs, function(x) {
-})
+# Best fitting is not used, the empty `{}` would never be expanded, so we don't
+# require best fitting
+map(xs, function(x) {})
+map(
+  xs_that_is_really_long_to_just_barely_pass_the_line_lengthhh,
+  function(x) {}
+)
+
+# Best fitting is not used, the empty `{}` would (typically) never be expanded,
+# so we don't require best fitting
+map(xs, function(x) {{ x }})
+map(
+  xs_that_is_long_to_just_barely_pass_the_line_lengthhhhh,
+  function(x) {{ x }}
+)
 
 # Best fitting is used to choose the most flat variant, and this stays
 # as is
@@ -1810,9 +1832,9 @@ foo(bar[
 
 # Lines exceeding max width of 80 characters
 ```
-  307:   my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
-  768:   foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz
-  772: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz()))
-  775: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
-  788:   name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
+  308:   my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
+  781:   foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz
+  785: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz()))
+  788: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
+  801:   name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
 ```

--- a/crates/air_r_formatter/tests/specs/r/for_statement.R
+++ b/crates/air_r_formatter/tests/specs/r/for_statement.R
@@ -19,29 +19,23 @@ for(x in xs) x + y
 # Comments
 
 for # leads for loop
-(i in 1:5) {
-}
+(i in 1:5) {}
 
 for ( # leads for loop
-i in 1:5) {
-}
+i in 1:5) {}
 
 for (i # leads for loop
-in 1:5) {
-}
+in 1:5) {}
 
 for (i in # leads for loop
-1:5) {
-}
+1:5) {}
 
 for (i in
 # leads for loop
-1:5) {
-}
+1:5) {}
 
 for (i in 1:5 # leads for loop
-) {
-}
+) {}
 
 for (i in 1:5) # dangles {}
   {

--- a/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
@@ -26,29 +26,23 @@ for(x in xs) x + y
 # Comments
 
 for # leads for loop
-(i in 1:5) {
-}
+(i in 1:5) {}
 
 for ( # leads for loop
-i in 1:5) {
-}
+i in 1:5) {}
 
 for (i # leads for loop
-in 1:5) {
-}
+in 1:5) {}
 
 for (i in # leads for loop
-1:5) {
-}
+1:5) {}
 
 for (i in
 # leads for loop
-1:5) {
-}
+1:5) {}
 
 for (i in 1:5 # leads for loop
-) {
-}
+) {}
 
 for (i in 1:5) # dangles {}
   {
@@ -110,8 +104,7 @@ for (a_really_long_argument_name in but_we_dont_ever_break_inside_for_conditions
 # ------------------------------------------------------------------------------
 # Autobracing
 
-for (x in xs) {
-}
+for (x in xs) {}
 
 # Unconditional autobracing on for loop bodies to maximize clarity and intent
 for (x in xs) {
@@ -125,28 +118,22 @@ for (x in xs) {
 # Comments
 
 # leads for loop
-for (i in 1:5) {
-}
+for (i in 1:5) {}
 
 # leads for loop
-for (i in 1:5) {
-}
+for (i in 1:5) {}
 
 # leads for loop
-for (i in 1:5) {
-}
+for (i in 1:5) {}
 
 # leads for loop
-for (i in 1:5) {
-}
+for (i in 1:5) {}
 
 # leads for loop
-for (i in 1:5) {
-}
+for (i in 1:5) {}
 
 # leads for loop
-for (i in 1:5) {
-}
+for (i in 1:5) {}
 
 for (i in 1:5) {
   # dangles {}

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R
@@ -53,22 +53,18 @@ function(a_really_long_argument_name_to_break_on, and_this) a_really_long_argume
 # Comments
 
 function # leads function
-() {
-}
+() {}
 
 function
 # leads function
-() {
-}
+() {}
 
 function( # dangles ()
-) {
-}
+) {}
 
 function(
   # dangles ()
-) {
-}
+) {}
 
 function() {
   # dangles {}
@@ -90,6 +86,9 @@ function() # leads `a`
 function() # dangles {}
 {
 }
+
+function() # dangles {}
+{}
 
 function() # dangles {}
 {

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
@@ -60,22 +60,18 @@ function(a_really_long_argument_name_to_break_on, and_this) a_really_long_argume
 # Comments
 
 function # leads function
-() {
-}
+() {}
 
 function
 # leads function
-() {
-}
+() {}
 
 function( # dangles ()
-) {
-}
+) {}
 
 function(
   # dangles ()
-) {
-}
+) {}
 
 function() {
   # dangles {}
@@ -97,6 +93,9 @@ function() # leads `a`
 function() # dangles {}
 {
 }
+
+function() # dangles {}
+{}
 
 function() # dangles {}
 {
@@ -288,22 +287,18 @@ function(a_really_long_argument_name_to_break_on, and_this) {
 # Comments
 
 # leads function
-function() {
-}
+function() {}
 
 # leads function
-function() {
-}
+function() {}
 
 function(
   # dangles ()
-) {
-}
+) {}
 
 function(
   # dangles ()
-) {
-}
+) {}
 
 function() {
   # dangles {}
@@ -320,6 +315,10 @@ function() {
   # leads `a`
   # an inner comment
   a
+}
+
+function() {
+  # dangles {}
 }
 
 function() {

--- a/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
@@ -934,10 +934,8 @@ fn(
 )
 
 # Allowed on one line without braces (value position)
-function(x = if (a) 1) {
-}
-function(x = if (a) 1, y = if (a) 1 else 2) {
-}
+function(x = if (a) 1) {}
+function(x = if (a) 1, y = if (a) 1 else 2) {}
 # Too complex, forces braces
 function(
   x = if (a) {
@@ -947,15 +945,13 @@ function(
   } else {
     3
   }
-) {
-}
+) {}
 # Breaks parameter list, but not if/else
 function(
   x = if (a) 1,
   y = if (a) 1 else 2,
   this_is_really_really_long_and_breaks_the_group_here
-) {
-}
+) {}
 
 # The group breaking forces braces
 x <- if (something_really_really_long_here_something_really_really_long_here) {

--- a/crates/air_r_formatter/tests/specs/r/repeat_statement.R
+++ b/crates/air_r_formatter/tests/specs/r/repeat_statement.R
@@ -1,3 +1,4 @@
+# Stays collapsed
 repeat {}
 
 repeat {

--- a/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
@@ -5,6 +5,7 @@ info: r/repeat_statement.R
 # Input
 
 ```R
+# Stays collapsed
 repeat {}
 
 repeat {
@@ -84,8 +85,8 @@ Skip: None
 -----
 
 ```R
-repeat {
-}
+# Stays collapsed
+repeat {}
 
 repeat {
   a + b

--- a/crates/air_r_formatter/tests/specs/r/while_statement.R
+++ b/crates/air_r_formatter/tests/specs/r/while_statement.R
@@ -1,3 +1,4 @@
+# Stays collapsed
 while(a){}
 
 while(a) {

--- a/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
@@ -5,6 +5,7 @@ info: r/while_statement.R
 # Input
 
 ```R
+# Stays collapsed
 while(a){}
 
 while(a) {
@@ -111,8 +112,8 @@ Skip: None
 -----
 
 ```R
-while (a) {
-}
+# Stays collapsed
+while (a) {}
 
 while (a) {
   1 + 1

--- a/docs/formatter.qmd
+++ b/docs/formatter.qmd
@@ -489,6 +489,42 @@ if (condition) {
 
 In general, prefer leading comments over trailing comments for readability and to have the highest chance of Air placing it in the correct location when comment adjustment is required.
 
+# Empty braces
+
+Braced expressions generally span multiple lines:
+
+``` r
+for (x in xs) {
+  print(x)
+}
+
+function(x, y) {
+  x + y
+}
+
+function() {
+  # Do nothing
+}
+```
+
+The one exception to this is completely empty braces, i.e. `{}`.
+These are never expanded, allowing for the following style:
+
+``` r
+dummy <- function() {}
+
+while (waiting()) {}
+
+switch(x, a = {}, b = 2)
+
+function(
+  expr = {}
+) {
+  this_first()
+  expr
+}
+```
+
 # Disabling formatting
 
 ## Skip comments


### PR DESCRIPTION
Closes #43 

CC @hadley 

I've done what ya'll preferred and used the simple rule of "never expand empty `{}`", which was easy enough to implement.

All of the following are now allowed

```r
# the motivating case for this
dummy <- function() {}

# the "block until done" pattern
while (waiting()) {}

# seen in lintr discussions as an alternative to `NULL`
switch(x, a = {}, b = 2)

# seen in httr2
function(
  expr = {}
) {
  this_first()
  expr
}

# swallow error, return NULL
tryCatch(
  expr = {
      stop("oh no")
  },
  error = function(e) {}
)
```

We end up allowing this weirdness for if/else, but it's almost certainly a logic error, and we have decided in the past that we don't make formatter decisions based on logic errors

```r
if (condition) {} else {
  2
}

if (condition) {
  2
} else {}
```