### PR TITLE
Prepend the active `air` executable location to the `PATH` of integrated terminals

### DIFF
--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Development version
 
-- New `air.addExecutableToPATH` configuration option to control whether the `air` executable located by `air.executableStrategy` is also added to the `PATH` of all integrated terminals. This ensures that a call to `air` in an integrated terminal uses the same version of Air used by the editor, which is particularly useful when agents call Air on your behalf. It is on by default (#500).
+- New `air.addExecutableToPath` configuration option to control whether the `air` executable located by `air.executableStrategy` is also added to the `PATH` of all integrated terminals. This ensures that a call to `air` in an integrated terminal uses the same version of Air used by the editor, which is particularly useful when agents call Air on your behalf. It is on by default (#500).
 
 
 ## 0.24.0

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Development version
 
+- New `air.addExecutableToPATH` configuration option to control whether the `air` executable located by `air.executableStrategy` is also added to the `PATH` of all integrated terminals. This ensures that a call to `air` in an integrated terminal uses the same version of Air used by the editor, which is particularly useful when agents call Air on your behalf. It is on by default (#500).
+
+
 ## 0.24.0
 
 - [Air 0.9.0](https://github.com/posit-dev/air/blob/main/CHANGELOG.md) is now bundled with the extension.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -103,7 +103,7 @@
 					"scope": "window",
 					"type": "string"
 				},
-				"air.addExecutableToPATH": {
+				"air.addExecutableToPath": {
 					"default": true,
 					"markdownDescription": "Whether to add the directory containing the `air` executable resolved by `air.executableStrategy` to the `PATH` of integrated terminals. This ensures that `air` invoked in an integrated terminal matches `air` used by the editor.",
 					"scope": "window",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -83,7 +83,7 @@
 				},
 				"air.executableStrategy": {
 					"default": "bundled",
-					"markdownDescription": "Strategy used to locate the `air` executable to start the language server with.",
+					"markdownDescription": "Strategy used to locate the `air` executable.",
 					"enum": [
 						"bundled",
 						"environment",
@@ -102,6 +102,12 @@
 					"markdownDescription": "The path to an `air` executable. Only utilized when `air.executableStrategy` is set to \"path\".",
 					"scope": "window",
 					"type": "string"
+				},
+				"air.addExecutableToPATH": {
+					"default": true,
+					"markdownDescription": "Whether to add the directory containing the `air` executable resolved by `air.executableStrategy` to the `PATH` of integrated terminals. This ensures that `air` invoked in an integrated terminal matches `air` used by the editor.",
+					"scope": "window",
+					"type": "boolean"
 				}
 			}
 		},

--- a/editors/code/src/environment.ts
+++ b/editors/code/src/environment.ts
@@ -2,18 +2,74 @@ import * as vscode from "vscode";
 import * as path from "path";
 
 import * as output from "./output";
+import { getWorkspaceSettings } from "./settings";
+import { StateChangeStarted, State, StateChange } from "./lsp";
+import { Disposable } from "vscode-languageclient";
 
-// Manages the contributions we make to the environment variables of integrated
+// Manages the `PATH` environment variable contribution we make to integrated
 // terminals.
-export class EnvironmentVariableManager {
-	constructor(private collection: vscode.EnvironmentVariableCollection) {
-		// `PATH` should mirror the running server's resolved binary, recomputed
-		// on each start, so don't cache it across IDE sessions. In particular,
-		// it would be bad if a collection was restored after an Air extension
-		// update, in which case there would be a short period where terminal
-		// `PATH`s point to an outdated location where an `air` executable no
-		// longer exists (until the next extension start updates it).
-		this.collection.persistent = false;
+export class PathEnvironmentVariableManager implements Disposable {
+	private executableDirectory: string | null = null;
+	private workspaceFolder: vscode.WorkspaceFolder | null = null;
+
+	private subscriptions: Disposable[] = [];
+
+	constructor(
+		private collection: vscode.EnvironmentVariableCollection,
+		onStateChange: vscode.Event<StateChange>,
+	) {
+		// When the LSP fully starts up, sync our shared state and update `PATH` contribution.
+		// When the LSP shuts down (restart or deactivation), clear shared state and unset `PATH` contribution.
+		this.subscriptions.push(
+			onStateChange((change) => {
+				switch (change.state) {
+					case State.Started: {
+						const started = change as StateChangeStarted;
+						this.executableDirectory = path.dirname(
+							started.binaryPath,
+						);
+						this.workspaceFolder = started.workspaceFolder;
+						this.update();
+						break;
+					}
+					case State.Stopped: {
+						this.executableDirectory = null;
+						this.workspaceFolder = null;
+						this.delete();
+						break;
+					}
+				}
+			}),
+		);
+
+		// When the user changes `air.addExecutableToPATH`, reflect this immediately in new terminals
+		this.subscriptions.push(
+			vscode.workspace.onDidChangeConfiguration((event) => {
+				if (event.affectsConfiguration("air.addExecutableToPATH")) {
+					this.update();
+				}
+			}),
+		);
+	}
+
+	private update(): void {
+		if (!this.workspaceFolder) {
+			return;
+		}
+		if (!this.executableDirectory) {
+			return;
+		}
+
+		const workspaceSettings = getWorkspaceSettings(
+			"air",
+			this.workspaceFolder,
+		);
+
+		if (workspaceSettings.addExecutableToPATH) {
+			this.prepend(this.executableDirectory);
+		} else {
+			this.delete();
+		}
 	}
 
 	// Prepend a directory to the `PATH`
@@ -27,7 +83,7 @@ export class EnvironmentVariableManager {
 	// - `applyAtShellIntegration` is the newer mechanism and applies the
 	//   modification via a VS Code managed shell integration script after any
 	//   shell startup scripts have run.
-	public prependToPATH(directory: string): void {
+	private prepend(directory: string): void {
 		this.collection.prepend("PATH", directory + path.delimiter, {
 			applyAtProcessCreation: false,
 			applyAtShellIntegration: true,
@@ -35,8 +91,14 @@ export class EnvironmentVariableManager {
 		output.log(`Added \`${directory}\` to the terminal PATH.`);
 	}
 
-	// Clear any contributions we've made
-	public clear(): void {
-		this.collection.clear();
+	private delete(): void {
+		this.collection.delete("PATH");
+		output.log(`Removed terminal PATH mutation.`);
+	}
+
+	dispose() {
+		for (const subscription of this.subscriptions) {
+			subscription.dispose();
+		}
 	}
 }

--- a/editors/code/src/environment.ts
+++ b/editors/code/src/environment.ts
@@ -40,10 +40,10 @@ export class PathEnvironmentVariableManager implements vscode.Disposable {
 			}),
 		);
 
-		// When the user changes `air.addExecutableToPATH`, reflect this immediately in new terminals
+		// When the user changes `air.addExecutableToPath`, reflect this immediately in new terminals
 		this.subscriptions.push(
 			vscode.workspace.onDidChangeConfiguration((event) => {
-				if (event.affectsConfiguration("air.addExecutableToPATH")) {
+				if (event.affectsConfiguration("air.addExecutableToPath")) {
 					this.update();
 				}
 			}),
@@ -63,7 +63,7 @@ export class PathEnvironmentVariableManager implements vscode.Disposable {
 			this.workspaceFolder,
 		);
 
-		if (workspaceSettings.addExecutableToPATH) {
+		if (workspaceSettings.addExecutableToPath) {
 			this.prepend(this.executableDirectory);
 		} else {
 			this.delete();

--- a/editors/code/src/environment.ts
+++ b/editors/code/src/environment.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+import * as output from "./output";
+
+// Manages the contributions we make to the environment variables of integrated
+// terminals.
+export class EnvironmentVariableManager {
+	constructor(private collection: vscode.EnvironmentVariableCollection) {
+		// `PATH` should mirror the running server's resolved binary, recomputed
+		// on each start, so don't cache it across IDE sessions. In particular,
+		// it would be bad if a collection was restored after an Air extension
+		// update, in which case there would be a short period where terminal
+		// `PATH`s point to an outdated location where an `air` executable no
+		// longer exists (until the next extension start updates it).
+		this.collection.persistent = false;
+	}
+
+	// Prepend a directory to the `PATH`
+	//
+	// `applyAtProcessCreation` and `applyAtShellIntegration` are really
+	// mutually exclusive:
+	//
+	// - `applyAtProcessCreation` would modify the `PATH` as early as possible,
+	//   before any shell startup scripts run (like zshrc, for example). This
+	//   could allow shell scripts to overwrite our modifications.
+	// - `applyAtShellIntegration` is the newer mechanism and applies the
+	//   modification via a VS Code managed shell integration script after any
+	//   shell startup scripts have run.
+	public prependToPATH(directory: string): void {
+		this.collection.prepend("PATH", directory + path.delimiter, {
+			applyAtProcessCreation: false,
+			applyAtShellIntegration: true,
+		});
+		output.log(`Added \`${directory}\` to the terminal PATH.`);
+	}
+
+	// Clear any contributions we've made
+	public clear(): void {
+		this.collection.clear();
+	}
+}

--- a/editors/code/src/environment.ts
+++ b/editors/code/src/environment.ts
@@ -4,15 +4,14 @@ import * as path from "path";
 import * as output from "./output";
 import { getWorkspaceSettings } from "./settings";
 import { State, StateChange } from "./lsp";
-import { Disposable } from "vscode-languageclient";
 
 // Manages the `PATH` environment variable contribution we make to integrated
 // terminals.
-export class PathEnvironmentVariableManager implements Disposable {
+export class PathEnvironmentVariableManager implements vscode.Disposable {
 	private executableDirectory: string | null = null;
 	private workspaceFolder: vscode.WorkspaceFolder | null = null;
 
-	private subscriptions: Disposable[] = [];
+	private subscriptions: vscode.Disposable[] = [];
 
 	constructor(
 		private collection: vscode.EnvironmentVariableCollection,

--- a/editors/code/src/environment.ts
+++ b/editors/code/src/environment.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 import * as output from "./output";
 import { getWorkspaceSettings } from "./settings";
-import { StateChangeStarted, State, StateChange } from "./lsp";
+import { State, StateChange } from "./lsp";
 import { Disposable } from "vscode-languageclient";
 
 // Manages the `PATH` environment variable contribution we make to integrated
@@ -24,11 +24,10 @@ export class PathEnvironmentVariableManager implements Disposable {
 			onStateChange((change) => {
 				switch (change.state) {
 					case State.Started: {
-						const started = change as StateChangeStarted;
 						this.executableDirectory = path.dirname(
-							started.binaryPath,
+							change.binaryPath,
 						);
-						this.workspaceFolder = started.workspaceFolder;
+						this.workspaceFolder = change.workspaceFolder;
 						this.update();
 						break;
 					}

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -2,11 +2,29 @@ import * as vscode from "vscode";
 import { Ctx } from "./context";
 import { Lsp } from "./lsp";
 import { registerCommands } from "./commands";
+import { PathEnvironmentVariableManager } from "./environment";
+import path from "path";
 
 let ctx: Ctx;
 
 export function activate(context: vscode.ExtensionContext) {
+	// Contributed environment variables should mirror the running server's
+	// resolved binary, should be recomputed on each start, and don't cache
+	// across IDE sessions. In particular, it would be bad if a collection was
+	// restored after an Air extension update, in which case there would be a
+	// short period where terminal `PATH`s point to an outdated location where
+	// an `air` executable no longer exists.
+	context.environmentVariableCollection.persistent = false;
+
 	let lsp = new Lsp(context);
+
+	context.subscriptions.push(
+		new PathEnvironmentVariableManager(
+			context.environmentVariableCollection,
+			lsp.onStateChange,
+		),
+	);
+
 	lsp.start();
 
 	ctx = new Ctx(context, lsp);

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -3,7 +3,6 @@ import { Ctx } from "./context";
 import { Lsp } from "./lsp";
 import { registerCommands } from "./commands";
 import { PathEnvironmentVariableManager } from "./environment";
-import path from "path";
 
 let ctx: Ctx;
 

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
+import * as path from "path";
 import { default as PQueue } from "p-queue";
 import { getInitializationOptions, getWorkspaceSettings } from "./settings";
 import {
@@ -11,6 +12,7 @@ import { SYNC_FILE_SETTINGS } from "./notification/sync-file-settings";
 import { registerLogger } from "./output";
 import { resolveAirBinaryPath } from "./binary";
 import { getRootWorkspaceFolder } from "./workspace";
+import { EnvironmentVariableManager } from "./environment";
 
 // All session management operations are put on a queue. They can't run
 // concurrently and either result in a started or stopped state. Starting when
@@ -41,9 +43,15 @@ export class Lsp {
 
 	private onSettingsNotificationEmitter: vscode.EventEmitter<SyncFileSettingsParams>;
 
+	private environmentVariableManager: EnvironmentVariableManager;
+
 	constructor(context: vscode.ExtensionContext) {
 		this.channel = vscode.window.createOutputChannel("Air Language Server");
 		context.subscriptions.push(this.channel, registerLogger(this.channel));
+
+		this.environmentVariableManager = new EnvironmentVariableManager(
+			context.environmentVariableCollection,
+		);
 
 		this.stateQueue = new PQueue({ concurrency: 1 });
 		this.fileSettings = new FileSettingsState(context);
@@ -204,6 +212,13 @@ export class Lsp {
 		this.client = client;
 		this.binaryPath = binaryPath;
 		this.state = State.Started;
+
+		// Only update PATH if no error occurred
+		if (workspaceSettings.addExecutableToPATH) {
+			this.environmentVariableManager.prependToPATH(
+				path.dirname(binaryPath),
+			);
+		}
 	}
 
 	private async stopImpl() {
@@ -211,6 +226,8 @@ export class Lsp {
 		if (this.state === State.Stopped) {
 			return;
 		}
+
+		this.environmentVariableManager.clear();
 
 		try {
 			await this.client?.stop();

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -12,21 +12,33 @@ import { SYNC_FILE_SETTINGS } from "./notification/sync-file-settings";
 import { registerLogger } from "./output";
 import { resolveAirBinaryPath } from "./binary";
 import { getRootWorkspaceFolder } from "./workspace";
-import { EnvironmentVariableManager } from "./environment";
 
 // All session management operations are put on a queue. They can't run
 // concurrently and either result in a started or stopped state. Starting when
 // started is a noop, same for stopping when stopped. On the other hand
 // restarting is always scheduled.
-enum State {
+export enum State {
 	Started = "started",
 	Stopped = "stopped",
 }
+
+export interface StateChangeStarted {
+	state: State;
+	binaryPath: string;
+	workspaceFolder: vscode.WorkspaceFolder;
+}
+export interface StateChangeStopped {
+	state: State;
+}
+export type StateChange = StateChangeStarted | StateChangeStopped;
 
 export class Lsp {
 	private client: lc.LanguageClient | null = null;
 
 	private binaryPath: string | null = null;
+
+	public onStateChange: vscode.Event<StateChange>;
+	private onStateChangeEmitter: vscode.EventEmitter<StateChange>;
 
 	// We've received and processed an `air.toml` settings synchronization
 	// notification. Used to synchronize unit tests with the LSP.
@@ -43,18 +55,16 @@ export class Lsp {
 
 	private onSettingsNotificationEmitter: vscode.EventEmitter<SyncFileSettingsParams>;
 
-	private environmentVariableManager: EnvironmentVariableManager;
-
 	constructor(context: vscode.ExtensionContext) {
 		this.channel = vscode.window.createOutputChannel("Air Language Server");
 		context.subscriptions.push(this.channel, registerLogger(this.channel));
 
-		this.environmentVariableManager = new EnvironmentVariableManager(
-			context.environmentVariableCollection,
-		);
-
 		this.stateQueue = new PQueue({ concurrency: 1 });
 		this.fileSettings = new FileSettingsState(context);
+
+		this.onStateChangeEmitter = new vscode.EventEmitter<StateChange>();
+		context.subscriptions.push(this.onStateChangeEmitter);
+		this.onStateChange = this.onStateChangeEmitter.event;
 
 		this.onSettingsNotificationEmitter =
 			new vscode.EventEmitter<SyncFileSettingsParams>();
@@ -212,13 +222,11 @@ export class Lsp {
 		this.client = client;
 		this.binaryPath = binaryPath;
 		this.state = State.Started;
-
-		// Only update PATH if no error occurred
-		if (workspaceSettings.addExecutableToPATH) {
-			this.environmentVariableManager.prependToPATH(
-				path.dirname(binaryPath),
-			);
-		}
+		this.onStateChangeEmitter.fire({
+			state: this.state,
+			binaryPath: this.binaryPath,
+			workspaceFolder: workspaceFolder,
+		});
 	}
 
 	private async stopImpl() {
@@ -226,8 +234,6 @@ export class Lsp {
 		if (this.state === State.Stopped) {
 			return;
 		}
-
-		this.environmentVariableManager.clear();
 
 		try {
 			await this.client?.stop();
@@ -238,6 +244,9 @@ export class Lsp {
 			this.state = State.Stopped;
 			this.client = null;
 			this.binaryPath = null;
+			this.onStateChangeEmitter.fire({
+				state: this.state,
+			});
 		}
 	}
 

--- a/editors/code/src/lsp.ts
+++ b/editors/code/src/lsp.ts
@@ -23,12 +23,12 @@ export enum State {
 }
 
 export interface StateChangeStarted {
-	state: State;
+	state: State.Started;
 	binaryPath: string;
 	workspaceFolder: vscode.WorkspaceFolder;
 }
 export interface StateChangeStopped {
-	state: State;
+	state: State.Stopped;
 }
 export type StateChange = StateChangeStarted | StateChangeStopped;
 

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -15,7 +15,7 @@ export type InitializationOptions = {
 export type WorkspaceSettings = {
 	executableStrategy: ExecutableStrategy;
 	executablePath?: string;
-	addExecutableToPATH: boolean;
+	addExecutableToPath: boolean;
 };
 
 export function getInitializationOptions(
@@ -42,7 +42,7 @@ export function getWorkspaceSettings(
 		executableStrategy:
 			config.get<ExecutableStrategy>("executableStrategy") ?? "bundled",
 		executablePath: config.get<string>("executablePath"),
-		addExecutableToPATH: config.get<boolean>("addExecutableToPATH") ?? true,
+		addExecutableToPath: config.get<boolean>("addExecutableToPath") ?? true,
 	};
 }
 

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -15,6 +15,7 @@ export type InitializationOptions = {
 export type WorkspaceSettings = {
 	executableStrategy: ExecutableStrategy;
 	executablePath?: string;
+	addExecutableToPATH: boolean;
 };
 
 export function getInitializationOptions(
@@ -41,6 +42,7 @@ export function getWorkspaceSettings(
 		executableStrategy:
 			config.get<ExecutableStrategy>("executableStrategy") ?? "bundled",
 		executablePath: config.get<string>("executablePath"),
+		addExecutableToPATH: config.get<boolean>("addExecutableToPATH") ?? true,
 	};
 }
 


### PR DESCRIPTION
Closes #500 

Seems like this works pretty well. A few things to note are listed below.

- We turn off the default caching of `vscode.EnvironmentVariableCollection` with `persistent = false`. By default, it caches across workspace sessions so that if your extension set an environment variable once, then on the next open of Positron it can restore that environment variable tweak _before your extension even activates_. I worry about this, because it means that there can be a period of time where integrated terminals can try to use a "stale" path to an Air binary. Like if we've cached a path to Air, but then Positron updates and brings in a new version of Air, then the user opens Positron, then an integrated terminal that starts up will point to a nonexistent Air binary until the Air extension can start up and reset the env var to the correct updated value. It seemed better to me to just never cache, and only make the env var tweak after we've located the `binaryPath` and successfully started up an LSP client with it.

- Integrated terminals will only get an updated `PATH` if they are started _after_ the Air extension itself has activated. I think this is totally fine, as Air activates fairly aggressively if any R related content is found, and it would be pretty rare to go into a terminal and try to call `air` in a project that doesn't have any R files.

- I did a reasonable amount of work to ensure that we are dynamic to `air.addExecutableToPATH` configuration changes. i.e., if you turn it off, then if you immediately create a new terminal it should not have a `PATH` adjustment, no restart required. But note that we are purposefully not dynamic to `air.executableStrategy` or `air.executablePath`. The reason is that we always want to be in sync with _the running server_. So just changing those isn't enough to cause the running server to change, you also have to do `Air: Restart server` and then both the running server and the `PATH` adjustment will update together.

In the video you'll also see that your terminal turns yellow when an environment variable is out of sync! This is pretty cool!

https://github.com/user-attachments/assets/cc6c11b2-5185-491b-aa94-a5a570fc5ffe

Claude in the integrated terminal can find the bundled Air now:

<img width="796" height="352" alt="Screenshot 2026-06-16 at 10 53 54 AM" src="https://github.com/user-attachments/assets/3e914dd4-61d1-48e5-ab79-e0135b7db4a6" />
