### PR TITLE
Remove some unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ clap = { version = "4.5.20", features = ["derive"] }
 colored = "3.0.0"
 comments = { path = "./crates/comments" }
 crates = { path = "./crates/crates" }
-crossbeam = "0.8.4"
 dissimilar = "1.0.9"
 fs = { path = "./crates/fs" }
 futures = "0.3.31"
@@ -46,7 +45,6 @@ ignore = "0.4.23"
 insta = "1.40.0"
 itertools = "0.13.0"
 line_ending = { path = "./crates/line_ending" }
-line-index = "0.1.2"
 lsp = { path = "./crates/lsp" }
 lsp_test = { path = "./crates/lsp_test" }
 memchr = "2.7.4"
@@ -66,7 +64,6 @@ syn = "2.0.59"
 tempfile = "3.9.0"
 tests_macros = { path = "./crates/tests_macros" }
 thiserror = "2.0.5"
-time = "0.3.37"
 tokio = "1.41.1"
 tokio-util = "0.7.12"
 toml = "0.8.19"

--- a/crates/air_r_formatter/Cargo.toml
+++ b/crates/air_r_formatter/Cargo.toml
@@ -25,7 +25,6 @@ tracing = { workspace = true }
 air_formatter_test = { workspace = true }
 air_r_parser = { workspace = true }
 biome_parser = { workspace = true }
-line_ending = { workspace = true }
 tests_macros = { workspace = true }
 workspace = { workspace = true }
 

--- a/crates/air_r_parser/Cargo.toml
+++ b/crates/air_r_parser/Cargo.toml
@@ -29,7 +29,6 @@ tree-sitter-r = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-line_ending = { workspace = true }
 tests_macros = { workspace = true }
 
 [lints]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -31,7 +31,6 @@ serde_json.workspace = true
 settings.workspace = true
 struct-field-names-as-array.workspace = true
 strum = { workspace = true, features = ["derive"] }
-time = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower-lsp.workspace = true
 tracing.workspace = true
@@ -44,15 +43,9 @@ workspace = { workspace = true }
 
 [dev-dependencies]
 assert_matches.workspace = true
-bytes.workspace = true
-futures-util.workspace = true
-httparse.workspace = true
 insta.workspace = true
 lsp_test.workspace = true
-memchr.workspace = true
 tempfile.workspace = true
-tests_macros.workspace = true
-tokio-util.workspace = true
 
 [lints]
 workspace = true

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -21,8 +21,6 @@ anyhow = { workspace = true }
 biome_formatter = { workspace = true }
 insta = { workspace = true }
 serde = { workspace = true }
-# Self dependency to activate optional features for tests
-settings = { features = ["biome", "serde"], path = "./" }
 toml = { workspace = true }
 
 [features]

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -29,7 +29,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-insta = { workspace = true }
 tempfile = { workspace = true }
 
 [features]


### PR DESCRIPTION
I just ran `cargo shear --fix` (https://github.com/boshen/cargo-shear). Maybe this doesn't change anything for compilation time since those dependencies might be pulled  by others, but it's just low effort for potential gains.