### PR TITLE
Converted from lspconfig to vim.lsp for Neovim 0.11 in docs

### DIFF
--- a/docs/editor-neovim.qmd
+++ b/docs/editor-neovim.qmd
@@ -24,7 +24,7 @@ lsp.config['air'] = {
         vim.api.nvim_create_autocmd("BufWritePre", {
             buffer = bufnr,
             callback = function()
-                lsp.buf.format()  
+                lsp.buf.format()
             end,
         })
     end,
@@ -35,7 +35,7 @@ lsp.enable('air')
 
 While not required, the BufWritePre command ensures that Air automatically formats your R code when you save a file.
 
-### Neovim <0.11 
+### Neovim \<0.11
 
 If you are using a version of Neovim that does not support vim.lsp.config:
 
@@ -65,7 +65,7 @@ vim.lsp.config['r_language_server']= {
 }
 ```
 
-### Neovim < 0.11
+### Neovim \< 0.11
 
 ``` lua
 require("lspconfig").r_language_server.setup({


### PR DESCRIPTION
The [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) documentation states that the require('lspconfig') is deprecated and will return a warning for Neovim 0.11+ users.

> require('lspconfig') (the legacy "framework" of nvim-lspconfig) https://github.com/neovim/nvim-lspconfig/issues/3693 in favor of [vim.lsp.config](https://neovim.io/doc/user/lsp.html#lsp-config) (Nvim 0.11+).

Since I had to do the conversion myself, I added another block in the documentation of the syntax for vim.lsp for >= 0.11+ users - if they wish to use it. 