### PR TITLE
Update description for Air extension in Zed

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "air"
 name = "Air"
-description = "Air extension for Zed - R formatting"
+description = "Air, the R formatter"
 version = "0.1.0"
 schema_version = 1
 authors = ["Posit Software, PBC"]


### PR DESCRIPTION
The description shown in Zed doesn't say much, making it hard to discover. 

<img width="272" height="134" alt="image" src="https://github.com/user-attachments/assets/883ef73c-496c-4a4d-98c7-9cd2a59ad4a1" />

Feel free to make your own iteration on this. I'd just love to make sure people can find your extension more easily.