### PR TITLE
Move `mark_suppression_checked()` out of `has_skip_directive()`

### DIFF
--- a/crates/air_r_formatter/src/lib.rs
+++ b/crates/air_r_formatter/src/lib.rs
@@ -16,7 +16,7 @@ use crate::comments::RCommentStyle;
 use crate::context::RFormatContext;
 use crate::context::RFormatOptions;
 use crate::cst::FormatRSyntaxNode;
-use crate::directives::has_skip_comment;
+use crate::directives::CommentDirectives;
 
 pub mod comments;
 pub mod context;
@@ -213,7 +213,10 @@ where
 
     /// Returns `true` if the node is suppressed and should use the same formatting as in the source document.
     fn is_suppressed(&self, node: &N, f: &RFormatter) -> bool {
-        has_skip_comment(node.syntax(), f)
+        let node = node.syntax();
+        let comments = f.comments();
+        comments.mark_suppression_checked(node);
+        comments.has_skip_directive(node)
     }
 
     /// Formats a suppressed node

--- a/crates/air_r_formatter/src/r/auxiliary/braced_expressions.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/braced_expressions.rs
@@ -246,8 +246,8 @@ fn fmt_curly_curly(node: &RCurlyCurly, f: &mut RFormatter) -> FormatResult<()> {
     let node_inner = node_inner.syntax();
 
     // It's only possible to suppress the formatting of the outer curlies of curly-curly,
-    // so we don't need to branch based on `comments.is_suppressed()`, but we do need to
-    // mark the node as suppression checked
+    // so we don't need to branch based on `comments.has_skip_directive()`, but we do need
+    // to mark the node as suppression checked
     comments.mark_suppression_checked(node_inner);
 
     // It's impossible to have dangling comments on `node_inner`. That's only possible

--- a/crates/air_r_formatter/src/r/auxiliary/call.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/call.rs
@@ -1,5 +1,4 @@
-use crate::directives::has_skip_comment;
-use crate::directives::has_table_comment;
+use crate::directives::CommentDirectives;
 use crate::directives::in_skip_setting;
 use crate::directives::in_table_setting;
 use crate::prelude::*;
@@ -32,12 +31,15 @@ impl FormatNodeRule<RCall> for FormatRCall {
     }
 
     fn is_suppressed(&self, node: &RCall, f: &RFormatter) -> bool {
-        has_skip_comment(node.syntax(), f) || in_skip_setting(node, f).unwrap_or(false)
+        let comments = f.comments();
+        comments.mark_suppression_checked(node.syntax());
+        comments.has_skip_directive(node.syntax()) || in_skip_setting(node, f).unwrap_or(false)
     }
 }
 
 fn is_table(node: &RCall, f: &RFormatter) -> bool {
-    has_table_comment(node.syntax(), f) || in_table_setting(node, f).unwrap_or(false)
+    let comments = f.comments();
+    comments.has_table_directive(node.syntax()) || in_table_setting(node, f).unwrap_or(false)
 }
 
 impl FormatRuleWithOptions<RCall> for FormatRCall {

--- a/crates/air_r_formatter/src/r/auxiliary/unary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/unary_expression.rs
@@ -1,3 +1,4 @@
+use crate::directives::CommentDirectives;
 use crate::prelude::*;
 use air_r_syntax::AnyRExpression;
 use air_r_syntax::RSyntaxKind;
@@ -18,7 +19,7 @@ impl FormatNodeRule<RUnaryExpression> for FormatRUnaryExpression {
 
         let argument = format_with(|f| {
             if f.comments().has_comments(argument.syntax())
-                && !f.comments().is_suppressed(argument.syntax())
+                && !f.comments().has_skip_directive(argument.syntax())
             {
                 // If an existing comment separates the operator and its argument, we are
                 // forced to line break


### PR DESCRIPTION
I set out to remove `mark_suppression_checked()` from `has_skip_directive()` because, as discussed, it was weird for this particular predicate function to be marking as well.

I realized that we actually had a footgun in the process.

In https://github.com/posit-dev/air/pull/419 we switched away from using `f.context().comments().is_suppressed()` to instead use our directive based approach.

That `Comments::is_suppressed()` method we switched away from does a few things that are noteworthy. It:

- Calls `mark_suppression_checked()`
- Runs on ALL OF leading, dangling, and trailing comments
- Calls `CommentStyle::is_suppression()` with `text` of the comment to determine if it is a suppression comment or not

Our directive based approach:

- Calls `mark_suppression_checked()`
- Runs on JUST leading comments

Even after #419, we still had an implementation for `is_suppression()` floating around that parsed the text and returned `true` if it was a `Skip` directive - regardless of whether it was a leading, trailing, or dangling comment, even though we only want to consider leading ones!

That means that if anyone called `f.context().comments().is_suppressed()`, then it would incorrectly report that a node was suppressed even if it has a non-leading skip directive. This is the footgun, and in fact we did this in `unary_expression.rs`.

I've removed this footgun by making `is_suppression()` unreachable, and by adding a big comment about what you should be looking to use instead. You instead want `f.comments().has_skip_directive(node)` to determine if a node should be suppressed, combined with an explicit call to `f.comments().mark_suppression_checked(node)` on that node to declare that you've checked if it needs to be suppressed or not. That feels a lot better than having the marking tied up in `has_skip_directive()`.

---

Along the way I rejiggered the `CommentDirectives` trait to just expose two extensions

```rust
fn has_skip_directive(&self, node: &SyntaxNode<Self::Language>) -> bool;
fn has_table_directive(&self, node: &SyntaxNode<Self::Language>) -> bool;
```

Previously you'd do `f.comments().directives().any(...)` and now you just do `f.comments().has_skip_directive(node)`, which goes nicely with the rest of the `f.comments().has_*()` family like `f.comments().has_leading_comments(node)`.

---

Lastly, it's worth noting that I really do wish we could just use `f.context().comments().is_suppressed(node)`. In theory between the `node` and the `comments()` we'd have everything we need to correctly determine if it is a correct suppression comment or not. In practice this doesn't work for two reasons:

- `Comments::is_suppressed(node)` isn't overridable, and looks at all of leading, dangling, and trailing comments. This would be okay, but...
- ...`CommentStyle::is_suppression(text)`, which is overridable, only gets the `text`, so we have no way of knowing whether its leading or not.

I think ideally `is_suppressed()` itself would have been configurable in some way?