### PR TITLE
Add --output and --stdout options to format command

### DIFF
--- a/crates/air/src/args.rs
+++ b/crates/air/src/args.rs
@@ -40,6 +40,16 @@ pub(crate) struct FormatCommand {
     /// and zero otherwise.
     #[arg(long)]
     pub check: bool,
+
+    /// Write formatted output to this file instead of overwriting the input file.
+    /// Only valid when formatting a single file.
+    #[arg(long, short = 'o', value_name = "FILE")]
+    pub output: Option<PathBuf>,
+
+    /// Write formatted output to stdout instead of overwriting the input file.
+    /// Only valid when formatting a single file.
+    #[arg(long)]
+    pub stdout: bool,
 }
 
 #[derive(Clone, Debug, Parser)]


### PR DESCRIPTION
Allows formatting without overwriting the original file by either writing to a different file (`--output`) or to stdout (`--stdout`). Both options only work with single input files and are mutually exclusive with each other and `--check`.