### PR TITLE
Add brew formula option for macOS/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ On macOS and Linux:
 curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
 ```
 
+Or, if you're familiar with [Homebrew](https://brew.sh/), install the [air formula](https://formulae.brew.sh/formula/air) with:
+
+```bash
+brew install air
+```
+
 On Windows:
 
 ```shell

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -16,6 +16,12 @@ On macOS and Linux:
 curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
 ```
 
+Or, if you're familiar with [Homebrew](https://brew.sh/), install the [air formula](https://formulae.brew.sh/formula/air) with:
+
+```bash
+brew install air
+```
+
 On Windows:
 
 ``` powershell


### PR DESCRIPTION
Update install options for macOS/Linux to include the Homebrew [air formula](https://formulae.brew.sh/formula/air) approach.