### PR TITLE
Add parser tests for CRLF trailing comment fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,7 @@ checksum = "e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600"
 [[package]]
 name = "tree-sitter-r"
 version = "1.2.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=3ee0e0a024a5b21b13506b7904a69b54652136d3#3ee0e0a024a5b21b13506b7904a69b54652136d3"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=462c29d96cc8f8c9b93294d172da9d351d410a5c#462c29d96cc8f8c9b93294d172da9d351d410a5c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,7 @@ checksum = "e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600"
 [[package]]
 name = "tree-sitter-r"
 version = "1.2.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=462c29d96cc8f8c9b93294d172da9d351d410a5c#462c29d96cc8f8c9b93294d172da9d351d410a5c"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=d459b97a9a11dd81643ab674938bede2874663b0#d459b97a9a11dd81643ab674938bede2874663b0"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tower-lsp = { branch = "bugfix/patches", git = "https://github.com/lionel-/tower
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.19"
 tree-sitter = "0.24.7"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "3ee0e0a024a5b21b13506b7904a69b54652136d3" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "462c29d96cc8f8c9b93294d172da9d351d410a5c" }
 url = "2.5.3"
 uuid = { version = "1.11.0", features = ["v4"] }
 workspace = { path = "./crates/workspace" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tower-lsp = { branch = "bugfix/patches", git = "https://github.com/lionel-/tower
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.19"
 tree-sitter = "0.24.7"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "462c29d96cc8f8c9b93294d172da9d351d410a5c" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "d459b97a9a11dd81643ab674938bede2874663b0" }
 url = "2.5.3"
 uuid = { version = "1.11.0", features = ["v4"] }
 workspace = { path = "./crates/workspace" }

--- a/crates/air_r_parser/src/parse.rs
+++ b/crates/air_r_parser/src/parse.rs
@@ -1391,6 +1391,18 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_trivia_comment_crlf_test() {
+        // Trailing comment: `1 # hi\r\n` (r-lib/tree-sitter-r#184)
+        assert_eq_trivia(
+            trivia("1 # hi\r\n"),
+            vec![ws(1, 2, Pos::Trailing), cmt(2, 6, Pos::Trailing), nl(6, 8)],
+        );
+
+        // Own-line comment: `# hi\r\n1`
+        assert_eq_trivia(trivia("# hi\r\n1"), vec![cmt(0, 4, Pos::Leading), nl(4, 6)]);
+    }
+
+    #[test]
     fn test_parse_trivia_comment_nothing_else_test() {
         assert_eq_trivia(trivia("#"), vec![cmt(0, 1, Pos::Leading)]);
     }

--- a/crates/air_r_parser/tests/snapshots/ok/crlf/trailing_comments.R
+++ b/crates/air_r_parser/tests/snapshots/ok/crlf/trailing_comments.R
@@ -1,0 +1,3 @@
+# Leading
+1 + 1 # Trailing
+# Leading

--- a/crates/air_r_parser/tests/snapshots/ok/crlf/trailing_comments.R.snap
+++ b/crates/air_r_parser/tests/snapshots/ok/crlf/trailing_comments.R.snap
@@ -1,0 +1,49 @@
+---
+source: crates/air_r_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```R
+# Leading
+1 + 1 # Trailing
+# Leading
+
+```
+
+
+## AST
+
+```
+RRoot {
+    bom_token: missing (optional),
+    expressions: RExpressionList [
+        RBinaryExpression {
+            left: RDoubleValue {
+                value_token: R_DOUBLE_LITERAL@0..12 "1" [Comments("# Leading"), Newline("\r\n")] [],
+            },
+            operator: PLUS@12..14 "+" [Whitespace(" ")] [],
+            right: RDoubleValue {
+                value_token: R_DOUBLE_LITERAL@14..27 "1" [Whitespace(" ")] [Whitespace(" "), Comments("# Trailing")],
+            },
+        },
+    ],
+    eof_token: EOF@27..40 "" [Newline("\r\n"), Comments("# Leading"), Newline("\r\n")] [],
+}
+```
+
+## CST
+
+```
+0: R_ROOT@0..40
+  0: (empty)
+  1: R_EXPRESSION_LIST@0..27
+    0: R_BINARY_EXPRESSION@0..27
+      0: R_DOUBLE_VALUE@0..12
+        0: R_DOUBLE_LITERAL@0..12 "1" [Comments("# Leading"), Newline("\r\n")] []
+      1: PLUS@12..14 "+" [Whitespace(" ")] []
+      2: R_DOUBLE_VALUE@14..27
+        0: R_DOUBLE_LITERAL@14..27 "1" [Whitespace(" ")] [Whitespace(" "), Comments("# Trailing")]
+  2: EOF@27..40 "" [Newline("\r\n"), Comments("# Leading"), Newline("\r\n")] []
+
+```


### PR DESCRIPTION
Brings in https://github.com/r-lib/tree-sitter-r/pull/184