### PR TITLE
Use rustup for toolchain installation

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -27,14 +27,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install rust"
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          targets: ${{ matrix.this.target }}
+      - name: "Install rust toolchain (rust-toolchain.toml)"
+        run: |
+          rustup toolchain install
+          rustup show
 
-      - name: "Report rust toolchain"
-        run: rustup show
+      - name: "Install rust target"
+        run: |
+          rustup target add ${{ matrix.this.target }}
+          rustup target list --installed
 
       - name: "Build"
         run: cargo build --release --locked --target ${{ matrix.this.target }} -p air

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -27,6 +27,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Docker container doesn't come with rustup
+      - name: "Install rustup"
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: "Install rust toolchain (rust-toolchain.toml)"
         run: |
           rustup toolchain install

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -20,14 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install rust"
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          targets: ${{ matrix.this.target }}
+      - name: "Install rust toolchain (rust-toolchain.toml)"
+        run: |
+          rustup toolchain install
+          rustup show
 
-      - name: "Report rust toolchain"
-        run: rustup show
+      - name: "Install rust target"
+        run: |
+          rustup target add ${{ matrix.this.target }}
+          rustup target list --installed
 
       - name: "Build"
         run: cargo build --release --locked --target ${{ matrix.this.target }} -p air

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,14 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install rust"
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          targets: ${{ matrix.this.target }}
+      - name: "Install rust toolchain (rust-toolchain.toml)"
+        run: |
+          rustup toolchain install
+          rustup show
 
-      - name: "Report rust toolchain"
-        run: rustup show
+      - name: "Install rust target"
+        run: |
+          rustup target add ${{ matrix.this.target }}
+          rustup target list --installed
 
       - name: "Build"
         run: cargo build --release --locked --target ${{ matrix.this.target }} -p air

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -22,8 +22,10 @@ jobs:
         run: |
           sudo apt-get update
 
-      - name: Report rust toolchain
-        run: rustup show
+      - name: Install rust toolchain (rust-toolchain.toml)
+        run: |
+          rustup toolchain install
+          rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RUSTUP_TOOLCHAIN: ${{ matrix.config.rust == 'nightly' && 'nightly' || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -30,12 +31,10 @@ jobs:
         run: |
           sudo apt-get update
 
-      - name: Install nightly rust
-        uses: dtolnay/rust-toolchain@nightly
-        if: matrix.config.rust == 'nightly'
-
-      - name: Report rust toolchain
-        run: rustup show
+      - name: Install rust toolchain (rust-toolchain.toml / RUSTUP_TOOLCHAIN)
+        run: |
+          rustup toolchain install
+          rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -7,20 +7,19 @@ on:
 jobs:
   macos:
     runs-on: macos-latest
-    name: "Rust: ${{ matrix.config.rust }}"
+    name: "Rust: stable"
     strategy:
       fail-fast: false
-      matrix:
-        config:
-          - { rust: 'stable' }
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Report rust toolchain
-        run: rustup show
+      - name: Install rust toolchain (rust-toolchain.toml)
+        run: |
+          rustup toolchain install
+          rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -7,20 +7,19 @@ on:
 jobs:
   windows:
     runs-on: windows-latest
-    name: "Rust: ${{ matrix.config.rust }}"
+    name: "Rust: stable"
     strategy:
       fail-fast: false
-      matrix:
-        config:
-          - { rust: 'stable' }
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Report rust toolchain
-        run: rustup show
+      - name: Install rust toolchain (rust-toolchain.toml)
+        run: |
+          rustup toolchain install
+          rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
So it always respects `rust-toolchain.toml`