### PR TITLE
Update tree-sitter-r to reject `.[digit]` as an `identifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
   - Hexadecimal constants with decimals are no longer parsed as two separate values (#495).
 
+  - `.{digit}` (like `.1`) is now correctly parsed as a double rather than as an identifier. This means that things like `function(.1 = 1) {}`, where `.1` is expected to be an identifier but not a double, now correctly fails to parse (#496).
+
 # Development version
 
 # 0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,7 @@ checksum = "e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600"
 [[package]]
 name = "tree-sitter-r"
 version = "1.2.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=ceee38d8260856c1ace9012348916a3d2965e5e5#ceee38d8260856c1ace9012348916a3d2965e5e5"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=37a6b1b5c8cc2426fd6ec16ca818cc98597d755b#37a6b1b5c8cc2426fd6ec16ca818cc98597d755b"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tower-lsp = { branch = "bugfix/patches", git = "https://github.com/lionel-/tower
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.19"
 tree-sitter = "0.24.7"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "ceee38d8260856c1ace9012348916a3d2965e5e5" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "37a6b1b5c8cc2426fd6ec16ca818cc98597d755b" }
 url = "2.5.3"
 uuid = { version = "1.11.0", features = ["v4"] }
 workspace = { path = "./crates/workspace" }

--- a/crates/air_r_parser/tests/snapshots/ok/value/complex_value.R
+++ b/crates/air_r_parser/tests/snapshots/ok/value/complex_value.R
@@ -2,3 +2,6 @@
 2.5i
 1e6i
 0x123Fi
+
+# https://github.com/r-lib/tree-sitter-r/pull/198
+.1i

--- a/crates/air_r_parser/tests/snapshots/ok/value/complex_value.R.snap
+++ b/crates/air_r_parser/tests/snapshots/ok/value/complex_value.R.snap
@@ -10,6 +10,9 @@ expression: snapshot
 1e6i
 0x123Fi
 
+# https://github.com/r-lib/tree-sitter-r/pull/198
+.1i
+
 ```
 
 
@@ -31,17 +34,20 @@ RRoot {
         RComplexValue {
             value_token: R_COMPLEX_LITERAL@12..20 "0x123Fi" [Newline("\n")] [],
         },
+        RComplexValue {
+            value_token: R_COMPLEX_LITERAL@20..75 ".1i" [Newline("\n"), Newline("\n"), Comments("# https://github.com/ ..."), Newline("\n")] [],
+        },
     ],
-    eof_token: EOF@20..21 "" [Newline("\n")] [],
+    eof_token: EOF@75..76 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: R_ROOT@0..21
+0: R_ROOT@0..76
   0: (empty)
-  1: R_EXPRESSION_LIST@0..20
+  1: R_EXPRESSION_LIST@0..75
     0: R_COMPLEX_VALUE@0..2
       0: R_COMPLEX_LITERAL@0..2 "1i" [] []
     1: R_COMPLEX_VALUE@2..7
