### PR TITLE
Sync to Biome 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -219,11 +219,10 @@ dependencies = [
 [[package]]
 name = "biome_console"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_markup",
  "biome_text_size",
- "schemars",
  "serde",
  "termcolor",
  "unicode-segmentation",
@@ -233,26 +232,25 @@ dependencies = [
 [[package]]
 name = "biome_deserialize"
 version = "0.6.0"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_console",
- "biome_deserialize_macros",
  "biome_diagnostics",
  "biome_json_parser",
  "biome_json_syntax",
  "biome_rowan",
  "enumflags2",
- "indexmap",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "biome_deserialize_macros"
 version = "0.6.0"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_string_case",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -261,7 +259,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "backtrace",
  "biome_console",
@@ -270,20 +268,18 @@ dependencies = [
  "biome_rowan",
  "biome_text_edit",
  "biome_text_size",
- "bpaf",
  "enumflags2",
- "oxc_resolver",
  "serde",
- "serde_ini",
  "serde_json",
  "termcolor",
+ "terminal_size",
  "unicode-width",
 ]
 
 [[package]]
 name = "biome_diagnostics_categories"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "quote",
  "serde",
@@ -292,9 +288,9 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_macros"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -303,7 +299,7 @@ dependencies = [
 [[package]]
 name = "biome_formatter"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -311,12 +307,11 @@ dependencies = [
  "biome_diagnostics",
  "biome_rowan",
  "biome_string_case",
+ "camino",
  "cfg-if",
- "countme",
  "drop_bomb",
  "indexmap",
  "rustc-hash",
- "schemars",
  "serde",
  "tracing",
  "unicode-width",
@@ -325,7 +320,7 @@ dependencies = [
 [[package]]
 name = "biome_json_factory"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_json_syntax",
  "biome_rowan",
@@ -334,7 +329,7 @@ dependencies = [
 [[package]]
 name = "biome_json_parser"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -350,10 +345,11 @@ dependencies = [
 [[package]]
 name = "biome_json_syntax"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
+ "camino",
  "serde",
 ]
 
@@ -368,9 +364,9 @@ dependencies = [
 [[package]]
 name = "biome_markup"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
 ]
@@ -378,7 +374,7 @@ dependencies = [
 [[package]]
 name = "biome_parser"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -392,26 +388,24 @@ dependencies = [
 [[package]]
 name = "biome_rowan"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_text_edit",
  "biome_text_size",
- "countme",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
  "rustc-hash",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "biome_string_case"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 
 [[package]]
 name = "biome_text_edit"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
  "biome_text_size",
  "serde",
@@ -421,9 +415,8 @@ dependencies = [
 [[package]]
 name = "biome_text_size"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 dependencies = [
- "schemars",
  "serde",
 ]
 
@@ -434,7 +427,7 @@ version = "0.3.1"
 [[package]]
 name = "biome_unicode_table"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome?rev=2648fa4201be4afd26f44eca1a4e77aac0a67272#2648fa4201be4afd26f44eca1a4e77aac0a67272"
+source = "git+https://github.com/biomejs/biome?rev=be9076b2c6714eb5f76ceff59881cdec48475067#be9076b2c6714eb5f76ceff59881cdec48475067"
 
 [[package]]
 name = "bitflags"
@@ -487,30 +480,47 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.19.1"
+name = "cargo-util-schemas"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.65",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
 dependencies = [
  "camino",
  "cargo-platform",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -536,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -613,12 +623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "countme"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
-
-[[package]]
 name = "crates"
 version = "0.0.0"
 dependencies = [
@@ -665,20 +669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,12 +701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,18 +720,19 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -761,13 +746,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
+name = "erased-serde"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -943,9 +938,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -1137,12 +1132,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -1191,15 +1186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-strip-comments"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b271732a960335e715b6b2ae66a086f115c74eb97360e996d2bd809bfc063bba"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,9 +1199,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
@@ -1260,6 +1246,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1403,6 +1395,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,30 +1428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "oxc_resolver"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20bb345f290c46058ba650fef7ca2b579612cf2786b927ebad7b8bec0845a7"
-dependencies = [
- "cfg-if",
- "dashmap 6.1.0",
- "dunce",
- "indexmap",
- "json-strip-comments",
- "once_cell",
- "rustc-hash",
- "serde",
- "serde_json",
- "simdutf8",
- "thiserror 1.0.65",
- "tracing",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1568,19 +1558,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.92"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1624,12 +1635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "result"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,9 +1642,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1650,8 +1655,21 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1682,11 +1700,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
- "indexmap",
  "schemars_derive",
  "serde",
  "serde_json",
- "smallvec",
 ]
 
 [[package]]
@@ -1718,18 +1734,39 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.215"
+name = "serde-untagged"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1748,23 +1785,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_ini"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb236687e2bb073a7521c021949be944641e671b8505a94069ca37b656c81139"
-dependencies = [
- "result",
- "serde",
- "void",
-]
-
-[[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -1829,16 +1854,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -1990,7 +2009,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.38",
  "windows-sys 0.59.0",
 ]
 
@@ -2005,11 +2024,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -2223,7 +2242,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "httparse",
  "lsp-types",
@@ -2255,9 +2274,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2266,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2277,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2338,6 +2357,12 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unicode-bom"
@@ -2425,12 +2450,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ workspace = { path = "./crates/workspace" }
 
 anyhow = "1.0.89"
 assert_matches = "1.5.0"
-biome_formatter = { git = "https://github.com/biomejs/biome", rev = "2648fa4201be4afd26f44eca1a4e77aac0a67272" }
-biome_parser = { git = "https://github.com/biomejs/biome", rev = "2648fa4201be4afd26f44eca1a4e77aac0a67272" }
-biome_rowan = { git = "https://github.com/biomejs/biome", rev = "2648fa4201be4afd26f44eca1a4e77aac0a67272" }
-biome_string_case = { git = "https://github.com/biomejs/biome", rev = "2648fa4201be4afd26f44eca1a4e77aac0a67272" }
-biome_text_size = { git = "https://github.com/biomejs/biome", rev = "2648fa4201be4afd26f44eca1a4e77aac0a67272" }
-biome_unicode_table = { git = "https://github.com/biomejs/biome", rev = "2648fa4201be4afd26f44eca1a4e77aac0a67272" }
+biome_formatter = { git = "https://github.com/biomejs/biome", rev = "be9076b2c6714eb5f76ceff59881cdec48475067" }
+biome_parser = { git = "https://github.com/biomejs/biome", rev = "be9076b2c6714eb5f76ceff59881cdec48475067" }
+biome_rowan = { git = "https://github.com/biomejs/biome", rev = "be9076b2c6714eb5f76ceff59881cdec48475067" }
+biome_string_case = { git = "https://github.com/biomejs/biome", rev = "be9076b2c6714eb5f76ceff59881cdec48475067" }
+biome_text_size = { git = "https://github.com/biomejs/biome", rev = "be9076b2c6714eb5f76ceff59881cdec48475067" }
+biome_unicode_table = { git = "https://github.com/biomejs/biome", rev = "be9076b2c6714eb5f76ceff59881cdec48475067" }
 bytes = "1.8.0"
-cargo_metadata = "0.19.1"
+cargo_metadata = "0.20.0"
 case = "1.0.0"
 clap = { version = "4.5.20", features = ["derive"] }
 colored = "3.0.0"

--- a/crates/air_r_formatter/src/context.rs
+++ b/crates/air_r_formatter/src/context.rs
@@ -3,8 +3,6 @@ use std::rc::Rc;
 
 use air_r_syntax::RLanguage;
 use biome_formatter::printer::PrinterOptions;
-use biome_formatter::AttributePosition;
-use biome_formatter::BracketSpacing;
 use biome_formatter::CstFormatContext;
 use biome_formatter::FormatContext;
 use biome_formatter::FormatOptions;
@@ -175,16 +173,6 @@ impl FormatOptions for RFormatOptions {
 
     fn line_ending(&self) -> biome_formatter::LineEnding {
         self.line_ending.into()
-    }
-
-    fn attribute_position(&self) -> AttributePosition {
-        // TODO: Do we use this?
-        AttributePosition::Auto
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        // TODO: Do we use this?
-        BracketSpacing::default()
     }
 
     fn as_print_options(&self) -> PrinterOptions {

--- a/crates/air_r_formatter/src/r/auxiliary/root.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/root.rs
@@ -88,14 +88,14 @@ impl FormatNodeRule<RRoot> for FormatRRoot {
         // manually with `dynamic_text()`.
         mark_visited(node.syntax(), f);
 
-        // `node.text()` trims trivia so we get the raw text on the syntax
+        // `node.to_trimmed_string()` trims trivia so we get the raw text on the syntax
         // node instead
-        let text: String = node.syntax().text().into();
+        let text: String = node.syntax().text_with_trivia().into();
 
         // Formatting with `format_suppressed_node()` does not work well
         // here because it only formats the node verbatim, not the leading
         // and trailing trivia
-        dynamic_text(&text, node.syntax().text_range().start()).fmt(f)
+        dynamic_text(&text, node.syntax().text_range_with_trivia().start()).fmt(f)
     }
 }
 

--- a/crates/crates/build.rs
+++ b/crates/crates/build.rs
@@ -21,7 +21,7 @@ fn write_workspace_crate_names() {
     let mut packages: Vec<String> = metadata
         .workspace_packages()
         .into_iter()
-        .map(|package| package.name.clone())
+        .map(|package| package.name.clone().into_inner())
         .collect();
 
     // Sort for stability across `cargo metadata` versions

--- a/crates/lsp/src/documents.rs
+++ b/crates/lsp/src/documents.rs
@@ -208,7 +208,7 @@ mod tests {
         let document = Document::doodle("\n\n# hi there");
         let root = document.syntax();
         assert_eq!(
-            root.text_range(),
+            root.text_range_with_trivia(),
             TextRange::new(TextSize::from(0), TextSize::from(12))
         );
     }

--- a/crates/lsp/src/handlers_format.rs
+++ b/crates/lsp/src/handlers_format.rs
@@ -236,7 +236,7 @@ fn find_deepest_enclosing_logical_lines(node: RSyntaxNode, range: TextRange) -> 
     // ```
     let logical_lines: Vec<RSyntaxNode> = iter
         .map(|expr| expr.into_syntax())
-        .skip_while(|node| !node.text_range().contains(range.start()))
+        .skip_while(|node| !node.text_range_with_trivia().contains(range.start()))
         .take_while(|node| node.text_trimmed_range().start() <= range.end())
         .collect();
 
@@ -258,7 +258,7 @@ fn find_expression_lists(node: &RSyntaxNode, offset: TextSize, end: bool) -> Vec
                     let trimmed_node_range = node.text_trimmed_range();
                     trimmed_node_range.contains_inclusive(offset)
                 } else {
-                    let node_range = node.text_range();
+                    let node_range = node.text_range_with_trivia();
                     node_range.contains(offset)
                 };
 


### PR DESCRIPTION
Biome has done their 2.0.0 release:
https://github.com/biomejs/biome/releases/tag/%40biomejs%2Fbiome%402.0.0

At the moment, that tag is pinned to this commit (though they have been sliding the commit associated with the tag as they work out minor buglets)
https://github.com/biomejs/biome/commit/be9076b2c6714eb5f76ceff59881cdec48475067

This PR updates us to also be pinned to the https://github.com/biomejs/biome/commit/be9076b2c6714eb5f76ceff59881cdec48475067 commit.

We will need to be up to date with Biome so that when they merge https://github.com/biomejs/biome/pull/6222 for us, we can take on the `biome_line_index` dependency and keep all biome deps pinned to the same git commit.

This is the first time we have updated Biome. Luckily, the breaking changes seem to be very minor, and look to all be improvements imo. I think for the most part the `biome_parser` and `biome_formatter` and `biome_rowan` crates are decently stable, and most of the churn comes in their other crates.

---

- [Overall diff (not that useful, and huge)](https://github.com/biomejs/biome/compare/2648fa4201be4afd26f44eca1a4e77aac0a67272...be9076b2c6714eb5f76ceff59881cdec48475067)

- [Changes in `biome_rowan`](https://github.com/biomejs/biome/commits/main/crates/biome_rowan?since=2024-11-18&until=2025-06-18)
    - https://github.com/biomejs/biome/pull/4297
        - `AstNode::text` to `AstNode::to_trimmed_string`
        - `SyntaxNode::text` to `SyntaxNode::text_with_trivia`
        - `SyntaxNode::text_range` to `SyntaxNode::text_range_with_trivia`
    - https://github.com/biomejs/biome/pull/6325
        - `PartialEq` on `SendNode` for use in salsa queries 
    - A few PRs related to this [`Text` object](https://github.com/biomejs/biome/blob/main/crates/biome_rowan/src/text.rs) I've never seen before, which is like a `Cow` for node text.
        - https://github.com/biomejs/biome/pull/5578 

- [Changes in `biome_parser`](https://github.com/biomejs/biome/commits/main/crates/biome_parser?since=2024-11-18&until=2025-06-18)
    - https://github.com/biomejs/biome/pull/6293
        - A fix for zero-width tokens and trivia placement. We don't have zero-width tokens right now, but it's still a meaningful bug fix I think. 

- [Changes in `biome_formatter`](https://github.com/biomejs/biome/commits/main/crates/biome_formatter?since=2024-11-18&until=2025-06-18)
    - https://github.com/biomejs/biome/pull/5088
        - The `FormatOptions` trait was simplified, removing `BracketSpacing` and `AttributePosition` from being "required". We were just specifying the default values, but weren't using them at all, I don't think they are relevant to us.
    - https://github.com/biomejs/biome/pull/5239
        - A fix for a lifetime issue in `best_fitting!` for Rust 2024 edition 

- [Changes in `biome_string_case`](https://github.com/biomejs/biome/commits/main/crates/biome_string_case?since=2024-11-18&until=2025-06-18)
    - Nothing notable 

- [Changes in `biome_text_size`](https://github.com/biomejs/biome/commits/main/crates/biome_text_size?since=2024-11-18&until=2025-06-18)
    - Nothing notable 

- [Changes in `biome_unicode_table`](https://github.com/biomejs/biome/commits/main/crates/biome_unicode_table?since=2024-11-18&until=2025-06-18)
    - Nothing notable 