### PR TITLE
Normalize line endings when doing `skip-file`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Development version
 
+- Fixed an issue where `# fmt: skip file` in a file with CRLF line endings would result in `\r\n` line endings getting converted to `\r\r\n` (#498).
+
 - New `assignment-style` option to enforce a preferred assignment operator, with the following values:
 
   - `"arrow"`: Use `<-`. This is the default, aligning Air further with the [tidyverse style guide](https://style.tidyverse.org/syntax.html#assignment-1).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "biome_rowan",
  "comments",
  "itertools",
+ "line_ending",
  "settings",
  "tests_macros",
  "tracing",

--- a/crates/air/fixtures/crlf/skip_file.R
+++ b/crates/air/fixtures/crlf/skip_file.R
@@ -1,0 +1,3 @@
+# fmt: skip file
+1+1
+x<-c(1,    2)

--- a/crates/air/fixtures/crlf/skip_file.R
+++ b/crates/air/fixtures/crlf/skip_file.R
@@ -1,3 +1,0 @@
-# fmt: skip file
-1+1
-x<-c(1,    2)

--- a/crates/air/tests/integration/format.rs
+++ b/crates/air/tests/integration/format.rs
@@ -163,10 +163,37 @@ default-exclude = false
 }
 
 #[test]
-fn test_doesnt_format_skipped_file_with_crlf_line_endings_and_the_auto_setting()
--> anyhow::Result<()> {
-    // A `# fmt: skip file` file is printed verbatim, so it must round-trip
-    // through formatting untouched (#498).
+fn test_skipped_multiline_node_with_crlf_line_endings_isnt_corrupted() -> anyhow::Result<()> {
+    // The `1\r\n+1` is treated as a single token, but is normalized to `1\n+1` before the
+    // printer sees it, which the printer then rewrites back to `1\r\n+1` (#498).
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    let test_contents = "# fmt: skip\r\n1\r\n+1\r\n2+2\r\n";
+
+    std::fs::write(directory.join(test_path), test_contents)?;
+
+    let output = Command::new(binary_path())
+        .current_dir(directory)
+        .arg("format")
+        .arg(".")
+        .run();
+
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "# fmt: skip\r\n1\r\n+1\r\n2 + 2\r\n"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_skipped_file_with_crlf_line_endings_isnt_corrupted() -> anyhow::Result<()> {
+    // All of `# fmt: skip file\r\n1+1\r\n2+2\r\n` is treated as a single token, but is
+    // normalized to `# fmt: skip file\n1+1\n2+2\n` before the printer sees it, which the
+    // printer then rewrites back with `\r\n` (#498).
 
     let directory = TempDir::new()?;
     let directory = directory.path();
@@ -183,17 +210,62 @@ fn test_doesnt_format_skipped_file_with_crlf_line_endings_and_the_auto_setting()
         .run();
 
     assert!(output.status.success());
-
     assert_eq!(
         std::fs::read_to_string(directory.join(test_path))?,
         test_contents
     );
-
     Ok(())
 }
 
 #[test]
-fn test_formats_skipped_file_with_crlf_line_endings_and_the_lf_setting() -> anyhow::Result<()> {
+fn test_skipped_multiline_node_with_crlf_line_endings_can_have_line_endings_rewritten()
+-> anyhow::Result<()> {
+    // `# fmt: skip` means `1\r\n+1` won't be reformatted, but the line endings MUST still
+    // be rewritten to `\n` due to `line-ending = "lf"`, otherwise it would create a file
+    // with mixed line endings, and that would be madness.
+    //
+    // So `# fmt: skip` is considered orthogonal to `line-ending` (#507).
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    let test_contents = "# fmt: skip\r\n1\r\n+1\r\n2+2\r\n";
+
+    let air_path = "air.toml";
+    let air_contents = r#"
+[format]
+line-ending = "lf"
+"#;
+
+    std::fs::write(directory.join(test_path), test_contents)?;
+    std::fs::write(directory.join(air_path), air_contents)?;
+
+    let output = Command::new(binary_path())
+        .current_dir(directory)
+        .arg("format")
+        .arg(".")
+        .run();
+
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "# fmt: skip\n1\n+1\n2 + 2\n"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_skipped_file_with_crlf_line_endings_can_have_line_endings_rewritten() -> anyhow::Result<()>
+{
+    // `# fmt: skip file` means `# fmt: skip file\r\n1+1\r\n2+2\r\n` won't be reformatted,
+    // but the line endings MUST still be rewritten to `\n` due to `line-ending = "lf"`.
+    //
+    // We asserted above that `# fmt: skip` must rewrite to `\n` to avoid mixed line
+    // endings in a single file. `# fmt: skip file` should be consistent with that,
+    // so it is also considered orthogonal to `line-ending`. If you truly want to avoid
+    // any changes to the file, `exclude` it (#507).
+
     let directory = TempDir::new()?;
     let directory = directory.path();
 
@@ -216,21 +288,10 @@ line-ending = "lf"
         .run();
 
     assert!(output.status.success());
-
-    // The `\r\n` are rewritten as `\n` even though we skipped the file.
-    // The biome printer's `print_char()` is in charge of normalizing newlines to the
-    // user's chosen `LineEnding`, and this happens even when we use `fmt_suppressed()`
-    // on the `RRoot`. A better option if a user cares about this is probably to use
-    // an `exclude` on this file (#498).
-    //
-    // This is really a biome bug that we probably need some new biome infra for, but it
-    // is a rare one and not super high priority for us:
-    // https://github.com/biomejs/biome/discussions/10682
     assert_eq!(
         std::fs::read_to_string(directory.join(test_path))?,
         "# fmt: skip file\n1+1\n2+2\n"
     );
-
     Ok(())
 }
 

--- a/crates/air/tests/integration/format.rs
+++ b/crates/air/tests/integration/format.rs
@@ -179,6 +179,22 @@ fn test_check_returns_cleanly_for_multiline_strings_with_crlf_line_endings() {
 }
 
 #[test]
+fn test_check_returns_cleanly_for_skip_file_with_crlf_line_endings() {
+    // A `# fmt: skip file` file is printed verbatim, so it must round-trip
+    // through formatting untouched (#498).
+    let path = relative_path_fixtures().join("crlf").join("skip_file.R");
+
+    let output = Command::new(binary_path())
+        .current_dir(path_root())
+        .arg("format")
+        .arg(path)
+        .arg("--check")
+        .run();
+
+    assert!(output.status.success());
+}
+
+#[test]
 fn test_check_when_no_formatting_is_required() {
     let path = relative_path_fixtures().join("formatted.R");
     let path = path.to_str().unwrap();

--- a/crates/air/tests/integration/format.rs
+++ b/crates/air/tests/integration/format.rs
@@ -163,6 +163,78 @@ default-exclude = false
 }
 
 #[test]
+fn test_doesnt_format_skipped_file_with_crlf_line_endings_and_the_auto_setting()
+-> anyhow::Result<()> {
+    // A `# fmt: skip file` file is printed verbatim, so it must round-trip
+    // through formatting untouched (#498).
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    let test_contents = "# fmt: skip file\r\n1+1\r\n2+2\r\n";
+
+    std::fs::write(directory.join(test_path), test_contents)?;
+
+    let output = Command::new(binary_path())
+        .current_dir(directory)
+        .arg("format")
+        .arg(".")
+        .run();
+
+    assert!(output.status.success());
+
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        test_contents
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_formats_skipped_file_with_crlf_line_endings_and_the_lf_setting() -> anyhow::Result<()> {
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    let test_contents = "# fmt: skip file\r\n1+1\r\n2+2\r\n";
+
+    let air_path = "air.toml";
+    let air_contents = r#"
+[format]
+line-ending = "lf"
+"#;
+
+    std::fs::write(directory.join(test_path), test_contents)?;
+    std::fs::write(directory.join(air_path), air_contents)?;
+
+    let output = Command::new(binary_path())
+        .current_dir(directory)
+        .arg("format")
+        .arg(".")
+        .run();
+
+    assert!(output.status.success());
+
+    // The `\r\n` are rewritten as `\n` even though we skipped the file.
+    // The biome printer's `print_char()` is in charge of normalizing newlines to the
+    // user's chosen `LineEnding`, and this happens even when we use `fmt_suppressed()`
+    // on the `RRoot`. A better option if a user cares about this is probably to use
+    // an `exclude` on this file (#498).
+    //
+    // This is really a biome bug that we probably need some new biome infra for, but it
+    // is a rare one and not super high priority for us:
+    // https://github.com/biomejs/biome/discussions/10682
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "# fmt: skip file\n1+1\n2+2\n"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_check_returns_cleanly_for_multiline_strings_with_crlf_line_endings() {
     let path = relative_path_fixtures()
         .join("crlf")
@@ -176,55 +248,6 @@ fn test_check_returns_cleanly_for_multiline_strings_with_crlf_line_endings() {
         .run();
 
     assert!(output.status.success());
-}
-
-#[test]
-fn test_check_returns_cleanly_for_skip_file_with_crlf_line_endings_and_the_auto_setting() {
-    // A `# fmt: skip file` file is printed verbatim, so it must round-trip
-    // through formatting untouched (#498).
-    let path = relative_path_fixtures().join("crlf").join("skip_file.R");
-
-    let output = Command::new(binary_path())
-        .current_dir(path_root())
-        .arg("format")
-        .arg(path)
-        .arg("--check")
-        .run();
-
-    assert!(output.status.success());
-}
-
-#[test]
-fn test_check_does_not_return_cleanly_for_skip_file_with_crlf_line_endings_and_the_lf_setting()
--> anyhow::Result<()> {
-    let directory = TempDir::new()?;
-    let directory = directory.path();
-
-    let from_path = relative_path_fixtures().join("crlf").join("skip_file.R");
-    std::fs::copy(from_path, directory.join("skip_file.R"))?;
-
-    let air_path = "air.toml";
-    let air_contents = r#"
-[format]
-line-ending = "lf"
-"#;
-    std::fs::write(directory.join(air_path), air_contents)?;
-
-    let output = Command::new(binary_path())
-        .current_dir(directory)
-        .arg("format")
-        .arg(".")
-        .arg("--check")
-        .run();
-
-    // Fails because `\r\n` are rewritten as `\n` even though we skipped the file.
-    // The biome printer's `print_char()` is in charge of normalizing newlines to the
-    // user's chosen `LineEnding`, and this happens even when we use `fmt_suppressed()`
-    // on the `RRoot`. A better option if a user cares about this is probably to use
-    // an `exclude` on this file (#498).
-    assert!(!output.status.success());
-
-    Ok(())
 }
 
 #[test]

--- a/crates/air/tests/integration/format.rs
+++ b/crates/air/tests/integration/format.rs
@@ -179,7 +179,7 @@ fn test_check_returns_cleanly_for_multiline_strings_with_crlf_line_endings() {
 }
 
 #[test]
-fn test_check_returns_cleanly_for_skip_file_with_crlf_line_endings() {
+fn test_check_returns_cleanly_for_skip_file_with_crlf_line_endings_and_the_auto_setting() {
     // A `# fmt: skip file` file is printed verbatim, so it must round-trip
     // through formatting untouched (#498).
     let path = relative_path_fixtures().join("crlf").join("skip_file.R");
@@ -192,6 +192,39 @@ fn test_check_returns_cleanly_for_skip_file_with_crlf_line_endings() {
         .run();
 
     assert!(output.status.success());
+}
+
+#[test]
+fn test_check_does_not_return_cleanly_for_skip_file_with_crlf_line_endings_and_the_lf_setting()
+-> anyhow::Result<()> {
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let from_path = relative_path_fixtures().join("crlf").join("skip_file.R");
+    std::fs::copy(from_path, directory.join("skip_file.R"))?;
+
+    let air_path = "air.toml";
+    let air_contents = r#"
+[format]
+line-ending = "lf"
+"#;
+    std::fs::write(directory.join(air_path), air_contents)?;
+
+    let output = Command::new(binary_path())
+        .current_dir(directory)
+        .arg("format")
+        .arg(".")
+        .arg("--check")
+        .run();
+
+    // Fails because `\r\n` are rewritten as `\n` even though we skipped the file.
+    // The biome printer's `print_char()` is in charge of normalizing newlines to the
+    // user's chosen `LineEnding`, and this happens even when we use `fmt_suppressed()`
+    // on the `RRoot`. A better option if a user cares about this is probably to use
+    // an `exclude` on this file (#498).
+    assert!(!output.status.success());
+
+    Ok(())
 }
 
 #[test]

--- a/crates/air_r_formatter/Cargo.toml
+++ b/crates/air_r_formatter/Cargo.toml
@@ -18,6 +18,7 @@ biome_formatter = { workspace = true }
 biome_rowan = { workspace = true }
 comments = { workspace = true }
 itertools = { workspace = true }
+line_ending = { workspace = true }
 settings = { workspace = true, features = ["biome", "serde"] }
 tracing = { workspace = true }
 

--- a/crates/air_r_formatter/src/r/auxiliary/root.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/root.rs
@@ -9,6 +9,7 @@ use biome_formatter::write;
 use biome_rowan::Direction;
 use biome_rowan::SyntaxElement;
 use comments::{Directive, FormatDirective, parse_comment_directive, parse_special_skip_file};
+use settings::LineEnding;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatRRoot;
@@ -83,19 +84,34 @@ impl FormatNodeRule<RRoot> for FormatRRoot {
     // does not work out well for `RRoot` because it doesn't format
     // trivia verbatim. So we use a custom implementation instead.
     fn fmt_suppressed(&self, node: &RRoot, f: &mut RFormatter) -> FormatResult<()> {
+        let syntax = node.syntax();
+
         // Mark everything as visited so the formatter doesn't panic
         // thinking we've missed elements. We're going to print each element
         // manually with `dynamic_text()`.
-        mark_visited(node.syntax(), f);
+        mark_visited(syntax, f);
 
         // `node.to_trimmed_string()` trims trivia so we get the raw text on the syntax
         // node instead
-        let text: String = node.syntax().text_with_trivia().into();
+        let text: String = syntax.text_with_trivia().into();
+        let start = syntax.text_range_with_trivia().start();
+
+        // Printing all of `RRoot` means that all whitespace and newlines are also printed
+        // as part of the `dynamic_text()` token. The formatter's printer requires that
+        // all tokens have `\n` newlines, so we must normalize here, and then the printer
+        // will rewrite any `\n` it sees using the user's chosen `LineEnding`. This is
+        // very similar to how `FormatStringContentToken` works, where the newlines are
+        // part of the string content token, so we take responsibility for normalization
+        // (#498, #127).
+        let text = match line_ending::infer(&text) {
+            LineEnding::Lf => text,
+            LineEnding::Crlf => line_ending::normalize(text),
+        };
 
         // Formatting with `format_suppressed_node()` does not work well
         // here because it only formats the node verbatim, not the leading
         // and trailing trivia
-        dynamic_text(&text, node.syntax().text_range_with_trivia().start()).fmt(f)
+        dynamic_text(&text, start).fmt(f)
     }
 }
 

--- a/crates/air_r_formatter/src/r/auxiliary/root.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/root.rs
@@ -101,8 +101,10 @@ impl FormatNodeRule<RRoot> for FormatRRoot {
         // all tokens have `\n` newlines, so we must normalize here, and then the printer
         // will rewrite any `\n` it sees using the user's chosen `LineEnding`. This is
         // very similar to how `FormatStringContentToken` works, where the newlines are
-        // part of the string content token, so we take responsibility for normalization
-        // (#498, #127).
+        // part of the string content token, so we take responsibility for normalization.
+        // This is also identical to how `fmt_suppressed()`'s default works via
+        // `format_suppressed_node()` and `FormatVerbatimNode`. It normalizes line endings
+        // right before calling `dynamic_text()` (#498, #127).
         let text = match line_ending::infer(&text) {
             LineEnding::Lf => text,
             LineEnding::Crlf => line_ending::normalize(text),

--- a/crates/air_r_formatter/src/r/auxiliary/root.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/root.rs
@@ -104,7 +104,7 @@ impl FormatNodeRule<RRoot> for FormatRRoot {
         // part of the string content token, so we take responsibility for normalization.
         // This is also identical to how `fmt_suppressed()`'s default works via
         // `format_suppressed_node()` and `FormatVerbatimNode`. It normalizes line endings
-        // right before calling `dynamic_text()` (#498, #127).
+        // right before calling `dynamic_text()` (#507).
         let text = match line_ending::infer(&text) {
             LineEnding::Lf => text,
             LineEnding::Crlf => line_ending::normalize(text),

--- a/crates/air_r_formatter/src/string_content.rs
+++ b/crates/air_r_formatter/src/string_content.rs
@@ -2,7 +2,6 @@ use air_r_syntax::RSyntaxKind::STRING_CONTENT;
 use air_r_syntax::RSyntaxToken;
 use biome_formatter::Format;
 use biome_formatter::FormatResult;
-use biome_formatter::prelude::Formatter;
 use biome_formatter::prelude::syntax_token_cow_slice;
 use biome_formatter::trivia::format_replaced;
 use std::borrow::Cow;
@@ -12,7 +11,7 @@ use crate::context::RFormatContext;
 
 /// Helper utility for formatting a string content token
 ///
-/// The main job of this utility is to `normalize()` the string and handle the
+/// The main job of this utility is to normalize the string content and handle the
 /// complicated way we have to call [format_replaced] with that normalized result.
 pub(crate) struct FormatStringContentToken<'token> {
     /// The string content token to format
@@ -23,51 +22,14 @@ impl<'token> FormatStringContentToken<'token> {
     pub(crate) fn new(token: &'token RSyntaxToken) -> Self {
         Self { token }
     }
-
-    fn normalize(&self) -> FormatNormalizedStringContentToken<'_> {
-        let token = self.token;
-
-        debug_assert!(
-            matches!(token.kind(), STRING_CONTENT),
-            "Found kind {:?}",
-            token.kind()
-        );
-        debug_assert!(
-            token.text() == token.text_trimmed(),
-            "String content tokens should never have trivia. \
-            Trivia should be on string open or string close tokens instead."
-        );
-
-        let text = token.text();
-        let text = normalize_string(text);
-
-        FormatNormalizedStringContentToken { token, text }
-    }
 }
 
 impl Format<RFormatContext> for FormatStringContentToken<'_> {
     fn fmt(&self, f: &mut RFormatter) -> FormatResult<()> {
-        self.normalize().fmt(f)
-    }
-}
-
-struct FormatNormalizedStringContentToken<'token> {
-    /// The original string content token before normalization
-    token: &'token RSyntaxToken,
-
-    /// The normalized text
-    text: Cow<'token, str>,
-}
-
-impl Format<RFormatContext> for FormatNormalizedStringContentToken<'_> {
-    fn fmt(&self, f: &mut Formatter<RFormatContext>) -> FormatResult<()> {
         format_replaced(
             self.token,
             &syntax_token_cow_slice(
-                // Cloning the `Cow<str>` is cheap since 99% of the time it will be the
-                // `Borrowed` variant. Only with multiline strings on Windows will it
-                // ever actually clone the underlying string.
-                self.text.clone(),
+                normalize_string_content_token(self.token),
                 self.token,
                 self.token.text_trimmed_range().start(),
             ),
@@ -76,13 +38,11 @@ impl Format<RFormatContext> for FormatNormalizedStringContentToken<'_> {
     }
 }
 
-/// Normalize a string, returning a [`Cow::Borrowed`] if the input was already normalized
+/// Normalize `STRING_CONTENT` text, returning a [`Cow::Borrowed`] if the text was already
+/// normalized
 ///
-/// This function:
-/// - Normalizes all line endings to `\n`
-///
-/// We may perform more normalization in the future. We don't use utilities from the
-/// `line_ending` crate because we don't own the string.
+/// Currently the only normalization this does is to convert `\r\n` to `\n`. We may do
+/// more normalization in the future (like, `quote-style`).
 ///
 /// This function is particularly useful for multiline strings, which capture the existing
 /// line ending inside the string content token itself. We must normalize those line
@@ -91,64 +51,17 @@ impl Format<RFormatContext> for FormatNormalizedStringContentToken<'_> {
 /// the very end, the printer will replace all `\n` with the `LineEnding` requested by the
 /// user.
 /// https://github.com/biomejs/biome/blob/a658a294087c143b83350cbeb6b44f7a2e9afdd1/crates/biome_formatter/src/printer/mod.rs#L714-L718
-fn normalize_string(input: &str) -> Cow<'_, str> {
-    // The normalized string if `input` is not yet normalized.
-    // `output` must remain empty if `input` is already normalized.
-    let mut output = String::new();
-
-    // Tracks the last index of `input` that has been written to `output`.
-    // If `last_loc` is `0` at the end, then the input is already normalized and can be returned as is.
-    let mut last_loc = 0;
-
-    let mut iter = input.char_indices().peekable();
-
-    while let Some((loc, char)) = iter.next() {
-        if char == '\r' {
-            output.push_str(&input[last_loc..loc]);
-
-            if iter.peek().is_some_and(|(_, next)| next == &'\n') {
-                // CRLF support - skip over the '\r' character, keep the `\n`
-                iter.next();
-            } else {
-                // CR support - Replace the `\r` with a `\n`
-                output.push('\n');
-            }
-
-            last_loc = loc + '\r'.len_utf8();
-        }
-    }
-
-    if last_loc == 0 {
-        Cow::Borrowed(input)
-    } else {
-        output.push_str(&input[last_loc..]);
-        Cow::Owned(output)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::string_content::normalize_string;
-    use std::borrow::Cow;
-
-    #[test]
-    fn normalize_empty() {
-        let x = "";
-        assert_eq!(normalize_string(x), Cow::Borrowed(x));
-    }
-
-    #[test]
-    fn normalize_newlines() {
-        let x = "abcd";
-        assert_eq!(normalize_string(x), Cow::Borrowed(x));
-
-        let x = "a\nb\nc\nd\n";
-        assert_eq!(normalize_string(x), Cow::Borrowed(x));
-
-        let x = "a\nb\rc\r\nd\n";
-        assert_eq!(
-            normalize_string(x),
-            Cow::Owned::<str>(String::from("a\nb\nc\nd\n"))
-        );
-    }
+///
+/// https://github.com/posit-dev/air/pull/127
+fn normalize_string_content_token(token: &RSyntaxToken) -> Cow<'_, str> {
+    debug_assert!(
+        matches!(token.kind(), STRING_CONTENT),
+        "Found kind {:?}",
+        token.kind()
+    );
+    debug_assert!(
+        token.text() == token.text_trimmed(),
+        "String content tokens should never have trivia. Trivia should be on string open or string close tokens instead."
+    );
+    line_ending::normalize_ref(token.text())
 }

--- a/crates/air_r_formatter/tests/specs/r/crlf/skip_file.R
+++ b/crates/air_r_formatter/tests/specs/r/crlf/skip_file.R
@@ -1,0 +1,3 @@
+# fmt: skip file
+1+1
+x<-c(1,    2)

--- a/crates/air_r_formatter/tests/specs/r/crlf/skip_file.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/crlf/skip_file.R.snap
@@ -1,0 +1,35 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/crlf/skip_file.R
+---
+# Input
+
+```R
+# fmt: skip file
+1+1
+x<-c(1,    2)
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: CRLF
+Line width: 80
+Persistent line breaks: Respect
+Assignment style: Arrow
+Table: fcase, tribble
+-----
+
+```R
+# fmt: skip file
+1+1
+x<-c(1,    2)
+```

--- a/crates/line_ending/src/lib.rs
+++ b/crates/line_ending/src/lib.rs
@@ -2,6 +2,7 @@
 //! This module does line ending conversion and detection (so that we can
 //! convert back to `\r\n` on the way out as needed).
 
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use memchr::memmem;
@@ -62,6 +63,17 @@ pub fn normalize(x: String) -> String {
         let new_len = buf.len() - gap_len;
         buf.set_len(new_len);
         String::from_utf8_unchecked(buf)
+    }
+}
+
+/// Normalize line endings, only allocating if required
+///
+/// Prefer [normalize()] when you have an owned [String] as that modifies in place,
+/// reusing the owned [String]'s existing allocation.
+pub fn normalize_ref(x: &str) -> Cow<'_, str> {
+    match infer(x) {
+        LineEnding::Lf => Cow::Borrowed(x),
+        LineEnding::Crlf => Cow::Owned(normalize(x.to_string())),
     }
 }
 

--- a/docs/formatter.qmd
+++ b/docs/formatter.qmd
@@ -616,6 +616,27 @@ Specifying this would retain the original formatting of the `graph_from_literal(
 skip = ["graph_from_literal"]
 ```
 
+## Line endings
+
+When using `# fmt: skip`, `# fmt: skip file`, or `skip` in `air.toml`, line endings are never considered skipped.
+
+For example, if you've set `line-ending = "lf"` in `air.toml` and have the following file with (invisible) CRLF line endings:
+
+``` r
+1+1
+
+# fmt: skip
+fn(
+  a, b
+)
+```
+
+Then the visible text making up the multiline call to `fn()` will be left as is, but the invisible CRLF line endings following `fn(` and `b` will be converted to LF line endings, even though they belong to the skipped node. Without this, you'd end up with a file containing mixed line endings, which would be very confusing!
+
+The only place this may be surprisingly is with `# fmt: skip file`, where the visible text within the file is untouched, but the line endings may be rewritten to match the `line-ending` option.
+Since `# fmt: skip file` is an extension of `# fmt: skip` to all nodes, we consider this behavior to be consistent.
+If you'd like Air to completely ignore a file, use an `air.toml` level `exclude` instead.
+
 # Comment directives
 
 With `# fmt: skip` we've already seen one kind of comment directive, but that's not all.


### PR DESCRIPTION
Closes https://github.com/posit-dev/air/issues/498
Very related to multiline string manipulation in https://github.com/posit-dev/air/pull/127

https://github.com/biomejs/biome/discussions/10682#discussioncomment-17355073