@@ -50,6 +56,8 @@ RRoot {
       0: R_COMPLEX_LITERAL@7..12 "1e6i" [Newline("\n")] []
     3: R_COMPLEX_VALUE@12..20
       0: R_COMPLEX_LITERAL@12..20 "0x123Fi" [Newline("\n")] []
-  2: EOF@20..21 "" [Newline("\n")] []
+    4: R_COMPLEX_VALUE@20..75
+      0: R_COMPLEX_LITERAL@20..75 ".1i" [Newline("\n"), Newline("\n"), Comments("# https://github.com/ ..."), Newline("\n")] []
+  2: EOF@75..76 "" [Newline("\n")] []
 
 ```

--- a/crates/air_r_parser/tests/snapshots/ok/value/double_value.R
+++ b/crates/air_r_parser/tests/snapshots/ok/value/double_value.R
@@ -3,6 +3,9 @@
 1e6
 0x123F
 
+# https://github.com/r-lib/tree-sitter-r/pull/198
+.1
+
 # Hexadecimal
 # `x` vs `X`
 0x123

--- a/crates/air_r_parser/tests/snapshots/ok/value/double_value.R.snap
+++ b/crates/air_r_parser/tests/snapshots/ok/value/double_value.R.snap
@@ -10,6 +10,9 @@ expression: snapshot
 1e6
 0x123F
 
+# https://github.com/r-lib/tree-sitter-r/pull/198
+.1
+
 # Hexadecimal
 # `x` vs `X`
 0x123
@@ -61,82 +64,85 @@ RRoot {
             value_token: R_DOUBLE_LITERAL@9..16 "0x123F" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@16..50 "0x123" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@16..70 ".1" [Newline("\n"), Newline("\n"), Comments("# https://github.com/ ..."), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@50..56 "0X123" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@70..104 "0x123" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@56..85 "0xDEAD" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@104..110 "0X123" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@85..92 "0XDEAD" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@110..139 "0xDEAD" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@92..100 "0x1f2F3" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@139..146 "0XDEAD" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@100..108 "0X1f2F3" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@146..154 "0x1f2F3" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@108..127 "0x0p0" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@154..162 "0X1f2F3" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@127..133 "0x0P0" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@162..181 "0x0p0" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@133..141 "0x0p123" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@181..187 "0x0P0" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@141..149 "0x0P123" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@187..195 "0x0p123" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@149..170 "0x0p+0" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@195..203 "0x0P123" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@170..177 "0x0p-0" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@203..224 "0x0p+0" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@177..186 "0x0p+123" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@224..231 "0x0p-0" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@186..195 "0x0p-123" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@231..240 "0x0p+123" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@195..215 "0x." [Newline("\n"), Comments("# Decimal point"), Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@240..249 "0x0p-123" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@215..220 "0x1." [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@249..269 "0x." [Newline("\n"), Comments("# Decimal point"), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@220..225 "0x.1" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@269..274 "0x1." [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@225..231 "0x1.1" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@274..279 "0x.1" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@231..267 "0x.p1" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@279..285 "0x1.1" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@267..274 "0x1.p1" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@285..321 "0x.p1" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@274..281 "0x.1p1" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@321..328 "0x1.p1" [Newline("\n")] [],
         },
         RDoubleValue {
-            value_token: R_DOUBLE_LITERAL@281..289 "0x1.1p1" [Newline("\n")] [],
+            value_token: R_DOUBLE_LITERAL@328..335 "0x.1p1" [Newline("\n")] [],
+        },
+        RDoubleValue {
+            value_token: R_DOUBLE_LITERAL@335..343 "0x1.1p1" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@289..289 "" [] [],
+    eof_token: EOF@343..343 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: R_ROOT@0..289
+0: R_ROOT@0..343
   0: (empty)
-  1: R_EXPRESSION_LIST@0..289
+  1: R_EXPRESSION_LIST@0..343
     0: R_DOUBLE_VALUE@0..1
       0: R_DOUBLE_LITERAL@0..1 "1" [] []
     1: R_DOUBLE_VALUE@1..5
@@ -145,50 +151,52 @@ RRoot {
       0: R_DOUBLE_LITERAL@5..9 "1e6" [Newline("\n")] []
     3: R_DOUBLE_VALUE@9..16
       0: R_DOUBLE_LITERAL@9..16 "0x123F" [Newline("\n")] []
-    4: R_DOUBLE_VALUE@16..50
-      0: R_DOUBLE_LITERAL@16..50 "0x123" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] []
-    5: R_DOUBLE_VALUE@50..56
-      0: R_DOUBLE_LITERAL@50..56 "0X123" [Newline("\n")] []
-    6: R_DOUBLE_VALUE@56..85
-      0: R_DOUBLE_LITERAL@56..85 "0xDEAD" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] []
-    7: R_DOUBLE_VALUE@85..92
-      0: R_DOUBLE_LITERAL@85..92 "0XDEAD" [Newline("\n")] []
-    8: R_DOUBLE_VALUE@92..100
-      0: R_DOUBLE_LITERAL@92..100 "0x1f2F3" [Newline("\n")] []
-    9: R_DOUBLE_VALUE@100..108
-      0: R_DOUBLE_LITERAL@100..108 "0X1f2F3" [Newline("\n")] []
-    10: R_DOUBLE_VALUE@108..127
-      0: R_DOUBLE_LITERAL@108..127 "0x0p0" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] []
-    11: R_DOUBLE_VALUE@127..133
-      0: R_DOUBLE_LITERAL@127..133 "0x0P0" [Newline("\n")] []
-    12: R_DOUBLE_VALUE@133..141
-      0: R_DOUBLE_LITERAL@133..141 "0x0p123" [Newline("\n")] []
-    13: R_DOUBLE_VALUE@141..149
-      0: R_DOUBLE_LITERAL@141..149 "0x0P123" [Newline("\n")] []
-    14: R_DOUBLE_VALUE@149..170
-      0: R_DOUBLE_LITERAL@149..170 "0x0p+0" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] []
-    15: R_DOUBLE_VALUE@170..177
-      0: R_DOUBLE_LITERAL@170..177 "0x0p-0" [Newline("\n")] []
-    16: R_DOUBLE_VALUE@177..186
-      0: R_DOUBLE_LITERAL@177..186 "0x0p+123" [Newline("\n")] []
-    17: R_DOUBLE_VALUE@186..195
-      0: R_DOUBLE_LITERAL@186..195 "0x0p-123" [Newline("\n")] []
-    18: R_DOUBLE_VALUE@195..215
-      0: R_DOUBLE_LITERAL@195..215 "0x." [Newline("\n"), Comments("# Decimal point"), Newline("\n")] []
-    19: R_DOUBLE_VALUE@215..220
-      0: R_DOUBLE_LITERAL@215..220 "0x1." [Newline("\n")] []
-    20: R_DOUBLE_VALUE@220..225
-      0: R_DOUBLE_LITERAL@220..225 "0x.1" [Newline("\n")] []
-    21: R_DOUBLE_VALUE@225..231
-      0: R_DOUBLE_LITERAL@225..231 "0x1.1" [Newline("\n")] []
-    22: R_DOUBLE_VALUE@231..267
-      0: R_DOUBLE_LITERAL@231..267 "0x.p1" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] []
-    23: R_DOUBLE_VALUE@267..274
-      0: R_DOUBLE_LITERAL@267..274 "0x1.p1" [Newline("\n")] []
-    24: R_DOUBLE_VALUE@274..281
-      0: R_DOUBLE_LITERAL@274..281 "0x.1p1" [Newline("\n")] []
-    25: R_DOUBLE_VALUE@281..289
-      0: R_DOUBLE_LITERAL@281..289 "0x1.1p1" [Newline("\n")] []
-  2: EOF@289..289 "" [] []
+    4: R_DOUBLE_VALUE@16..70
+      0: R_DOUBLE_LITERAL@16..70 ".1" [Newline("\n"), Newline("\n"), Comments("# https://github.com/ ..."), Newline("\n")] []
+    5: R_DOUBLE_VALUE@70..104
+      0: R_DOUBLE_LITERAL@70..104 "0x123" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] []
+    6: R_DOUBLE_VALUE@104..110
+      0: R_DOUBLE_LITERAL@104..110 "0X123" [Newline("\n")] []
+    7: R_DOUBLE_VALUE@110..139
+      0: R_DOUBLE_LITERAL@110..139 "0xDEAD" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] []
+    8: R_DOUBLE_VALUE@139..146
+      0: R_DOUBLE_LITERAL@139..146 "0XDEAD" [Newline("\n")] []
+    9: R_DOUBLE_VALUE@146..154
+      0: R_DOUBLE_LITERAL@146..154 "0x1f2F3" [Newline("\n")] []
+    10: R_DOUBLE_VALUE@154..162
+      0: R_DOUBLE_LITERAL@154..162 "0X1f2F3" [Newline("\n")] []
+    11: R_DOUBLE_VALUE@162..181
+      0: R_DOUBLE_LITERAL@162..181 "0x0p0" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] []
+    12: R_DOUBLE_VALUE@181..187
+      0: R_DOUBLE_LITERAL@181..187 "0x0P0" [Newline("\n")] []
+    13: R_DOUBLE_VALUE@187..195
+      0: R_DOUBLE_LITERAL@187..195 "0x0p123" [Newline("\n")] []
+    14: R_DOUBLE_VALUE@195..203
+      0: R_DOUBLE_LITERAL@195..203 "0x0P123" [Newline("\n")] []
+    15: R_DOUBLE_VALUE@203..224
+      0: R_DOUBLE_LITERAL@203..224 "0x0p+0" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] []
+    16: R_DOUBLE_VALUE@224..231
+      0: R_DOUBLE_LITERAL@224..231 "0x0p-0" [Newline("\n")] []
+    17: R_DOUBLE_VALUE@231..240
+      0: R_DOUBLE_LITERAL@231..240 "0x0p+123" [Newline("\n")] []
+    18: R_DOUBLE_VALUE@240..249
+      0: R_DOUBLE_LITERAL@240..249 "0x0p-123" [Newline("\n")] []
+    19: R_DOUBLE_VALUE@249..269
+      0: R_DOUBLE_LITERAL@249..269 "0x." [Newline("\n"), Comments("# Decimal point"), Newline("\n")] []
+    20: R_DOUBLE_VALUE@269..274
+      0: R_DOUBLE_LITERAL@269..274 "0x1." [Newline("\n")] []
+    21: R_DOUBLE_VALUE@274..279
+      0: R_DOUBLE_LITERAL@274..279 "0x.1" [Newline("\n")] []
+    22: R_DOUBLE_VALUE@279..285
+      0: R_DOUBLE_LITERAL@279..285 "0x1.1" [Newline("\n")] []
+    23: R_DOUBLE_VALUE@285..321
+      0: R_DOUBLE_LITERAL@285..321 "0x.p1" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] []
+    24: R_DOUBLE_VALUE@321..328
+      0: R_DOUBLE_LITERAL@321..328 "0x1.p1" [Newline("\n")] []
+    25: R_DOUBLE_VALUE@328..335
+      0: R_DOUBLE_LITERAL@328..335 "0x.1p1" [Newline("\n")] []
+    26: R_DOUBLE_VALUE@335..343
+      0: R_DOUBLE_LITERAL@335..343 "0x1.1p1" [Newline("\n")] []
+  2: EOF@343..343 "" [] []
 
 ```

--- a/crates/air_r_parser/tests/snapshots/ok/value/integer_value.R
+++ b/crates/air_r_parser/tests/snapshots/ok/value/integer_value.R
@@ -1,6 +1,9 @@
 1L
 1e5L
 
+# https://github.com/r-lib/tree-sitter-r/pull/198
+.1L
+
 # Hexadecimal
 # `x` vs `X`
 0x123L

--- a/crates/air_r_parser/tests/snapshots/ok/value/integer_value.R.snap
+++ b/crates/air_r_parser/tests/snapshots/ok/value/integer_value.R.snap
@@ -8,6 +8,9 @@ expression: snapshot
 1L
 1e5L
 
+# https://github.com/r-lib/tree-sitter-r/pull/198
+.1L
+
 # Hexadecimal
 # `x` vs `X`
 0x123L
@@ -53,130 +56,135 @@ RRoot {
             value_token: R_INTEGER_LITERAL@2..7 "1e5L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@7..42 "0x123L" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@7..62 ".1L" [Newline("\n"), Newline("\n"), Comments("# https://github.com/ ..."), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@42..49 "0X123L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@62..97 "0x123L" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@49..79 "0xDEADL" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@97..104 "0X123L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@79..87 "0XDEADL" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@104..134 "0xDEADL" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@87..96 "0x1f2F3L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@134..142 "0XDEADL" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@96..105 "0X1f2F3L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@142..151 "0x1f2F3L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@105..125 "0x0p0L" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@151..160 "0X1f2F3L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@125..132 "0x0P0L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@160..180 "0x0p0L" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@132..141 "0x0p123L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@180..187 "0x0P0L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@141..150 "0x0P123L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@187..196 "0x0p123L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@150..172 "0x0p+0L" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@196..205 "0x0P123L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@172..180 "0x0p-0L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@205..227 "0x0p+0L" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@180..190 "0x0p+123L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@227..235 "0x0p-0L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@190..200 "0x0p-123L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@235..245 "0x0p+123L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@200..221 "0x.L" [Newline("\n"), Comments("# Decimal point"), Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@245..255 "0x0p-123L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@221..227 "0x1.L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@255..276 "0x.L" [Newline("\n"), Comments("# Decimal point"), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@227..233 "0x.1L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@276..282 "0x1.L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@233..240 "0x1.1L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@282..288 "0x.1L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@240..277 "0x.p1L" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@288..295 "0x1.1L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@277..285 "0x1.p1L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@295..332 "0x.p1L" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@285..293 "0x.1p1L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@332..340 "0x1.p1L" [Newline("\n")] [],
         },
         RIntegerValue {
-            value_token: R_INTEGER_LITERAL@293..302 "0x1.1p1L" [Newline("\n")] [],
+            value_token: R_INTEGER_LITERAL@340..348 "0x.1p1L" [Newline("\n")] [],
+        },
+        RIntegerValue {
+            value_token: R_INTEGER_LITERAL@348..357 "0x1.1p1L" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@302..302 "" [] [],
+    eof_token: EOF@357..357 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: R_ROOT@0..302
+0: R_ROOT@0..357
   0: (empty)
-  1: R_EXPRESSION_LIST@0..302
+  1: R_EXPRESSION_LIST@0..357
     0: R_INTEGER_VALUE@0..2
       0: R_INTEGER_LITERAL@0..2 "1L" [] []
     1: R_INTEGER_VALUE@2..7
       0: R_INTEGER_LITERAL@2..7 "1e5L" [Newline("\n")] []
-    2: R_INTEGER_VALUE@7..42
-      0: R_INTEGER_LITERAL@7..42 "0x123L" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] []
-    3: R_INTEGER_VALUE@42..49
-      0: R_INTEGER_LITERAL@42..49 "0X123L" [Newline("\n")] []
-    4: R_INTEGER_VALUE@49..79
-      0: R_INTEGER_LITERAL@49..79 "0xDEADL" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] []
-    5: R_INTEGER_VALUE@79..87
-      0: R_INTEGER_LITERAL@79..87 "0XDEADL" [Newline("\n")] []
-    6: R_INTEGER_VALUE@87..96
-      0: R_INTEGER_LITERAL@87..96 "0x1f2F3L" [Newline("\n")] []
-    7: R_INTEGER_VALUE@96..105
-      0: R_INTEGER_LITERAL@96..105 "0X1f2F3L" [Newline("\n")] []
-    8: R_INTEGER_VALUE@105..125
-      0: R_INTEGER_LITERAL@105..125 "0x0p0L" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] []
-    9: R_INTEGER_VALUE@125..132
-      0: R_INTEGER_LITERAL@125..132 "0x0P0L" [Newline("\n")] []
-    10: R_INTEGER_VALUE@132..141
-      0: R_INTEGER_LITERAL@132..141 "0x0p123L" [Newline("\n")] []
-    11: R_INTEGER_VALUE@141..150
-      0: R_INTEGER_LITERAL@141..150 "0x0P123L" [Newline("\n")] []
-    12: R_INTEGER_VALUE@150..172
-      0: R_INTEGER_LITERAL@150..172 "0x0p+0L" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] []
-    13: R_INTEGER_VALUE@172..180
-      0: R_INTEGER_LITERAL@172..180 "0x0p-0L" [Newline("\n")] []
-    14: R_INTEGER_VALUE@180..190
-      0: R_INTEGER_LITERAL@180..190 "0x0p+123L" [Newline("\n")] []
-    15: R_INTEGER_VALUE@190..200
-      0: R_INTEGER_LITERAL@190..200 "0x0p-123L" [Newline("\n")] []
-    16: R_INTEGER_VALUE@200..221
-      0: R_INTEGER_LITERAL@200..221 "0x.L" [Newline("\n"), Comments("# Decimal point"), Newline("\n")] []
-    17: R_INTEGER_VALUE@221..227
-      0: R_INTEGER_LITERAL@221..227 "0x1.L" [Newline("\n")] []
-    18: R_INTEGER_VALUE@227..233
-      0: R_INTEGER_LITERAL@227..233 "0x.1L" [Newline("\n")] []
-    19: R_INTEGER_VALUE@233..240
-      0: R_INTEGER_LITERAL@233..240 "0x1.1L" [Newline("\n")] []
-    20: R_INTEGER_VALUE@240..277
-      0: R_INTEGER_LITERAL@240..277 "0x.p1L" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] []
-    21: R_INTEGER_VALUE@277..285
-      0: R_INTEGER_LITERAL@277..285 "0x1.p1L" [Newline("\n")] []
-    22: R_INTEGER_VALUE@285..293
-      0: R_INTEGER_LITERAL@285..293 "0x.1p1L" [Newline("\n")] []
-    23: R_INTEGER_VALUE@293..302
-      0: R_INTEGER_LITERAL@293..302 "0x1.1p1L" [Newline("\n")] []
-  2: EOF@302..302 "" [] []
+    2: R_INTEGER_VALUE@7..62
+      0: R_INTEGER_LITERAL@7..62 ".1L" [Newline("\n"), Newline("\n"), Comments("# https://github.com/ ..."), Newline("\n")] []
+    3: R_INTEGER_VALUE@62..97
+      0: R_INTEGER_LITERAL@62..97 "0x123L" [Newline("\n"), Newline("\n"), Comments("# Hexadecimal"), Newline("\n"), Comments("# `x` vs `X`"), Newline("\n")] []
+    4: R_INTEGER_VALUE@97..104
+      0: R_INTEGER_LITERAL@97..104 "0X123L" [Newline("\n")] []
+    5: R_INTEGER_VALUE@104..134
+      0: R_INTEGER_LITERAL@104..134 "0xDEADL" [Newline("\n"), Comments("# Numbers and letters"), Newline("\n")] []
+    6: R_INTEGER_VALUE@134..142
+      0: R_INTEGER_LITERAL@134..142 "0XDEADL" [Newline("\n")] []
+    7: R_INTEGER_VALUE@142..151
+      0: R_INTEGER_LITERAL@142..151 "0x1f2F3L" [Newline("\n")] []
+    8: R_INTEGER_VALUE@151..160
+      0: R_INTEGER_LITERAL@151..160 "0X1f2F3L" [Newline("\n")] []
+    9: R_INTEGER_VALUE@160..180
+      0: R_INTEGER_LITERAL@160..180 "0x0p0L" [Newline("\n"), Comments("# `p` vs `P`"), Newline("\n")] []
+    10: R_INTEGER_VALUE@180..187
+      0: R_INTEGER_LITERAL@180..187 "0x0P0L" [Newline("\n")] []
+    11: R_INTEGER_VALUE@187..196
+      0: R_INTEGER_LITERAL@187..196 "0x0p123L" [Newline("\n")] []
+    12: R_INTEGER_VALUE@196..205
+      0: R_INTEGER_LITERAL@196..205 "0x0P123L" [Newline("\n")] []
+    13: R_INTEGER_VALUE@205..227
+      0: R_INTEGER_LITERAL@205..227 "0x0p+0L" [Newline("\n"), Comments("# `+` and `-`"), Newline("\n")] []
+    14: R_INTEGER_VALUE@227..235
+      0: R_INTEGER_LITERAL@227..235 "0x0p-0L" [Newline("\n")] []
+    15: R_INTEGER_VALUE@235..245
+      0: R_INTEGER_LITERAL@235..245 "0x0p+123L" [Newline("\n")] []
+    16: R_INTEGER_VALUE@245..255
+      0: R_INTEGER_LITERAL@245..255 "0x0p-123L" [Newline("\n")] []
+    17: R_INTEGER_VALUE@255..276
+      0: R_INTEGER_LITERAL@255..276 "0x.L" [Newline("\n"), Comments("# Decimal point"), Newline("\n")] []
+    18: R_INTEGER_VALUE@276..282
+      0: R_INTEGER_LITERAL@276..282 "0x1.L" [Newline("\n")] []
+    19: R_INTEGER_VALUE@282..288
+      0: R_INTEGER_LITERAL@282..288 "0x.1L" [Newline("\n")] []
+    20: R_INTEGER_VALUE@288..295
+      0: R_INTEGER_LITERAL@288..295 "0x1.1L" [Newline("\n")] []
+    21: R_INTEGER_VALUE@295..332
+      0: R_INTEGER_LITERAL@295..332 "0x.p1L" [Newline("\n"), Comments("# Decimal point with  ..."), Newline("\n")] []
+    22: R_INTEGER_VALUE@332..340
+      0: R_INTEGER_LITERAL@332..340 "0x1.p1L" [Newline("\n")] []
+    23: R_INTEGER_VALUE@340..348
+      0: R_INTEGER_LITERAL@340..348 "0x.1p1L" [Newline("\n")] []
+    24: R_INTEGER_VALUE@348..357
+      0: R_INTEGER_LITERAL@348..357 "0x1.1p1L" [Newline("\n")] []
+  2: EOF@357..357 "" [] []
 
 ```


### PR DESCRIPTION
For https://github.com/r-lib/tree-sitter-r/pull/198