### PR TITLE
RC 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Development version
 
+
+# 0.7.1
+
 - We now recommend using [Tombi](https://github.com/tombi-toml/tombi) for `air.toml` autocompletion and validation instead of Even Better TOML. Tombi is easily installable from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=tombi-toml.tombi), the [OpenVSX Marketplace](https://open-vsx.org/namespace/tombi-toml), as a [Zed extension](https://zed.dev/extensions?query=tombi&filter=language-servers), or using some other [supported installation method](https://tombi-toml.github.io/tombi/docs/installation). We've improved on our `air.toml` configuration documentation to help tombi provide the best `air.toml` editing experience (#371).
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/air/Cargo.toml
+++ b/crates/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air"
-version = "0.7.0"
+version = "0.7.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## Development version
 
+
+## 0.16.0
+
+- [Air 0.7.1](https://github.com/posit-dev/air/blob/main/CHANGELOG.md) is now bundled with the extension.
+
 - New `Air: Initialize Workspace Folder` command to initialize a project for use with Air. This supercedes `usethis::use_air()` for VS Code and Positron users by providing a holistic setup experience from within the IDE (#323).
 
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
 	"name": "air-vscode",
 	"displayName": "Air - R Language Support",
 	"description": "R formatter and language server",
-	"version": "0.14.0",
+	"version": "0.16.0",
 	"publisher": "Posit",
 	"license": "MIT",
 	"homepage": "https://posit-dev.github.io/air",


### PR DESCRIPTION
No user facing changes in the binary itself, but we need a new `air.schema.json` to get published to a github release for everyone to get #371, and the VS Code extension gained `Air: Initialize Workspace Folder`, so we'll just do a full minor release.