### PR TITLE
Optimize `on_did_change()`

### DIFF
--- a/crates/lsp/src/handlers_state.rs
+++ b/crates/lsp/src/handlers_state.rs
@@ -168,7 +168,7 @@ pub(crate) fn did_change(
 ) -> anyhow::Result<()> {
     let uri = &params.text_document.uri;
     let doc = state.get_document_mut_or_error(uri)?;
-    doc.on_did_change(params);
+    doc.on_did_change(params.content_changes, params.text_document.version);
 
     Ok(())
 }

--- a/crates/lsp/src/line_index.rs
+++ b/crates/lsp/src/line_index.rs
@@ -10,3 +10,11 @@ use triomphe::Arc;
 pub struct LineIndex {
     pub index: Arc<biome_line_index::LineIndex>,
 }
+
+impl LineIndex {
+    pub fn new(text: &str) -> Self {
+        Self {
+            index: Arc::new(biome_line_index::LineIndex::new(text)),
+        }
+    }
+}


### PR DESCRIPTION
Branched from #363 

It turns out that we are rebuilding our `LineIndex` _at least twice_ on every single `on_did_change()` call.
- One is here, where we ignore the fact that we already had a `LineIndex` built for this `Document` https://github.com/posit-dev/air/blob/be96e71284928f504a9402368bc716520fe15647/crates/lsp/src/rust_analyzer/utils.rs#L35
- One is here, after we've applied all changes https://github.com/posit-dev/air/blob/be96e71284928f504a9402368bc716520fe15647/crates/lsp/src/documents.rs#L135-L136

That's not super efficient! In the ~90% case where the user is just typing one character at a time, we should only be rebuilding the line index exactly 1 time.

I've folded `apply_document_changes()` into `on_did_change()` to keep all of the mutable-state-updating code close together.

The actual implementation is basically still the same, I've just had to rework things a little to do this optimization.

I had added in some logging and can confirm that we now only rebuild the `LineIndex` 1 time on every update as the user is typing. We typically also rebuild it exactly 1 time during a find-and-replace as well, due to how we take advantage of VS Code sending us the updates from bottom to top (so we can apply them sequentially without invalidating our line index).

I might try a PR upstream to rust-analyzer, because I'm fairly certain they have this too from looking at their code.