### PR TITLE
Implement `assignment-style`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # Development version
 
+- New `assignment-style` option to enforce a preferred assignment operator, with the following values:
+
+  - `"arrow"`: Use `<-`. This is the default, aligning Air further with the [tidyverse style guide](https://style.tidyverse.org/syntax.html#assignment-1).
+
+  - `"equal"`: Use `=`.
+
+  - `"preserve"`: Assignment operators are preserved as is.
+
+  Note that prior to this option, Air's behavior was implicitly `"preserve"`. Set `"preserve"` or `"equal"` directly if you prefer either of those behaviors (#502).
+
 - Updated bundled tree-sitter-r, which comes with a few small fixes:
 
   - Hexadecimal constants with decimals are no longer parsed as two separate values (#495).

--- a/artifacts/air.schema.json
+++ b/artifacts/air.schema.json
@@ -20,11 +20,6 @@
     "AssignmentStyle": {
       "oneOf": [
         {
-          "title": "Assignment operators are preserved as is",
-          "type": "string",
-          "const": "preserve"
-        },
-        {
           "title": "Use `<-`",
           "type": "string",
           "const": "arrow"
@@ -34,6 +29,11 @@
           "description": "Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
           "type": "string",
           "const": "equal"
+        },
+        {
+          "title": "Assignment operators are preserved as is",
+          "type": "string",
+          "const": "preserve"
         }
       ]
     },
@@ -43,7 +43,7 @@
       "properties": {
         "assignment-style": {
           "title": "The preferred assignment style",
-          "description": "- `preserve` (default): Assignment operators are preserved as is.\n\n - `arrow`: Use `<-`.\n\n - `equal`: Use `=`.\n\n Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
+          "description": "- `arrow` (default): Use `<-`.\n\n - `equal`: Use `=`.\n\n - `preserve`: Assignment operators are preserved as is.\n\n Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
           "anyOf": [
             {
               "$ref": "#/$defs/AssignmentStyle"

--- a/artifacts/air.schema.json
+++ b/artifacts/air.schema.json
@@ -17,10 +17,42 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "AssignmentStyle": {
+      "oneOf": [
+        {
+          "title": "Assignment operators are preserved as is",
+          "type": "string",
+          "const": "preserve"
+        },
+        {
+          "title": "Use `<-`",
+          "type": "string",
+          "const": "arrow"
+        },
+        {
+          "title": "Use `=`",
+          "description": "Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
+          "type": "string",
+          "const": "equal"
+        }
+      ]
+    },
     "FormatTomlOptions": {
       "description": "Options to configure code formatting.",
       "type": "object",
       "properties": {
+        "assignment-style": {
+          "title": "The preferred assignment style",
+          "description": "- `preserve` (default): Assignment operators are preserved as is.\n\n - `arrow`: Use `<-`.\n\n - `equal`: Use `=`.\n\n Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AssignmentStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "default-exclude": {
           "title": "Whether or not to use default exclude patterns",
           "description": "Air automatically excludes a default set of folders and files. If this option is\n set to `false`, these files will be formatted as well.\n\n The default set of excluded patterns are:\n - `.git/`\n - `renv/`\n - `revdep/`\n - `cpp11.R`\n - `RcppExports.R`\n - `extendr-wrappers.R`\n - `import-standalone-*.R`",

--- a/crates/air_r_formatter/src/context.rs
+++ b/crates/air_r_formatter/src/context.rs
@@ -222,12 +222,7 @@ impl fmt::Display for RFormatOptions {
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Persistent line breaks: {}", self.persistent_line_breaks)?;
-        match self.assignment_style {
-            AssignmentStyle::Preserve => (),
-            AssignmentStyle::Arrow | AssignmentStyle::Equal => {
-                writeln!(f, "Assignment style: {}", self.assignment_style)?
-            }
-        }
+        writeln!(f, "Assignment style: {}", self.assignment_style)?;
         if let Some(skip) = &self.skip {
             writeln!(f, "Skip: {skip}")?;
         };

--- a/crates/air_r_formatter/src/context.rs
+++ b/crates/air_r_formatter/src/context.rs
@@ -7,6 +7,7 @@ use biome_formatter::FormatContext;
 use biome_formatter::FormatOptions;
 use biome_formatter::TransformSourceMap;
 use biome_formatter::printer::PrinterOptions;
+use settings::AssignmentStyle;
 use settings::IndentStyle;
 use settings::IndentWidth;
 use settings::LineEnding;
@@ -83,6 +84,9 @@ pub struct RFormatOptions {
     /// The behavior of persistent line breaks.
     persistent_line_breaks: PersistentLineBreaks,
 
+    /// The assignment style to use.
+    assignment_style: AssignmentStyle,
+
     /// The set of functions that are skipped without requiring a `# fmt: skip` comment.
     skip: Option<Skip>,
 
@@ -125,6 +129,11 @@ impl RFormatOptions {
         self
     }
 
+    pub fn with_assignment_style(mut self, assignment_style: AssignmentStyle) -> Self {
+        self.assignment_style = assignment_style;
+        self
+    }
+
     pub fn with_skip(mut self, skip: Option<Skip>) -> Self {
         self.skip = skip;
         self
@@ -155,6 +164,10 @@ impl RFormatOptions {
         self.persistent_line_breaks = persistent_line_breaks;
     }
 
+    pub fn set_assignment_style(&mut self, assignment_style: AssignmentStyle) {
+        self.assignment_style = assignment_style;
+    }
+
     pub fn set_skip(&mut self, skip: Option<Skip>) {
         self.skip = skip;
     }
@@ -165,6 +178,10 @@ impl RFormatOptions {
 
     pub fn persistent_line_breaks(&self) -> PersistentLineBreaks {
         self.persistent_line_breaks
+    }
+
+    pub fn assignment_style(&self) -> AssignmentStyle {
+        self.assignment_style
     }
 
     pub fn skip(&self) -> Option<&Skip> {
@@ -205,6 +222,12 @@ impl fmt::Display for RFormatOptions {
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Persistent line breaks: {}", self.persistent_line_breaks)?;
+        match self.assignment_style {
+            AssignmentStyle::Preserve => (),
+            AssignmentStyle::Arrow | AssignmentStyle::Equal => {
+                writeln!(f, "Assignment style: {}", self.assignment_style)?
+            }
+        }
         if let Some(skip) = &self.skip {
             writeln!(f, "Skip: {skip}")?;
         };

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -258,10 +258,6 @@ fn fmt_left_assignment_operator(
     f: &mut RFormatter,
 ) -> FormatResult<()> {
     match f.options().assignment_style() {
-        AssignmentStyle::Preserve => {
-            // Preserve as is
-            operator.format().fmt(f)
-        }
         AssignmentStyle::Arrow => match left_assignment_kind {
             LeftAssignmentKind::Equal => format_replaced(
                 operator,
@@ -290,6 +286,10 @@ fn fmt_left_assignment_operator(
                 }
             }
         },
+        AssignmentStyle::Preserve => {
+            // Preserve as is
+            operator.format().fmt(f)
+        }
     }
 }
 

--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -6,14 +6,26 @@ use crate::r::auxiliary::call_arguments::FormatRCallArgumentsOptions;
 use air_r_syntax::AnyRExpression;
 use air_r_syntax::RBinaryExpression;
 use air_r_syntax::RBinaryExpressionFields;
+use air_r_syntax::RElseClause;
+use air_r_syntax::RExpressionList;
+use air_r_syntax::RForStatement;
+use air_r_syntax::RFunctionDefinition;
+use air_r_syntax::RIfStatement;
 use air_r_syntax::RLanguage;
+use air_r_syntax::RParenthesizedExpression;
+use air_r_syntax::RRepeatStatement;
 use air_r_syntax::RSyntaxKind;
+use air_r_syntax::RUnaryExpression;
+use air_r_syntax::RWhileStatement;
 use biome_formatter::FormatRuleWithOptions;
 use biome_formatter::format_args;
+use biome_formatter::prelude::dynamic_text;
+use biome_formatter::trivia::format_replaced;
 use biome_formatter::write;
 use biome_rowan::AstNode;
 use biome_rowan::SyntaxResult;
 use biome_rowan::SyntaxToken;
+use settings::AssignmentStyle;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub(crate) enum ChainAlignment {
@@ -213,15 +225,219 @@ fn fmt_binary_assignment(
         }
     });
 
+    let operator_format = format_with(|f: &mut RFormatter| match operator.kind() {
+        RSyntaxKind::ASSIGN => {
+            fmt_left_assignment_operator(node, &operator, LeftAssignmentKind::Arrow, f)
+        }
+        RSyntaxKind::EQUAL => {
+            fmt_left_assignment_operator(node, &operator, LeftAssignmentKind::Equal, f)
+        }
+        _ => operator.format().fmt(f),
+    });
+
     write!(
         f,
         [group(&format_args![
             left.format(),
             space(),
-            operator.format(),
+            operator_format,
             right_format
         ])]
     )
+}
+
+enum LeftAssignmentKind {
+    Arrow,
+    Equal,
+}
+
+fn fmt_left_assignment_operator(
+    node: &RBinaryExpression,
+    operator: &SyntaxToken<RLanguage>,
+    left_assignment_kind: LeftAssignmentKind,
+    f: &mut RFormatter,
+) -> FormatResult<()> {
+    match f.options().assignment_style() {
+        AssignmentStyle::Preserve => {
+            // Preserve as is
+            operator.format().fmt(f)
+        }
+        AssignmentStyle::Arrow => match left_assignment_kind {
+            LeftAssignmentKind::Equal => format_replaced(
+                operator,
+                &dynamic_text("<-", operator.text_trimmed_range().start()),
+            )
+            .fmt(f),
+            LeftAssignmentKind::Arrow => {
+                // Already matches style
+                operator.format().fmt(f)
+            }
+        },
+        AssignmentStyle::Equal => match left_assignment_kind {
+            LeftAssignmentKind::Equal => {
+                // Already matches style
+                operator.format().fmt(f)
+            }
+            LeftAssignmentKind::Arrow => {
+                if can_normalize_to_equal(node) {
+                    format_replaced(
+                        operator,
+                        &dynamic_text("=", operator.text_trimmed_range().start()),
+                    )
+                    .fmt(f)
+                } else {
+                    operator.format().fmt(f)
+                }
+            }
+        },
+    }
+}
+
+/// Can we safely normalize `<-` to `=`?
+///
+/// In R, it is always safe to normalize `=` to `<-`, but the reverse is not true.
+///
+/// For example, it may change the semantic meaning:
+///
+/// ```r
+/// # Expression `x <- 1` as unnamed argument to function `f`
+/// f(x <- 1)
+///
+/// # Named argument `x` with value `1` to function `f`
+/// f(x = 1)
+/// ```
+///
+/// Or it may become a syntax error:
+///
+/// ```r
+/// # Expression `x <- 1`'s result is used as the `condition`
+/// if (x <- 1) this
+///
+/// # Syntax error
+/// if (x = 1) this
+/// ```
+///
+/// To handle this precisely, we looked for all usage of `expr_or_assign_or_help` in the
+/// R `gram.y` grammar. This is the only place that `EQ_ASSIGN` is used in an assignment
+/// context. Each usage of `expr_or_assign_or_help` in `gram.y` is replicated below,
+/// ensuring that we capture all possible places that `=` is allowed.
+/// https://github.com/wch/r-source/blob/b7e27523048d135e3a02560e51cb266702bd49c1/src/main/gram.y#L453-L455
+///
+/// Note how `LEFT_ASSIGN` is instead part of `expr`, making usage of it more permissive
+/// than `EQ_ASSIGN` (a superset, really). This is why we can always replace `=` with
+/// `<-`.
+/// https://github.com/wch/r-source/blob/b7e27523048d135e3a02560e51cb266702bd49c1/src/main/gram.y#L497
+///
+/// `EQ_ASSIGN` is also used in `sub:` and `formlist:`, but these correspond to named
+/// arguments (i.e. `fn(x = 1)`) and parameters with defaults (i.e. `function(x = 1) {}`)
+/// respectively, so are not relevant usages for us (and in fact those are locations where
+/// normalizing to `=` is not allowed).
+/// https://github.com/wch/r-source/blob/b7e27523048d135e3a02560e51cb266702bd49c1/src/main/gram.y#L549-L564
+fn can_normalize_to_equal(node: &RBinaryExpression) -> bool {
+    let node = node.syntax();
+
+    let Some(parent) = node.parent() else {
+        // Should not happen, should always be at least contained in an RRoot's
+        // RExpressionList. We return the conservative `false` if we somehow get here.
+        return false;
+    };
+    let parent_kind = parent.kind();
+
+    // i.e. top level `x <- 1` to `x = 1`
+    // i.e. `{ x <- 1 }` to `{ x = 1 }`
+    if RExpressionList::can_cast(parent_kind) {
+        return true;
+    }
+
+    // i.e. `(x <- 1)` to `(x = 1)`
+    if RParenthesizedExpression::can_cast(parent_kind) {
+        return true;
+    }
+
+    // i.e. `? x <- 1` to `? x = 1`
+    if let Some(parent) = RUnaryExpression::cast_ref(&parent)
+        && let Ok(operator) = parent.operator()
+        && operator.kind() == RSyntaxKind::WAT
+    {
+        return true;
+    }
+
+    // i.e. `x <- y <- 1` to `x = y = 1`
+    // i.e. `x = y <- 1` to `x = y = 1`, but notably `x <- y = 1` is a parse error.
+    // i.e. `x <- 1 ? y` to `x = 1 ? y`
+    // i.e. `y ? x <- 1` to `y ? x = 1`
+    //
+    // We recurse through `can_normalize_to_equal()` in these cases because the parent
+    // binary expression must also be in a position where `=` would be valid. These would
+    // all result in parse errors or change semantic meaning if we didn't check this:
+    //
+    // i.e. `f(x <- y <- 1)` to `f(x <- y = 1)` gives parse error
+    // i.e. `if (x <- y <- 1) z` to `if (x <- y = 1) z` gives parse error
+    //
+    // i.e. `f(x ? y <- 1)` to `f(x ? y = 1)` gives parse error
+    // i.e. `if(x ? y <- 1) z` to `if(x ? y = 1) z` gives parse error
+    //
+    // i.e. `f(x <- 1 ? y)` to `f(x = 1 ? y)` changes semantic meaning
+    // i.e. `if(x <- 1 ? y) z` to `if(x = 1 ? y) z` gives parse error
+    if let Some(parent) = RBinaryExpression::cast_ref(&parent)
+        && let Ok(operator) = parent.operator()
+        && matches!(
+            operator.kind(),
+            RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL | RSyntaxKind::WAT
+        )
+    {
+        return can_normalize_to_equal(&parent);
+    }
+
+    // i.e. `function(x) x <- 1` to `function(x) x = 1`
+    if let Some(parent) = RFunctionDefinition::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `if (cond) x <- 1` to `if (cond) x = 1`
+    if let Some(parent) = RIfStatement::cast_ref(&parent)
+        && let Ok(consequence) = parent.consequence()
+        && consequence.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `if (cond) x else y <- 1` to `if (cond) x else y = 1`
+    if let Some(parent) = RElseClause::cast_ref(&parent)
+        && let Ok(alternative) = parent.alternative()
+        && alternative.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `for(i in 1:5) x <- 1` to `for(i in 1:5) x = 1`
+    if let Some(parent) = RForStatement::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `while(cond) x <- 1` to `while(cond) x = 1`
+    if let Some(parent) = RWhileStatement::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `repeat x <- 1` to `repeat x = 1`
+    if let Some(parent) = RRepeatStatement::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    false
 }
 
 fn format_assignment_rhs(right: &AnyRExpression, table: bool) -> impl Format<RFormatContext> {

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R
@@ -1,3 +1,6 @@
+#' [format]
+#' assignment-style = "preserve"
+
 1 + 2 + 3 + 4
 
 argument_that_is_quite_long + argument_that_is_quite_long + argument_that_is_quite_long + argument_that_is_quite_long

--- a/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression.R.snap
@@ -5,6 +5,9 @@ info: r/binary_expression.R
 # Input
 
 ```R
+#' [format]
+#' assignment-style = "preserve"
+
 1 + 2 + 3 + 4
 
 argument_that_is_quite_long + argument_that_is_quite_long + argument_that_is_quite_long + argument_that_is_quite_long
@@ -696,10 +699,14 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Preserve
 Table: fcase, tribble
 -----
 
 ```R
+#' [format]
+#' assignment-style = "preserve"
+
 1 + 2 + 3 + 4
 
 argument_that_is_quite_long +
@@ -1517,17 +1524,17 @@ y ~ x1 +
 
 # Lines exceeding max width of 80 characters
 ```
-  203: # TODO: Do we really want these chained? It seems like no good can come of that even though they have same precedence
-  579: a_really_really_really_really_really_really_long_thing_here ~ a_really_really_really_really_really_really_long_thing_here2
-  580: a_really_really_really_really_really_really_long_thing_here = a_really_really_really_really_really_really_long_thing_here2
-  581: a_really_really_really_really_really_really_long_thing_here := a_really_really_really_really_really_really_long_thing_here2
-  582: a_really_really_really_really_really_really_long_thing_here <- a_really_really_really_really_really_really_long_thing_here2
-  583: a_really_really_really_really_really_really_long_thing_here -> a_really_really_really_really_really_really_long_thing_here2
-  584: a_really_really_really_really_really_really_long_thing_here <<- a_really_really_really_really_really_really_long_thing_here2
-  585: a_really_really_really_really_really_really_long_thing_here ->> a_really_really_really_really_really_really_long_thing_here2
-  697: a_really_really_long_thing_here1 ~ a_really_really_long_thing_here2 ~ a_really_really_long_thing_here3
-  698: a_really_really_long_thing_here1 ~ a_really_really_really_really_really_really_long_thing_here2 ~ a_really_really_long_thing_here3
-  699: (a_really_really_long_thing_here1 ~ a_really_really_long_thing_here2) ~ a_really_really_long_thing_here3
-  700: a_really_really_long_thing_here1 ~ (a_really_really_long_thing_here2 ~ a_really_really_long_thing_here3)
-  753: # https://github.com/posit-dev/positron/discussions/6095#discussioncomment-13112983
+  206: # TODO: Do we really want these chained? It seems like no good can come of that even though they have same precedence
+  582: a_really_really_really_really_really_really_long_thing_here ~ a_really_really_really_really_really_really_long_thing_here2
+  583: a_really_really_really_really_really_really_long_thing_here = a_really_really_really_really_really_really_long_thing_here2
+  584: a_really_really_really_really_really_really_long_thing_here := a_really_really_really_really_really_really_long_thing_here2
+  585: a_really_really_really_really_really_really_long_thing_here <- a_really_really_really_really_really_really_long_thing_here2
+  586: a_really_really_really_really_really_really_long_thing_here -> a_really_really_really_really_really_really_long_thing_here2
+  587: a_really_really_really_really_really_really_long_thing_here <<- a_really_really_really_really_really_really_long_thing_here2
+  588: a_really_really_really_really_really_really_long_thing_here ->> a_really_really_really_really_really_really_long_thing_here2
+  700: a_really_really_long_thing_here1 ~ a_really_really_long_thing_here2 ~ a_really_really_long_thing_here3
+  701: a_really_really_long_thing_here1 ~ a_really_really_really_really_really_really_long_thing_here2 ~ a_really_really_long_thing_here3
+  702: (a_really_really_long_thing_here1 ~ a_really_really_long_thing_here2) ~ a_really_really_long_thing_here3
+  703: a_really_really_long_thing_here1 ~ (a_really_really_long_thing_here2 ~ a_really_really_long_thing_here3)
+  756: # https://github.com/posit-dev/positron/discussions/6095#discussioncomment-13112983
 ```

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_arrow.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_arrow.R
@@ -1,0 +1,58 @@
+#' [format]
+#' assignment-style = "arrow"
+
+# Top level
+x = 1
+
+# A trailing comment on the operator is preserved
+x = # keep me
+  1
+
+# Inside `{ }`
+{
+  x = 1
+  y = 2
+}
+
+# Isolated by an extra pair of `( )`
+(x = 1)
+
+# Unary `?`
+? x = 1
+f(? x = 1)
+
+# Inside binary `=` (both convert)
+x = y = 1
+
+# NOT inside binary `<-` as this is a syntax error to begin with!
+# x <- y = 1
+
+# Inside binary `?`
+x = 1 ? y
+y ? x = 1
+
+# Function body
+function(x) x = 1
+lapply(xs, function(x) x = 1)
+
+# If statement consequence
+if (cond) x = 1
+
+# Else clause alternative
+if (cond) x else y = 1
+
+# For loop body
+for(i in 1:5) x = 1
+
+# While loop body
+while(cond) x = 1
+
+# Repeat loop body
+repeat x = 1
+
+# Other assignment-ish operators are never changed
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_arrow.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_arrow.R.snap
@@ -1,0 +1,157 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/binary_expression_assignment_arrow.R
+---
+# Input
+
+```R
+#' [format]
+#' assignment-style = "arrow"
+
+# Top level
+x = 1
+
+# A trailing comment on the operator is preserved
+x = # keep me
+  1
+
+# Inside `{ }`
+{
+  x = 1
+  y = 2
+}
+
+# Isolated by an extra pair of `( )`
+(x = 1)
+
+# Unary `?`
+? x = 1
+f(? x = 1)
+
+# Inside binary `=` (both convert)
+x = y = 1
+
+# NOT inside binary `<-` as this is a syntax error to begin with!
+# x <- y = 1
+
+# Inside binary `?`
+x = 1 ? y
+y ? x = 1
+
+# Function body
+function(x) x = 1
+lapply(xs, function(x) x = 1)
+
+# If statement consequence
+if (cond) x = 1
+
+# Else clause alternative
+if (cond) x else y = 1
+
+# For loop body
+for(i in 1:5) x = 1
+
+# While loop body
+while(cond) x = 1
+
+# Repeat loop body
+repeat x = 1
+
+# Other assignment-ish operators are never changed
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Persistent line breaks: Respect
+Assignment style: Arrow
+Table: fcase, tribble
+-----
+
+```R
+#' [format]
+#' assignment-style = "arrow"
+
+# Top level
+x <- 1
+
+# A trailing comment on the operator is preserved
+x <- # keep me
+  1
+
+# Inside `{ }`
+{
+  x <- 1
+  y <- 2
+}
+
+# Isolated by an extra pair of `( )`
+(x <- 1)
+
+# Unary `?`
+?x <- 1
+f(?x <- 1)
+
+# Inside binary `=` (both convert)
+x <- y <- 1
+
+# NOT inside binary `<-` as this is a syntax error to begin with!
+# x <- y = 1
+
+# Inside binary `?`
+x <- 1?y
+y?x <- 1
+
+# Function body
+function(x) x <- 1
+lapply(xs, function(x) x <- 1)
+
+# If statement consequence
+if (cond) {
+  x <- 1
+}
+
+# Else clause alternative
+if (cond) {
+  x
+} else {
+  y <- 1
+}
+
+# For loop body
+for (i in 1:5) {
+  x <- 1
+}
+
+# While loop body
+while (cond) {
+  x <- 1
+}
+
+# Repeat loop body
+repeat {
+  x <- 1
+}
+
+# Other assignment-ish operators are never changed
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+```

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_equal.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_equal.R
@@ -1,0 +1,111 @@
+#' [format]
+#' assignment-style = "equal"
+
+# `<-` becomes `=` in all the positions where `=` is a valid assignment operator
+
+# Top level
+x <- 1
+
+# A trailing comment is preserved
+x <- # keep me
+  1
+
+# Inside `{ }`
+{
+  x <- 1
+  y <- 2
+}
+
+# Isolated by an extra pair of `( )`
+(x <- 1)
+
+# Unary `?`
+? x <- 1
+f(? x <- 1)
+
+# Inside binary `<-` (both convert)
+x <- y <- 1
+
+# Inside binary `=` (notably `x <- y = 1` is an R syntax error)
+x = y <- 1
+
+# Inside binary `?`
+x <- 1 ? y
+y ? x <- 1
+
+# Function body
+function(x) x <- 1
+lapply(xs, function(x) x <- 1)
+
+# If statement consequence
+if (cond) x <- 1
+
+# Else clause alternative
+if (cond) x else y <- 1
+
+# For loop body
+for(i in 1:5) x <- 1
+
+# While loop body
+while(cond) x <- 1
+
+# Repeat loop body
+repeat x <- 1
+
+# Other assignment-ish operators are never changed
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+
+# `<-` is left untouched where `=` cannot replace it
+
+# Function call argument (semantic difference)
+f(x <- 1)
+f(x <- 1, y <- 2)
+x[i <- 1]
+x[[i <- 1]]
+
+# Parameter default (semantic difference)
+function(a = b <- 1) a
+
+# Control flow (syntax error)
+if (x <- f()) y
+while (x <- f()) y
+for (i in x <- xs) y
+
+# But a surrounding pair of parentheses lifts the restriction
+if ((x <- f())) y
+while ((x <- f())) y
+for (i in (x <- xs)) y
+
+# Tricky recursive cases with binary expression parents
+
+# `?` parent and `<-` RHS
+# `<-` to `=` would result in parse errors
+f(a ? b <- 1)
+x[a ? b <- 1]
+x[[a ? b <- 1]]
+if (a ? b <- 1) c
+while (a ? b <- 1) c
+function(x = a ? b <- 1) x
+
+# `?` parent and `<-` LHS
+# `<-` to `=` would result in semantic changes for `f()`, `x[]`, and `x[[]]`
+# `<-` to `=` would result in parse errors for `if`, `while`, and `function`
+f(a <- 1 ? b)
+x[a <- 1 ? b]
+x[[a <- 1 ? b]]
+if (a <- 1 ? b) c
+while (a <- 1 ? b) c
+function(x = a <- 1 ? b) x
+
+# `<-` parent
+# `<-` to `=` would result in parse errors
+f(a <- b <- 1)
+x[a <- b <- 1]
+x[[a <- b <- 1]]
+if (a <- b <- 1) c
+while (a <- b <- 1) c
+function(x = a <- b <- 1) x

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_equal.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_equal.R.snap
@@ -1,0 +1,287 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/binary_expression_assignment_equal.R
+---
+# Input
+
+```R
+#' [format]
+#' assignment-style = "equal"
+
+# `<-` becomes `=` in all the positions where `=` is a valid assignment operator
+
+# Top level
+x <- 1
+
+# A trailing comment is preserved
+x <- # keep me
+  1
+
+# Inside `{ }`
+{
+  x <- 1
+  y <- 2
+}
+
+# Isolated by an extra pair of `( )`
+(x <- 1)
+
+# Unary `?`
+? x <- 1
+f(? x <- 1)
+
+# Inside binary `<-` (both convert)
+x <- y <- 1
+
+# Inside binary `=` (notably `x <- y = 1` is an R syntax error)
+x = y <- 1
+
+# Inside binary `?`
+x <- 1 ? y
+y ? x <- 1
+
+# Function body
+function(x) x <- 1
+lapply(xs, function(x) x <- 1)
+
+# If statement consequence
+if (cond) x <- 1
+
+# Else clause alternative
+if (cond) x else y <- 1
+
+# For loop body
+for(i in 1:5) x <- 1
+
+# While loop body
+while(cond) x <- 1
+
+# Repeat loop body
+repeat x <- 1
+
+# Other assignment-ish operators are never changed
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+
+# `<-` is left untouched where `=` cannot replace it
+
+# Function call argument (semantic difference)
+f(x <- 1)
+f(x <- 1, y <- 2)
+x[i <- 1]
+x[[i <- 1]]
+
+# Parameter default (semantic difference)
+function(a = b <- 1) a
+
+# Control flow (syntax error)
+if (x <- f()) y
+while (x <- f()) y
+for (i in x <- xs) y
+
+# But a surrounding pair of parentheses lifts the restriction
+if ((x <- f())) y
+while ((x <- f())) y
+for (i in (x <- xs)) y
+
+# Tricky recursive cases with binary expression parents
+
+# `?` parent and `<-` RHS
+# `<-` to `=` would result in parse errors
+f(a ? b <- 1)
+x[a ? b <- 1]
+x[[a ? b <- 1]]
+if (a ? b <- 1) c
+while (a ? b <- 1) c
+function(x = a ? b <- 1) x
+
+# `?` parent and `<-` LHS
+# `<-` to `=` would result in semantic changes for `f()`, `x[]`, and `x[[]]`
+# `<-` to `=` would result in parse errors for `if`, `while`, and `function`
+f(a <- 1 ? b)
+x[a <- 1 ? b]
+x[[a <- 1 ? b]]
+if (a <- 1 ? b) c
+while (a <- 1 ? b) c
+function(x = a <- 1 ? b) x
+
+# `<-` parent
+# `<-` to `=` would result in parse errors
+f(a <- b <- 1)
+x[a <- b <- 1]
+x[[a <- b <- 1]]
+if (a <- b <- 1) c
+while (a <- b <- 1) c
+function(x = a <- b <- 1) x
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Persistent line breaks: Respect
+Assignment style: Equal
+Table: fcase, tribble
+-----
+
+```R
+#' [format]
+#' assignment-style = "equal"
+
+# `<-` becomes `=` in all the positions where `=` is a valid assignment operator
+
+# Top level
+x = 1
+
+# A trailing comment is preserved
+x = # keep me
+  1
+
+# Inside `{ }`
+{
+  x = 1
+  y = 2
+}
+
+# Isolated by an extra pair of `( )`
+(x = 1)
+
+# Unary `?`
+?x = 1
+f(?x = 1)
+
+# Inside binary `<-` (both convert)
+x = y = 1
+
+# Inside binary `=` (notably `x <- y = 1` is an R syntax error)
+x = y = 1
+
+# Inside binary `?`
+x = 1?y
+y?x = 1
+
+# Function body
+function(x) x = 1
+lapply(xs, function(x) x = 1)
+
+# If statement consequence
+if (cond) {
+  x = 1
+}
+
+# Else clause alternative
+if (cond) {
+  x
+} else {
+  y = 1
+}
+
+# For loop body
+for (i in 1:5) {
+  x = 1
+}
+
+# While loop body
+while (cond) {
+  x = 1
+}
+
+# Repeat loop body
+repeat {
+  x = 1
+}
+
+# Other assignment-ish operators are never changed
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+
+# `<-` is left untouched where `=` cannot replace it
+
+# Function call argument (semantic difference)
+f(x <- 1)
+f(x <- 1, y <- 2)
+x[i <- 1]
+x[[i <- 1]]
+
+# Parameter default (semantic difference)
+function(a = b <- 1) a
+
+# Control flow (syntax error)
+if (x <- f()) {
+  y
+}
+while (x <- f()) {
+  y
+}
+for (i in x <- xs) {
+  y
+}
+
+# But a surrounding pair of parentheses lifts the restriction
+if ((x = f())) {
+  y
+}
+while ((x = f())) {
+  y
+}
+for (i in (x = xs)) {
+  y
+}
+
+# Tricky recursive cases with binary expression parents
+
+# `?` parent and `<-` RHS
+# `<-` to `=` would result in parse errors
+f(a?b <- 1)
+x[a?b <- 1]
+x[[a?b <- 1]]
+if (a?b <- 1) {
+  c
+}
+while (a?b <- 1) {
+  c
+}
+function(x = a?b <- 1) x
+
+# `?` parent and `<-` LHS
+# `<-` to `=` would result in semantic changes for `f()`, `x[]`, and `x[[]]`
+# `<-` to `=` would result in parse errors for `if`, `while`, and `function`
+f(a <- 1?b)
+x[a <- 1?b]
+x[[a <- 1?b]]
+if (a <- 1?b) {
+  c
+}
+while (a <- 1?b) {
+  c
+}
+function(x = a <- 1?b) x
+
+# `<-` parent
+# `<-` to `=` would result in parse errors
+f(a <- b <- 1)
+x[a <- b <- 1]
+x[[a <- b <- 1]]
+if (a <- b <- 1) {
+  c
+}
+while (a <- b <- 1) {
+  c
+}
+function(x = a <- b <- 1) x
+```

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_preserve.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_preserve.R
@@ -1,0 +1,29 @@
+#' [format]
+#' assignment-style = "preserve"
+
+# Both `<-` and `=` are left exactly as written, in every position
+
+# Top level
+x <- 1
+x = 1
+
+# Inside `{ }`
+{
+  x <- 1
+  y = 2
+}
+
+# Function body
+function(x) x <- 1
+function(x) x = 1
+
+# If statement consequence
+if (cond) x <- 1
+if (cond) x = 1
+
+# Other assignment-ish operators are also left as is
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_preserve.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_assignment_preserve.R.snap
@@ -1,0 +1,91 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/binary_expression_assignment_preserve.R
+---
+# Input
+
+```R
+#' [format]
+#' assignment-style = "preserve"
+
+# Both `<-` and `=` are left exactly as written, in every position
+
+# Top level
+x <- 1
+x = 1
+
+# Inside `{ }`
+{
+  x <- 1
+  y = 2
+}
+
+# Function body
+function(x) x <- 1
+function(x) x = 1
+
+# If statement consequence
+if (cond) x <- 1
+if (cond) x = 1
+
+# Other assignment-ish operators are also left as is
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Persistent line breaks: Respect
+Assignment style: Preserve
+Table: fcase, tribble
+-----
+
+```R
+#' [format]
+#' assignment-style = "preserve"
+
+# Both `<-` and `=` are left exactly as written, in every position
+
+# Top level
+x <- 1
+x = 1
+
+# Inside `{ }`
+{
+  x <- 1
+  y = 2
+}
+
+# Function body
+function(x) x <- 1
+function(x) x = 1
+
+# If statement consequence
+if (cond) {
+  x <- 1
+}
+if (cond) {
+  x = 1
+}
+
+# Other assignment-ish operators are also left as is
+x <<- 1
+6 -> x
+7 ->> x
+quote(x := 1)
+x ~ y
+```

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_sticky.R.snap
@@ -65,6 +65,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/braced_expressions.R.snap
@@ -198,6 +198,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call.R.snap
@@ -888,6 +888,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/call_table.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/call_table.R.snap
@@ -443,6 +443,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 
@@ -667,7 +668,7 @@ foo <<- list(
 )
 
 # fmt: table
-foo = list(
+foo <- list(
   1 + 1 , 1 + 1 ,
   1 + 1 , 1 + 1
 )
@@ -880,8 +881,8 @@ tribble(
 
 ## Unimplemented nodes/tokens
 
-"(\n\"foo\n\",  2)" => 5299..5312
-"(\n{ foo },  2\n)" => 5331..5346
+"(\n\"foo\n\",  2)" => 5300..5313
+"(\n{ foo },  2\n)" => 5332..5347
 # Lines exceeding max width of 80 characters
 ```
    91:   foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo , baaaaaaaaar , foooooooooo(baaaaaaaaar, foooooooooo, baaaaaaaaar) ,

--- a/crates/air_r_formatter/tests/specs/r/comment.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/comment.R.snap
@@ -23,6 +23,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/crlf/string_value.R.snap
@@ -23,6 +23,7 @@ Indent width: 2
 Line ending: CRLF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/directives/skip-file-not.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip-file-not.R.snap
@@ -40,6 +40,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/directives/skip-file-trailing-separated.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip-file-trailing-separated.R.snap
@@ -44,6 +44,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/directives/skip-file-trailing.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip-file-trailing.R.snap
@@ -41,6 +41,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/directives/skip-file.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip-file.R.snap
@@ -38,6 +38,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/directives/skip-generated-by.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip-generated-by.R.snap
@@ -38,6 +38,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/directives/skip.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/directives/skip.R.snap
@@ -190,6 +190,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/dot_dot_i.R.snap
@@ -28,6 +28,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/for_statement.R.snap
@@ -89,6 +89,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/function_definition.R.snap
@@ -201,6 +201,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/if_statement.R.snap
@@ -434,6 +434,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 
@@ -901,10 +902,10 @@ if (a) {
 }
 
 # Allowed on one line without braces (value position)
-x = if (a) 1
+x <- if (a) 1
 x <- if (a) 1
 x <<- if (a) 1
-x = if (a) 1 else 2
+x <- if (a) 1 else 2
 x <- if (a) 1 else 2
 x <<- if (a) 1 else 2
 {

--- a/crates/air_r_formatter/tests/specs/r/keyword.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/keyword.R.snap
@@ -34,6 +34,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/parenthesized_expression.R.snap
@@ -40,6 +40,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/binary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/binary_expression.R.snap
@@ -32,6 +32,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Ignore
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/call.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/call.R.snap
@@ -39,6 +39,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Ignore
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/function_definition.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/persistent-line-breaks/function_definition.R.snap
@@ -31,6 +31,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Ignore
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/pipelines.R.snap
@@ -55,6 +55,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 
@@ -83,7 +84,7 @@ name <- mtcars |>
     argument_that_is_quite_long = argument_that_is_quite_long
   )
 
-name = mtcars |>
+name <- mtcars |>
   mutate(foo = 1) %>%
   filter(
     foo == 1,

--- a/crates/air_r_formatter/tests/specs/r/program.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/program.R.snap
@@ -63,6 +63,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/repeat_statement.R.snap
@@ -81,6 +81,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/skip/skip-graph-from-literal.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/skip/skip-graph-from-literal.R.snap
@@ -42,6 +42,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Skip: graph_from_literal
 Table: fcase, tribble
 -----

--- a/crates/air_r_formatter/tests/specs/r/skip/skip-tribble.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/skip/skip-tribble.R.snap
@@ -54,6 +54,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Skip: tribble
 Table: fcase, tribble
 -----

--- a/crates/air_r_formatter/tests/specs/r/smoke.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/smoke.R.snap
@@ -22,6 +22,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/subset.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset.R.snap
@@ -161,6 +161,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/subset2.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/subset2.R.snap
@@ -109,6 +109,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/table/table-default.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/table/table-default.R.snap
@@ -52,6 +52,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 
@@ -75,7 +76,7 @@ fcase(
   default = 5L
 )
 
-a = fcase(
+a <- fcase(
   x < 5L , 1L ,
   x > 5L , 3L ,
   default = 5L

--- a/crates/air_r_formatter/tests/specs/r/table/table-explicit.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/table/table-explicit.R.snap
@@ -55,6 +55,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, foo, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/table/table-no-default.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/table/table-no-default.R.snap
@@ -44,6 +44,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: foo
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/test_that.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/test_that.R.snap
@@ -55,6 +55,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/unary_expression.R.snap
@@ -92,6 +92,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/complex_value.R.snap
@@ -25,6 +25,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/double_value.R.snap
@@ -25,6 +25,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/integer_value.R.snap
@@ -23,6 +23,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/value/string_value.R.snap
@@ -30,6 +30,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/while_statement.R.snap
@@ -108,6 +108,7 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Persistent line breaks: Respect
+Assignment style: Arrow
 Table: fcase, tribble
 -----
 

--- a/crates/settings/src/assignment_style.rs
+++ b/crates/settings/src/assignment_style.rs
@@ -1,0 +1,48 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Debug, Default, Clone, Copy, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "kebab-case")
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum AssignmentStyle {
+    /// # Assignment operators are preserved as is
+    #[default]
+    Preserve,
+
+    /// # Use `<-`
+    Arrow,
+
+    /// # Use `=`
+    ///
+    /// Note that changing from `<-` to `=` is not always possible. For example, `f(x <-
+    /// 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named
+    /// `x`. In these cases, the `<-` is left as is.
+    Equal,
+}
+
+impl FromStr for AssignmentStyle {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "preserve" => Ok(Self::Preserve),
+            "arrow" => Ok(Self::Arrow),
+            "equal" => Ok(Self::Equal),
+            _ => Err("Unsupported value for this option"),
+        }
+    }
+}
+
+impl Display for AssignmentStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AssignmentStyle::Preserve => std::write!(f, "Preserve"),
+            AssignmentStyle::Arrow => std::write!(f, "Arrow"),
+            AssignmentStyle::Equal => std::write!(f, "Equal"),
+        }
+    }
+}

--- a/crates/settings/src/assignment_style.rs
+++ b/crates/settings/src/assignment_style.rs
@@ -9,11 +9,8 @@ use std::str::FromStr;
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AssignmentStyle {
-    /// # Assignment operators are preserved as is
-    #[default]
-    Preserve,
-
     /// # Use `<-`
+    #[default]
     Arrow,
 
     /// # Use `=`
@@ -22,6 +19,9 @@ pub enum AssignmentStyle {
     /// 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named
     /// `x`. In these cases, the `<-` is left as is.
     Equal,
+
+    /// # Assignment operators are preserved as is
+    Preserve,
 }
 
 impl FromStr for AssignmentStyle {
@@ -29,9 +29,9 @@ impl FromStr for AssignmentStyle {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "preserve" => Ok(Self::Preserve),
             "arrow" => Ok(Self::Arrow),
             "equal" => Ok(Self::Equal),
+            "preserve" => Ok(Self::Preserve),
             _ => Err("Unsupported value for this option"),
         }
     }
@@ -40,9 +40,9 @@ impl FromStr for AssignmentStyle {
 impl Display for AssignmentStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssignmentStyle::Preserve => std::write!(f, "Preserve"),
             AssignmentStyle::Arrow => std::write!(f, "Arrow"),
             AssignmentStyle::Equal => std::write!(f, "Equal"),
+            AssignmentStyle::Preserve => std::write!(f, "Preserve"),
         }
     }
 }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -1,3 +1,4 @@
+mod assignment_style;
 mod indent_style;
 mod indent_width;
 mod line_ending;
@@ -7,6 +8,7 @@ mod skip;
 mod sorted_strings;
 mod table;
 
+pub use assignment_style::*;
 pub use indent_style::*;
 pub use indent_width::*;
 pub use line_ending::*;

--- a/crates/workspace/src/settings.rs
+++ b/crates/workspace/src/settings.rs
@@ -11,6 +11,7 @@ pub use exclude_patterns::ExcludePatterns;
 pub(crate) use line_ending::LineEnding;
 
 use air_r_formatter::context::RFormatOptions;
+use settings::AssignmentStyle;
 use settings::IndentStyle;
 use settings::IndentWidth;
 use settings::LineWidth;
@@ -35,6 +36,7 @@ pub struct FormatSettings {
     pub line_ending: LineEnding,
     pub line_width: LineWidth,
     pub persistent_line_breaks: PersistentLineBreaks,
+    pub assignment_style: AssignmentStyle,
     pub exclude: Option<ExcludePatterns>,
     pub default_exclude: Option<DefaultExcludePatterns>,
     pub default_include: Option<DefaultIncludePatterns>,
@@ -54,6 +56,7 @@ impl Default for FormatSettings {
             line_ending: Default::default(),
             line_width: Default::default(),
             persistent_line_breaks: Default::default(),
+            assignment_style: Default::default(),
             exclude: Default::default(),
             default_exclude: Some(Default::default()),
             default_include: Some(Default::default()),
@@ -72,6 +75,7 @@ impl FormatSettings {
             .with_line_ending(self.line_ending.finalize(source))
             .with_line_width(self.line_width)
             .with_persistent_line_breaks(self.persistent_line_breaks)
+            .with_assignment_style(self.assignment_style)
             // Note that `clone()` on these options is ultimately on an `Arc`
             .with_skip(self.skip.clone())
             .with_table(self.table.clone())

--- a/crates/workspace/src/toml_options.rs
+++ b/crates/workspace/src/toml_options.rs
@@ -21,6 +21,7 @@ use crate::settings::ExcludePatterns;
 use crate::settings::FormatSettings;
 use crate::settings::LineEnding;
 use crate::settings::Settings;
+use settings::AssignmentStyle;
 use settings::IndentStyle;
 use settings::IndentWidth;
 use settings::LineWidth;
@@ -121,6 +122,19 @@ pub struct FormatTomlOptions {
     /// It may be preferable to ignore persistent line breaks if you prefer that `line-width`
     /// should be the only value that influences line breaks.
     pub persistent_line_breaks: Option<bool>,
+
+    /// # The preferred assignment style
+    ///
+    /// - `preserve` (default): Assignment operators are preserved as is.
+    ///
+    /// - `arrow`: Use `<-`.
+    ///
+    /// - `equal`: Use `=`.
+    ///
+    /// Note that changing from `<-` to `=` is not always possible. For example, `f(x <-
+    /// 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named
+    /// `x`. In these cases, the `<-` is left as is.
+    pub assignment_style: Option<AssignmentStyle>,
 
     /// # Patterns to exclude from formatting
     ///
@@ -248,6 +262,7 @@ impl TomlOptions {
                 }
                 None => PersistentLineBreaks::Respect,
             },
+            assignment_style: format.assignment_style.unwrap_or_default(),
             exclude: match format.exclude {
                 Some(exclude) => {
                     let exclude = exclude.iter().map(String::as_str);

--- a/crates/workspace/src/toml_options.rs
+++ b/crates/workspace/src/toml_options.rs
@@ -125,11 +125,11 @@ pub struct FormatTomlOptions {
 
     /// # The preferred assignment style
     ///
-    /// - `preserve` (default): Assignment operators are preserved as is.
-    ///
-    /// - `arrow`: Use `<-`.
+    /// - `arrow` (default): Use `<-`.
     ///
     /// - `equal`: Use `=`.
+    ///
+    /// - `preserve`: Assignment operators are preserved as is.
     ///
     /// Note that changing from `<-` to `=` is not always possible. For example, `f(x <-
     /// 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named

--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -20,6 +20,7 @@ indent-width = 2
 indent-style = "space"
 line-ending = "auto"
 persistent-line-breaks = true
+assignment-style = "preserve"
 exclude = []
 default-exclude = true
 skip = []
@@ -195,6 +196,22 @@ dictionary <- list(apple = 0.75, banana = 0.25, cherry = 0.50)
 Alternatively, use a tool such as [codegrip](https://github.com/lionel-/codegrip) bound to a keyboard shortcut to flatten the code, and Air will keep it flattened as long as it fits within the `line-width`.
 
 It may be preferable to ignore persistent line breaks if you prefer that `line-width` should be the only value that influences line breaks.
+
+### assignment-style
+
+The preferred assignment style to use.
+
+One of the following values, with a default of `"preserve"`:
+
+-   `"preserve"`: Assignment operators are preserved as is.
+
+-   `"arrow"`: Use `<-`.
+
+-   `"equal"`: Use `=`.
+
+Note that changing from `<-` to `=` is not always possible.
+For example, `f(x <- 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named `x`.
+In these cases, the `<-` is left as is.
 
 ### exclude
 

--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -20,7 +20,7 @@ indent-width = 2
 indent-style = "space"
 line-ending = "auto"
 persistent-line-breaks = true
-assignment-style = "preserve"
+assignment-style = "arrow"
 exclude = []
 default-exclude = true
 skip = []
@@ -201,13 +201,13 @@ It may be preferable to ignore persistent line breaks if you prefer that `line-w
 
 The preferred assignment style to use.
 
-One of the following values, with a default of `"preserve"`:
-
--   `"preserve"`: Assignment operators are preserved as is.
+One of the following values, with a default of `"arrow"`:
 
 -   `"arrow"`: Use `<-`.
 
 -   `"equal"`: Use `=`.
+
+-   `"preserve"`: Assignment operators are preserved as is.
 
 Note that changing from `<-` to `=` is not always possible.
 For example, `f(x <- 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named `x`.

--- a/xtask/json_schema/src/snapshots/xtask_json_schema__tests__schema_can_be_generated_and_hasnt_changed.snap
+++ b/xtask/json_schema/src/snapshots/xtask_json_schema__tests__schema_can_be_generated_and_hasnt_changed.snap
@@ -24,11 +24,6 @@ expression: schema
     "AssignmentStyle": {
       "oneOf": [
         {
-          "title": "Assignment operators are preserved as is",
-          "type": "string",
-          "const": "preserve"
-        },
-        {
           "title": "Use `<-`",
           "type": "string",
           "const": "arrow"
@@ -38,6 +33,11 @@ expression: schema
           "description": "Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
           "type": "string",
           "const": "equal"
+        },
+        {
+          "title": "Assignment operators are preserved as is",
+          "type": "string",
+          "const": "preserve"
         }
       ]
     },
@@ -47,7 +47,7 @@ expression: schema
       "properties": {
         "assignment-style": {
           "title": "The preferred assignment style",
-          "description": "- `preserve` (default): Assignment operators are preserved as is.\n\n - `arrow`: Use `<-`.\n\n - `equal`: Use `=`.\n\n Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
+          "description": "- `arrow` (default): Use `<-`.\n\n - `equal`: Use `=`.\n\n - `preserve`: Assignment operators are preserved as is.\n\n Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
           "anyOf": [
             {
               "$ref": "#/$defs/AssignmentStyle"

--- a/xtask/json_schema/src/snapshots/xtask_json_schema__tests__schema_can_be_generated_and_hasnt_changed.snap
+++ b/xtask/json_schema/src/snapshots/xtask_json_schema__tests__schema_can_be_generated_and_hasnt_changed.snap
@@ -21,10 +21,42 @@ expression: schema
   },
   "additionalProperties": false,
   "$defs": {
+    "AssignmentStyle": {
+      "oneOf": [
+        {
+          "title": "Assignment operators are preserved as is",
+          "type": "string",
+          "const": "preserve"
+        },
+        {
+          "title": "Use `<-`",
+          "type": "string",
+          "const": "arrow"
+        },
+        {
+          "title": "Use `=`",
+          "description": "Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
+          "type": "string",
+          "const": "equal"
+        }
+      ]
+    },
     "FormatTomlOptions": {
       "description": "Options to configure code formatting.",
       "type": "object",
       "properties": {
+        "assignment-style": {
+          "title": "The preferred assignment style",
+          "description": "- `preserve` (default): Assignment operators are preserved as is.\n\n - `arrow`: Use `<-`.\n\n - `equal`: Use `=`.\n\n Note that changing from `<-` to `=` is not always possible. For example, `f(x <-\n 5)` can't be rewritten as `f(x = 5)` because that would parse as an argument named\n `x`. In these cases, the `<-` is left as is.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AssignmentStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "default-exclude": {
           "title": "Whether or not to use default exclude patterns",
           "description": "Air automatically excludes a default set of folders and files. If this option is\n set to `false`, these files will be formatted as well.\n\n The default set of excluded patterns are:\n - `.git/`\n - `renv/`\n - `revdep/`\n - `cpp11.R`\n - `RcppExports.R`\n - `extendr-wrappers.R`\n - `import-standalone-*.R`",


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/359

- Defaults to `"preserve"`, no changes to assignment operators
- `"arrow"` changes all `=` to `<-`
- `"equal"` changes all `<-` to `=` _where possible_

The _where possible_ part is contained within `can_normalize_to_equal()`. It is really the only tricky part about this PR. I am fairly confident with it though. It is hand crafted after an extremely close read of `gram.y`, and double checked with a deep claude review.

The name `assignment-style` is meant to be similar to `indent-style` and an eventual `quote-style` (also used by ruff). The `"preserve"` name matches ruff's `quote-style = "preserve"`.

Note that I've chosen to make this opt-in. Hopefully people will find and use it. I considered setting `<-` as the default, but I was worried about aggressively changing people's code if they already use Air but prefer `=`.

In other news, let-chains are amazing