### PR TITLE
Add pyproject.toml for building python wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "air"
+description = "A formatter for R code"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [
+    { name = "Posit Software, PBC" }
+]
+keywords = ["formatter", "parser", "r", "rstats"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "Topic :: Software Development :: Quality Assurance",
+]
+requires-python = ">=3.8"
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/posit-dev/air"
+Repository = "https://github.com/posit-dev/air"
+Documentation = "https://github.com/posit-dev/air"
+Issues = "https://github.com/posit-dev/air/issues"
+
+[tool.maturin]
+manifest-path = "crates/air/Cargo.toml"
+bindings = "bin"
+strip = true # Strip debug symbols for smaller wheels


### PR DESCRIPTION
As discussed in https://github.com/posit-dev/air/issues/269#issuecomment-2826796419, I suggest to use PyPI as one route of distributing `air` binaries. Amongst others, it would be helpful for implementing an official pre-commit hook. 

I gave it a try, and it turns out it is actually quite simple to build python wheels for rust projects using the [maturin](https://github.com/PyO3/maturin) build backend. A simple `pyproject.toml` file is enough. 

To test, simply run 
```
> uv run air --help
```
from a directory that has this PR checked out and it will compile the project and execute the air from the python package. 

Using 
```
uv build
```
the wheels can be compiled that could be distributed via PyPI. 


This PR is meant as a proof-of-concept. If you are interested, I can also help setting up a github action for PyPI publishing. 