### PR TITLE
Preserve comment placement when trailing a name clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 # Development version
 
+- We now preserve the placement of comments after `=`. E.g. this:
+
+  ```r
+  foo(
+    name = # comment
+      value
+    )
+  ```
+
+  now gets formatted to:
+
+  ```r
+  foo(
+    name =
+      # comment
+      value
+  )
+  ```
+
+  instead of:
+
+  ```r
+  foo(
+    # comment
+    name =
+      value
+  )
+  ```
+
 - Added support for formatting notebook cells (progress towards #405, @kv9898).
 
 

--- a/crates/air_r_formatter/src/comments.rs
+++ b/crates/air_r_formatter/src/comments.rs
@@ -779,7 +779,11 @@ fn handle_argument_comment(comment: DecoratedComment<RLanguage>) -> CommentPlace
         // )
         // ```
         if name_clause.syntax() == preceding {
-            return CommentPlacement::leading(preceding.clone(), comment);
+            if let Some(following) = comment.following_node() {
+                return CommentPlacement::leading(following.clone(), comment);
+            } else {
+                return CommentPlacement::leading(preceding.clone(), comment);
+            }
         }
     }
 

--- a/crates/air_r_formatter/tests/specs/r/call.R
+++ b/crates/air_r_formatter/tests/specs/r/call.R
@@ -527,6 +527,18 @@ with(
   # own-line
 )
 
+list(
+  # comment0
+  foo  # comment1
+  =1, bar  # comment2
+  =  # comment3
+  # comment4
+  2 #comment5
+  #comment6
+  , #comment7
+  #comment8
+)
+
 # ------------------------------------------------------------------------
 # Comments: Trailing inline function
 

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -534,6 +534,18 @@ with(
   # own-line
 )
 
+list(
+  # comment0
+  foo  # comment1
+  =1, bar  # comment2
+  =  # comment3
+  # comment4
+  2 #comment5
+  #comment6
+  , #comment7
+  #comment8
+)
+
 # ------------------------------------------------------------------------
 # Comments: Trailing inline function
 
@@ -1454,18 +1466,20 @@ with(
 
 with(
   xs,
-  # end-of-line
-  expr = {
-    x + 1
-  }
+  expr =
+    # end-of-line
+    {
+      x + 1
+    }
 )
 
 with(
   xs,
-  # own-line
-  expr = {
-    x + 1
-  }
+  expr =
+    # own-line
+    {
+      x + 1
+    }
 )
 
 with(
@@ -1481,6 +1495,19 @@ with(
     x + 1
   }
   # own-line
+)
+
+list(
+  # comment0
+  # comment1
+  foo = 1,
+  # comment2
+  bar =
+    # comment3
+    # comment4
+    2, #comment5 #comment7
+  #comment8
+  #comment6
 )
 
 # ------------------------------------------------------------------------
@@ -1527,18 +1554,20 @@ fn(
 
 fn(
   xs,
-  # end-of-line
-  f = function(x) {
-    x + 1
-  }
+  f =
+    # end-of-line
+    function(x) {
+      x + 1
+    }
 )
 
 fn(
   xs,
-  # own-line
-  f = function(x) {
-    x + 1
-  }
+  f =
+    # own-line
+    function(x) {
+      x + 1
+    }
 )
 
 fn(
@@ -1751,8 +1780,9 @@ c(list(
 ))
 
 c(list(
-  #foo
-  x = 1
+  x =
+    #foo
+    1
 ))
 
 c(list(
@@ -1849,8 +1879,8 @@ foo(bar[
 # Lines exceeding max width of 80 characters
 ```
   316:   my_long_list_my_long_list_my_long_list_my_long_list_long_long_long_long_long_list,
-  789:   foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz
-  793: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz()))
-  796: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
-  809:   name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
+  806:   foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz
+  810: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz()))
+  813: c(list(foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
+  826:   name = foobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbafoobarbazzzzzzzzzfoobarbaz(
 ```

--- a/crates/air_r_formatter/tests/specs/r/call_table.R
+++ b/crates/air_r_formatter/tests/specs/r/call_table.R
@@ -122,7 +122,6 @@ list(
   1,2    # comment
 )
 
-# Unfortunate: comment3 gets pulled up by Biome's Comments builder
 # fmt: table
 list(
   foo  # comment1

--- a/crates/air_r_formatter/tests/specs/r/call_table.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call_table.R.snap
@@ -129,7 +129,6 @@ list(
   1,2    # comment
 )
 
-# Unfortunate: comment3 gets pulled up by Biome's Comments builder
 # fmt: table
 list(
   foo  # comment1
@@ -561,14 +560,14 @@ list(
   1 , 2 # comment
 )
 
-# Unfortunate: comment3 gets pulled up by Biome's Comments builder
 # fmt: table
 list(
   # comment1
   foo = 1,
-  # comment3
   # comment2
-  bar = 2,
+  bar =
+    # comment3
+    2,
 )
 
 # ------------------------------------------------------------------------
@@ -854,8 +853,8 @@ list(
 
 ## Unimplemented nodes/tokens
 
-"(\n\"foo\n\",  2)" => 5299..5312
-"(\n{ foo },  2\n)" => 5331..5346
+"(\n\"foo\n\",  2)" => 5238..5251
+"(\n{ foo },  2\n)" => 5270..5285
 # Lines exceeding max width of 80 characters
 ```
    91:   foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo(baaaaaaaaar, foooooooooo, baaaaaaaaar) ,


### PR DESCRIPTION
Progress towards solving the idempotence panic mentioned in https://github.com/posit-dev/air/pull/434
Progress towards #435 

Comments in:

```r
foo(
  name = # comment
    value
)

foo(
  name =
    # comment
    value
)
```

are currently placed on the RArgument node. This causes them to move higher in the tree, and they get formatted as:

```r
foo(
  # comment
  name = value
)

foo(
  # comment
  name = value
)
```

This displacement is particularly problematic in:

```r
list(
  foo  # comment1
  =1, bar  # comment2
  =  # comment3
  2,
)
```

as the comment ordering becomes:

```r
list(
  # comment1
  foo = 1,
  # comment3
  # comment2
  bar = 2,
)
```

To solve this, the PR:

- Places trailing name clause comments as leading comments of argument values
- Introduces a line break and an indent in arguments _with both_ name clauses and leading comments on values

This solves the ordering issue in the last example which is now formatted as:

```r
list(
  # comment1
  foo = 1,
  # comment2
  bar =
    # comment3
    2,
)
```

Remaining issues: in the following example, comment 6 is still formatted out of order, and comment 7 is still on the same line as comment 5:

```r
# fmt: table
list(
  # comment0
  foo  # comment1
  =1, bar  # comment2
  =  # comment3
  # comment4
  2 #comment5
  #comment6
  , #comment7
  #comment8
)
```

becomes:

```r
# fmt: table
list(
  # comment0
  # comment1
  foo = 1,
  # comment2
  bar =
    # comment3
    # comment4
    2, #comment5 #comment7
  #comment8
  #comment6
)
```