### PR TITLE
Lazily analyze node directives

### DIFF
--- a/crates/air_r_formatter/src/comments.rs
+++ b/crates/air_r_formatter/src/comments.rs
@@ -1,4 +1,3 @@
-use crate::prelude::*;
 use air_r_syntax::AnyRExpression;
 use air_r_syntax::RArgument;
 use air_r_syntax::RArgumentNameClause;
@@ -21,11 +20,27 @@ use biome_formatter::comments::DecoratedComment;
 use biome_formatter::comments::SourceComment;
 use biome_formatter::write;
 use biome_rowan::AstNode;
+use biome_rowan::SyntaxNode;
 use biome_rowan::SyntaxTriviaPieceComments;
 use comments::Directive;
 use comments::FormatDirective;
 
+use crate::directives::CommentDirectives;
+use crate::prelude::*;
+
 pub type RComments = Comments<RLanguage>;
+
+impl CommentDirectives for RComments {
+    type Language = RLanguage;
+
+    fn directives(&self, node: &SyntaxNode<Self::Language>) -> impl Iterator<Item = Directive> {
+        // We intentionally only consider directives in leading comments. This is a
+        // departure from Biome (and Ruff?).
+        self.leading_comments(node)
+            .iter()
+            .filter_map(|c| comments::parse_comment_directive(c.piece().text()))
+    }
+}
 
 #[derive(Default)]
 pub struct FormatRLeadingComment;

--- a/crates/air_r_formatter/src/directives.rs
+++ b/crates/air_r_formatter/src/directives.rs
@@ -1,0 +1,11 @@
+use biome_rowan::Language;
+use biome_rowan::SyntaxNode;
+use comments::Directive;
+
+/// Generic trait for extracting [comments::Directive]s from a node's comments
+pub trait CommentDirectives {
+    type Language: Language;
+
+    /// Returns an iterator over [comments::Directive]s present in a node's comments
+    fn directives(&self, node: &SyntaxNode<Self::Language>) -> impl Iterator<Item = Directive>;
+}


### PR DESCRIPTION
I think we can delay the `collect()` of `Vec<Directive>` pretty effectively by making a new `CommentDirectives` trait with a `directives()` method that returns an iterator over `Directive`.

I think we are only going to ever iterate over these things, so we shouldn't ever need to do a full materialization of that vector.

I also think it's quite natural to be able to write `f.comments().directives(node)` to get the directives of a node.