### PR TITLE
Move json schema generation to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,15 +921,14 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -1231,9 +1230,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,13 +2821,20 @@ dependencies = [
  "biome_ungrammar",
  "bpaf",
  "git2",
- "insta",
  "proc-macro2",
  "quote",
+ "xtask",
+]
+
+[[package]]
+name = "xtask_json_schema"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "insta",
  "schemars",
  "serde_json",
  "workspace",
- "xtask",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/*", "editors/zed", "xtask/codegen"]
+members = ["crates/*", "editors/zed", "xtask/codegen", "xtask/json_schema"]
 
 [workspace.package]
 authors = ["Posit Software, PBC"]

--- a/crates/crates/src/snapshots/crates__tests__crate_names.snap
+++ b/crates/crates/src/snapshots/crates__tests__crate_names.snap
@@ -22,5 +22,6 @@ expression: AIR_CRATE_NAMES
     "workspace",
     "xtask",
     "xtask_codegen",
+    "xtask_json_schema",
     "zed_air",
 ]

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ gen-grammar:
 
 # Generates the `air.schema.json`
 gen-schema:
-    cargo run -p xtask_codegen -- json-schema
+    cargo run -p xtask_json_schema
 
 # Run the tests
 test *ARGS:

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -12,13 +12,7 @@ bpaf = { version = "0.9.15", features = ["derive"] }
 git2 = { version = "0.19.0", default-features = false }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 quote = { workspace = true }
-schemars = { workspace = true }
-serde_json = { workspace = true }
-workspace = { workspace = true, features = ["schemars"] }
 xtask = { version = "0.0", path = "../" }
-
-[dev-dependencies]
-insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { workspace = true }
 biome_string_case = { workspace = true }
 biome_ungrammar = { workspace = true }
 bpaf = { version = "0.9.15", features = ["derive"] }
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.21.0", default-features = false }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 quote = { workspace = true }
 xtask = { version = "0.0", path = "../" }

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -51,7 +51,7 @@ impl GitRepo {
         let mut dirty = HashSet::new();
 
         for status in statuses.iter() {
-            if let Some(path) = status.path() {
+            if let Ok(path) = status.path() {
                 match status.status() {
                     Status::CURRENT => (),
                     Status::INDEX_NEW

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -8,7 +8,6 @@ mod generate_nodes;
 mod generate_nodes_mut;
 mod generate_syntax_factory;
 mod generate_syntax_kinds;
-mod r_json_schema;
 mod r_kinds_src;
 
 mod kind_src;
@@ -22,7 +21,6 @@ use xtask::{glue::fs2, Mode, Result};
 
 pub use self::ast::generate_ast;
 pub use self::formatter::generate_formatters;
-pub use self::r_json_schema::generate_json_schema;
 
 pub enum UpdateResult {
     NotUpdated,
@@ -73,6 +71,4 @@ pub enum TaskCommand {
     /// Runs ALL the codegen
     #[bpaf(command)]
     All,
-    #[bpaf(command, long("json-schema"))]
-    JsonSchema,
 }

--- a/xtask/codegen/src/main.rs
+++ b/xtask/codegen/src/main.rs
@@ -1,9 +1,7 @@
 use xtask::{project_root, pushd, Result};
 
 use xtask::Mode::Overwrite;
-use xtask_codegen::{
-    generate_ast, generate_formatters, generate_json_schema, task_command, TaskCommand,
-};
+use xtask_codegen::{generate_ast, generate_formatters, task_command, TaskCommand};
 
 fn main() -> Result<()> {
     let _d = pushd(project_root());
@@ -19,9 +17,6 @@ fn main() -> Result<()> {
         TaskCommand::All => {
             generate_ast(Overwrite, vec![])?;
             generate_formatters();
-        }
-        TaskCommand::JsonSchema => {
-            generate_json_schema()?;
         }
     }
 

--- a/xtask/json_schema/Cargo.toml
+++ b/xtask/json_schema/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "xtask_json_schema"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+schemars = { workspace = true }
+serde_json = { workspace = true }
+# This pulls in air_r_syntax, so we keep it separate from the codegen xtask
+workspace = { workspace = true, features = ["schemars"] }
+
+[dev-dependencies]
+insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/xtask/json_schema/src/main.rs
+++ b/xtask/json_schema/src/main.rs
@@ -2,7 +2,11 @@ use std::path::PathBuf;
 
 const ROOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../");
 
-pub fn generate_json_schema() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    generate_json_schema()
+}
+
+fn generate_json_schema() -> anyhow::Result<()> {
     let schema = json_schema()?;
     let schema_path = schema_path();
     std::fs::write(schema_path, schema.as_bytes())?;
@@ -23,8 +27,8 @@ fn schema_path() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use crate::r_json_schema::json_schema;
-    use crate::r_json_schema::schema_path;
+    use crate::json_schema;
+    use crate::schema_path;
 
     #[test]
     fn test_schema_can_be_generated_and_hasnt_changed() -> anyhow::Result<()> {

--- a/xtask/json_schema/src/snapshots/xtask_json_schema__tests__schema_can_be_generated_and_hasnt_changed.snap
+++ b/xtask/json_schema/src/snapshots/xtask_json_schema__tests__schema_can_be_generated_and_hasnt_changed.snap
@@ -1,5 +1,5 @@
 ---
-source: xtask/codegen/src/r_json_schema.rs
+source: xtask/json_schema/src/main.rs
 expression: schema
 ---
 {


### PR DESCRIPTION
It requires `workspace`, which means we can't run the codegen without requiring `air_r_syntax` to compile, and it often doesn't while we are actively working on the grammar!