### PR TITLE
Support table directives in argument position

### DIFF
--- a/crates/air_r_formatter/tests/quick_test.rs
+++ b/crates/air_r_formatter/tests/quick_test.rs
@@ -16,15 +16,14 @@ mod language {
 #[test]
 fn quick_test() {
     let src = r#"
-# fmt: tabular
-tribble(
-    ~quarter, ~region, ~product, ~price, ~units_sold,
-    "Q1", "North", "Laptop", 1499.99, 250,
-    "Q1", "North", "Tablet", 85.5, 340,
-
-    # fmt: tabular off
-    "Q2", "South", "Laptop", 989.0, 196,
-    "Q2", "South", "Tablet", 76.95, 304,
+matrix(
+  data =
+  # fmt: table
+  c(
+    1, 2,
+    10, 200
+  ),
+  ncol = 2
 )
     "#;
 

--- a/crates/air_r_formatter/tests/specs/r/call_table.R
+++ b/crates/air_r_formatter/tests/specs/r/call_table.R
@@ -92,6 +92,29 @@ foooooooooo,baaaaaaaaar,foooooooooo,baaaaaaaaar,foooooooooo,baaaaaaaaar,fooooooo
 )
 
 # ------------------------------------------------------------------------
+# Comment directives
+
+# In argument
+x <- matrix(
+  # fmt: table
+  c(
+    1, 2,
+    10, 200
+  ),
+  ncol = 2
+)
+
+# In argument with name
+matrix(
+  # fmt: table
+  data = c(
+    1, 2,
+    10, 200
+  ),
+  ncol = 2
+)
+
+# ------------------------------------------------------------------------
 # Comments
 
 # fmt: table

--- a/crates/air_r_formatter/tests/specs/r/call_table.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call_table.R.snap
@@ -99,6 +99,29 @@ foooooooooo,baaaaaaaaar,foooooooooo,baaaaaaaaar,foooooooooo,baaaaaaaaar,fooooooo
 )
 
 # ------------------------------------------------------------------------
+# Comment directives
+
+# In argument
+x <- matrix(
+  # fmt: table
+  c(
+    1, 2,
+    10, 200
+  ),
+  ncol = 2
+)
+
+# In argument with name
+matrix(
+  # fmt: table
+  data = c(
+    1, 2,
+    10, 200
+  ),
+  ncol = 2
+)
+
+# ------------------------------------------------------------------------
 # Comments
 
 # fmt: table
@@ -529,6 +552,29 @@ list(
 )
 
 # ------------------------------------------------------------------------
+# Comment directives
+
+# In argument
+x <- matrix(
+  # fmt: table
+  c(
+     1 ,   2 ,
+    10 , 200
+  ),
+  ncol = 2
+)
+
+# In argument with name
+matrix(
+  # fmt: table
+  data = c(
+     1 ,   2 ,
+    10 , 200
+  ),
+  ncol = 2
+)
+
+# ------------------------------------------------------------------------
 # Comments
 
 # fmt: table
@@ -854,8 +900,8 @@ list(
 
 ## Unimplemented nodes/tokens
 
-"(\n\"foo\n\",  2)" => 5299..5312
-"(\n{ foo },  2\n)" => 5331..5346
+"(\n\"foo\n\",  2)" => 5596..5609
+"(\n{ foo },  2\n)" => 5628..5643
 # Lines exceeding max width of 80 characters
 ```
    91:   foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo(baaaaaaaaar, foooooooooo, baaaaaaaaar) ,


### PR DESCRIPTION
Closes #433 

This works but I'll take a deeper look at comments placement in argument lists to make sure it all makes sense.

Also need to investigate panic with:

```r
matrix(
  data =
  # fmt: table
  c(
    1, 2,
    10, 200
  ),
  ncol = 2
)
```