### PR TITLE
Implement user level `air.toml` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Development version
 
+- New support for a user level `air.toml`. This is used as a fallback instead of Air's default settings whenever there isn't a project level `air.toml` available (#309):
+
+  - On Linux and macOS, place it at `~/.config/air/air.toml`.
+  - On Windows, place it at `%APPDATA%\air\air.toml`.
+
+  For shared projects, we highly recommend using a version controlled project level `air.toml` instead to ensure that everyone shares the same settings.
+
 # 0.10.0
 
 - New `assignment-style` option to enforce a preferred assignment operator, with the following values:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,6 +2790,7 @@ dependencies = [
  "air_r_parser",
  "anyhow",
  "biome_formatter",
+ "etcetera",
  "fs",
  "ignore",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,6 +2782,7 @@ dependencies = [
  "biome_formatter",
  "fs",
  "ignore",
+ "insta",
  "line_ending",
  "rustc-hash",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ colored = "3.0.0"
 comments = { path = "./crates/comments" }
 crates = { path = "./crates/crates" }
 dissimilar = "1.0.9"
+etcetera = "0.11.0"
 fs = { path = "./crates/fs" }
 futures = "0.3.31"
 futures-util = "0.3.31"

--- a/crates/air/src/commands/format/paths.rs
+++ b/crates/air/src/commands/format/paths.rs
@@ -15,6 +15,7 @@ use workspace::discovery;
 use workspace::discovery::DiscoveredSettings;
 use workspace::discovery::discover_r_file_paths;
 use workspace::discovery::discover_settings;
+use workspace::discovery::discover_user_settings;
 use workspace::format::FormatSourceError;
 use workspace::format::FormattedSource;
 use workspace::resolve::PathResolver;
@@ -38,7 +39,7 @@ pub(crate) fn format(
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> anyhow::Result<ExitStatus> {
-    let mut resolver = PathResolver::new(Settings::default());
+    let mut resolver = PathResolver::new();
 
     for DiscoveredSettings {
         directory,
@@ -48,9 +49,11 @@ pub(crate) fn format(
         resolver.add(&directory, settings);
     }
 
+    let default_settings = discover_user_settings()?.unwrap_or_default();
+
     match mode {
         FormatMode::Write => {
-            let errors = format_paths_write(&paths, &resolver, exclude, include);
+            let errors = format_paths_write(&paths, &resolver, &default_settings, exclude, include);
 
             for error in &errors {
                 tracing::error!("{error}");
@@ -63,7 +66,8 @@ pub(crate) fn format(
             }
         }
         FormatMode::Check => {
-            let (paths, errors) = format_paths_check(&paths, &resolver, exclude, include);
+            let (paths, errors) =
+                format_paths_check(&paths, &resolver, &default_settings, exclude, include);
 
             for error in &errors {
                 tracing::error!("{error}");
@@ -98,16 +102,27 @@ fn inform_changed(paths: &[PathBuf], f: &mut impl Write) -> io::Result<()> {
 fn format_paths_write<P: AsRef<Path>>(
     paths: &[P],
     resolver: &PathResolver<Settings>,
+    default_settings: &Settings,
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> Vec<FormatPathError> {
-    let paths = discover_r_file_paths(paths, resolver, discovery::Mode::Format, exclude, include);
+    let paths = discover_r_file_paths(
+        paths,
+        resolver,
+        default_settings,
+        discovery::Mode::Format,
+        exclude,
+        include,
+    );
 
     paths
         .into_iter()
         .filter_map(|path| match path {
             Ok(path) => {
-                let settings = resolver.resolve_or_fallback(&path);
+                let settings = resolver
+                    .resolve(&path)
+                    .map_or(default_settings, |item| item.value());
+
                 match format_path(&path, &settings.format) {
                     Ok(formatted) => match write_path(&path, formatted) {
                         Ok(()) => None,
@@ -124,16 +139,27 @@ fn format_paths_write<P: AsRef<Path>>(
 fn format_paths_check<P: AsRef<Path>>(
     paths: &[P],
     resolver: &PathResolver<Settings>,
+    default_settings: &Settings,
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> (Vec<PathBuf>, Vec<FormatPathError>) {
-    let paths = discover_r_file_paths(paths, resolver, discovery::Mode::Format, exclude, include);
+    let paths = discover_r_file_paths(
+        paths,
+        resolver,
+        default_settings,
+        discovery::Mode::Format,
+        exclude,
+        include,
+    );
 
     paths
         .into_iter()
         .filter_map(|path| match path {
             Ok(path) => {
-                let settings = resolver.resolve_or_fallback(&path);
+                let settings = resolver
+                    .resolve(&path)
+                    .map_or(default_settings, |item| item.value());
+
                 match format_path(&path, &settings.format) {
                     Ok(file) => check_path(&path, file).map(Ok),
                     Err(err) => Some(Err(err)),

--- a/crates/air/src/commands/format/stdin.rs
+++ b/crates/air/src/commands/format/stdin.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use workspace::discovery;
 use workspace::discovery::DiscoveredSettings;
 use workspace::discovery::discover_settings;
+use workspace::discovery::discover_user_settings;
 use workspace::format::FormatSourceError;
 use workspace::format::FormattedSource;
 use workspace::resolve::PathResolver;
@@ -43,7 +44,7 @@ pub(crate) fn format(
     // Normalize up front, relative to current working directory
     let path = fs::normalize_path(path);
 
-    let mut resolver = PathResolver::new(Settings::default());
+    let mut resolver = PathResolver::new();
 
     for DiscoveredSettings {
         directory,
@@ -53,37 +54,46 @@ pub(crate) fn format(
         resolver.add(&directory, settings);
     }
 
+    let default_settings = discover_user_settings()?.unwrap_or_default();
+
     match mode {
-        FormatMode::Write => match format_stdin_write(&path, &resolver, exclude, include) {
-            Ok(()) => Ok(ExitStatus::Success),
-            Err(error) => {
-                tracing::error!("{error}");
-                Ok(ExitStatus::Error)
-            }
-        },
-        FormatMode::Check => match format_stdin_check(&path, &resolver, exclude, include) {
-            Ok(changed) => {
-                if changed {
-                    Ok(ExitStatus::Failure)
-                } else {
-                    Ok(ExitStatus::Success)
+        FormatMode::Write => {
+            match format_stdin_write(&path, &resolver, &default_settings, exclude, include) {
+                Ok(()) => Ok(ExitStatus::Success),
+                Err(error) => {
+                    tracing::error!("{error}");
+                    Ok(ExitStatus::Error)
                 }
             }
-            Err(error) => {
-                tracing::error!("{error}");
-                Ok(ExitStatus::Error)
+        }
+        FormatMode::Check => {
+            match format_stdin_check(&path, &resolver, &default_settings, exclude, include) {
+                Ok(changed) => {
+                    if changed {
+                        Ok(ExitStatus::Failure)
+                    } else {
+                        Ok(ExitStatus::Success)
+                    }
+                }
+                Err(error) => {
+                    tracing::error!("{error}");
+                    Ok(ExitStatus::Error)
+                }
             }
-        },
+        }
     }
 }
 
 fn format_stdin_write<P: AsRef<Path>>(
     path: P,
     resolver: &PathResolver<Settings>,
+    default_settings: &Settings,
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> Result<(), FormatStdinError> {
-    let settings = resolver.resolve_or_fallback(&path);
+    let settings = resolver
+        .resolve(&path)
+        .map_or(default_settings, |item| item.value());
 
     let formatted = if is_stdin_formattable(path, settings, exclude, include) {
         format_stdin(&settings.format)?
@@ -105,10 +115,13 @@ fn format_stdin_write<P: AsRef<Path>>(
 fn format_stdin_check<P: AsRef<Path>>(
     path: P,
     resolver: &PathResolver<Settings>,
+    default_settings: &Settings,
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> Result<bool, FormatStdinError> {
-    let settings = resolver.resolve_or_fallback(&path);
+    let settings = resolver
+        .resolve(&path)
+        .map_or(default_settings, |item| item.value());
 
     if !is_stdin_formattable(path, settings, exclude, include) {
         // Don't even attempt to read from stdin, we know nothing will change

--- a/crates/air/tests/integration/config.rs
+++ b/crates/air/tests/integration/config.rs
@@ -1,0 +1,265 @@
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+use tempfile::TempDir;
+use workspace::config::user_config_directory_env_var;
+
+use crate::helpers::CommandExt;
+use crate::helpers::binary_path;
+
+fn write_user_air_toml(config: &Path, contents: &str) -> anyhow::Result<()> {
+    let directory = config.join("air");
+    std::fs::create_dir(&directory)?;
+    std::fs::write(directory.join("air.toml"), contents)?;
+    Ok(())
+}
+
+fn user_air_toml(config: &Path) -> PathBuf {
+    config.join("air").join("air.toml")
+}
+
+#[test]
+fn test_user_config_applies_when_no_project_air_toml() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+    write_user_air_toml(user_config_directory, "[format]\nindent-width = 8\n")?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    std::fs::write(directory.join(test_path), "if (TRUE) {\n1\n}\n")?;
+
+    // No project `air.toml`, so the user level `indent-width = 8` applies
+    let output = Command::new(binary_path())
+        .env(user_config_directory_env_var(), user_config_directory)
+        .current_dir(directory)
+        .arg("format")
+        .arg(test_path)
+        .run();
+
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "if (TRUE) {\n        1\n}\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_user_config_applies_to_stdin() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+    write_user_air_toml(user_config_directory, "[format]\nindent-width = 8\n")?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    // The user level `indent-width = 8` applies to `--stdin-file-path` as well,
+    // and shows up in the snapshot
+    insta::assert_snapshot!(
+        Command::new(binary_path())
+            .env(user_config_directory_env_var(), user_config_directory)
+            .current_dir(directory)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .arg("format")
+            .arg("--stdin-file-path")
+            .arg("test.R")
+            .run_with_stdin("if (TRUE) {\n1\n}\n".to_string())
+            .remove_arguments()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_project_air_toml_wins_over_user_config() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+    write_user_air_toml(user_config_directory, "[format]\nindent-width = 8\n")?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    // A project `air.toml` fully shadows the user level one
+    std::fs::write(directory.join("air.toml"), "[format]\nindent-width = 4\n")?;
+
+    let test_path = "test.R";
+    std::fs::write(directory.join(test_path), "if (TRUE) {\n1\n}\n")?;
+
+    let output = Command::new(binary_path())
+        .env(user_config_directory_env_var(), user_config_directory)
+        .current_dir(directory)
+        .arg("format")
+        .arg(test_path)
+        .run();
+
+    assert!(output.status.success());
+
+    // Formatted with the project's `indent-width = 4`, not the user level `8`
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "if (TRUE) {\n    1\n}\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_user_config_with_dot_air_toml() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+
+    let user_directory = user_config_directory.join("air");
+    std::fs::create_dir(&user_directory)?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    let input = "if (TRUE) {\n1\n}\n";
+
+    // Only a `.air.toml`, which is discovered just like a project `.air.toml`
+    std::fs::write(
+        user_directory.join(".air.toml"),
+        "[format]\nindent-width = 8\n",
+    )?;
+    std::fs::write(directory.join(test_path), input)?;
+
+    let output = Command::new(binary_path())
+        .env(user_config_directory_env_var(), user_config_directory)
+        .current_dir(directory)
+        .arg("format")
+        .arg(test_path)
+        .run();
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "if (TRUE) {\n        1\n}\n"
+    );
+
+    // Now add an `air.toml` as well, which is preferred over `.air.toml`
+    std::fs::write(
+        user_directory.join("air.toml"),
+        "[format]\nindent-width = 4\n",
+    )?;
+    std::fs::write(directory.join(test_path), input)?;
+
+    let output = Command::new(binary_path())
+        .env(user_config_directory_env_var(), user_config_directory)
+        .current_dir(directory)
+        .arg("format")
+        .arg(test_path)
+        .run();
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "if (TRUE) {\n    1\n}\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_user_config_unrooted_exclude() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+    write_user_air_toml(user_config_directory, "[format]\nexclude = [\"foo/\"]\n")?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    std::fs::create_dir(directory.join("foo"))?;
+    let excluded_path = Path::new("foo").join("a.R");
+    let excluded_contents = "1+1";
+    std::fs::write(directory.join(&excluded_path), excluded_contents)?;
+
+    let formatted_path = "b.R";
+    let formatted_contents = "1+1";
+    std::fs::write(directory.join(formatted_path), formatted_contents)?;
+
+    let output = Command::new(binary_path())
+        .env(user_config_directory_env_var(), user_config_directory)
+        .current_dir(directory)
+        .arg("format")
+        .arg(".")
+        .run();
+
+    assert!(output.status.success());
+
+    // The user level `exclude` skips `foo/a.R` but not `b.R`
+    assert_eq!(
+        std::fs::read_to_string(directory.join(&excluded_path))?,
+        excluded_contents
+    );
+    assert!(formatted_contents != std::fs::read_to_string(directory.join(formatted_path))?);
+
+    Ok(())
+}
+
+#[test]
+fn test_user_config_rooted_exclude_is_a_hard_error() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+
+    // A user level `exclude` must be unrooted, so a rooted pattern (interior `/`) is a
+    // hard error.
+    write_user_air_toml(
+        user_config_directory,
+        "[format]\nexclude = [\"src/foo.R\"]\n",
+    )?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+    std::fs::write(directory.join("test.R"), "1+1")?;
+
+    insta::assert_snapshot!(
+        Command::new(binary_path())
+            .env(user_config_directory_env_var(), user_config_directory)
+            .current_dir(directory)
+            .arg("format")
+            .arg(".")
+            .arg("--no-color")
+            .run()
+            .remove_arguments()
+            .replace_stderr(
+                &user_air_toml(user_config_directory).display().to_string(),
+                "[AIR_TOML]"
+            )
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_user_config_broken_toml_is_a_hard_error() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+    write_user_air_toml(user_config_directory, "not valid toml")?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+    std::fs::write(directory.join("test.R"), "1+1")?;
+
+    // A broken user level `air.toml` is a hard error, matching project `air.toml`
+    insta::assert_snapshot!(
+        Command::new(binary_path())
+            .env(user_config_directory_env_var(), user_config_directory)
+            .current_dir(directory)
+            .arg("format")
+            .arg(".")
+            .arg("--no-color")
+            .run()
+            .replace_stderr(
+                &user_air_toml(user_config_directory).display().to_string(),
+                "[AIR_TOML]"
+            )
+    );
+
+    Ok(())
+}

--- a/crates/air/tests/integration/config.rs
+++ b/crates/air/tests/integration/config.rs
@@ -81,7 +81,10 @@ fn test_user_config_applies_to_stdin() -> anyhow::Result<()> {
 fn test_project_air_toml_wins_over_user_config() -> anyhow::Result<()> {
     let user_config_directory = TempDir::new()?;
     let user_config_directory = user_config_directory.path();
-    write_user_air_toml(user_config_directory, "[format]\nindent-width = 8\n")?;
+    write_user_air_toml(
+        user_config_directory,
+        "[format]\nindent-width = 8\nindent-style = \"tab\"\n",
+    )?;
 
     let directory = TempDir::new()?;
     let directory = directory.path();
@@ -101,7 +104,8 @@ fn test_project_air_toml_wins_over_user_config() -> anyhow::Result<()> {
 
     assert!(output.status.success());
 
-    // Formatted with the project's `indent-width = 4`, not the user level `8`
+    // Formatted with the project's `indent-width = 4`, not the user level `8`, and with
+    // the project implied default of spaces, not the user level tabs.
     assert_eq!(
         std::fs::read_to_string(directory.join(test_path))?,
         "if (TRUE) {\n    1\n}\n"

--- a/crates/air/tests/integration/helpers/command_ext.rs
+++ b/crates/air/tests/integration/helpers/command_ext.rs
@@ -54,6 +54,15 @@ impl Output {
             arguments: String::from("<removed>"),
         }
     }
+
+    pub fn replace_stderr(self, from: &str, to: &str) -> Self {
+        Self {
+            status: self.status,
+            stdout: self.stdout,
+            stderr: self.stderr.replace(from, to),
+            arguments: self.arguments,
+        }
+    }
 }
 
 impl CommandExt for Command {

--- a/crates/air/tests/integration/main.rs
+++ b/crates/air/tests/integration/main.rs
@@ -6,6 +6,7 @@
 /// Resolves problems with:
 /// - Compilation times, by only having 1 integration test binary
 /// - Dead code analysis of integration test helpers https://github.com/rust-lang/rust/issues/46379
+mod config;
 mod format;
 mod generate_shell_completion;
 mod help;

--- a/crates/air/tests/integration/snapshots/integration__config__user_config_applies_to_stdin.snap
+++ b/crates/air/tests/integration/snapshots/integration__config__user_config_applies_to_stdin.snap
@@ -1,0 +1,15 @@
+---
+source: crates/air/tests/integration/config.rs
+expression: "Command::new(binary_path()).env(user_config_directory_env_var(),\nuser_config_directory).current_dir(directory).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped()).arg(\"format\").arg(\"--stdin-file-path\").arg(\"test.R\").run_with_stdin(\"if (TRUE) {\\n1\\n}\\n\".to_string()).remove_arguments()"
+---
+success: true
+exit_code: 0
+----- stdout -----
+if (TRUE) {
+        1
+}
+
+----- stderr -----
+
+----- args -----
+<removed>

--- a/crates/air/tests/integration/snapshots/integration__config__user_config_broken_toml_is_a_hard_error.snap
+++ b/crates/air/tests/integration/snapshots/integration__config__user_config_broken_toml_is_a_hard_error.snap
@@ -1,0 +1,20 @@
+---
+source: crates/air/tests/integration/config.rs
+expression: "Command::new(binary_path()).env(user_config_directory_env_var(),\nuser_config_directory).current_dir(directory).arg(\"format\").arg(\".\").arg(\"--no-color\").run().replace_stderr(&user_air_toml(user_config_directory).display().to_string(),\n\"[AIR_TOML]\")"
+---
+success: false
+exit_code: 255
+----- stdout -----
+
+----- stderr -----
+air failed
+  Cause: Failed to parse [AIR_TOML]:
+TOML parse error at line 1, column 5
+  |
+1 | not valid toml
+  |     ^
+expected `.`, `=`
+
+
+----- args -----
+format . --no-color

--- a/crates/air/tests/integration/snapshots/integration__config__user_config_rooted_exclude_is_a_hard_error.snap
+++ b/crates/air/tests/integration/snapshots/integration__config__user_config_rooted_exclude_is_a_hard_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/air/tests/integration/config.rs
-assertion_line: 168
 expression: "Command::new(binary_path()).env(user_config_directory_env_var(),\nuser_config_directory).current_dir(directory).arg(\"format\").arg(\".\").arg(\"--no-color\").run().remove_arguments().replace_stderr(&user_air_toml(user_config_directory).display().to_string(),\n\"[AIR_TOML]\")"
 ---
 success: false
@@ -10,9 +9,9 @@ exit_code: 255
 ----- stderr -----
 air failed
   Cause: Failed to parse [AIR_TOML]:
-Pattern `src/foo.R` must meet one of the following conditions:
-- Start with `**/`, i.e. `**/foo.R`
-- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`
+Pattern `src/foo.R` must be unrooted. It is currently a rooted pattern implying `{root}/src/foo.R`.
+- Unrooted patterns start with `**/` and match at any depth. For convenience, simple patterns like `foo.R` and `folder/` are also considered to be unrooted.
+- Rooted patterns contain a leading or interior `/`, like `/foo.R` or `R/foo.R`, and imply `{root}/foo.R` or `{root}/R/foo.R`, which can't be resolved by a user level `air.toml`.
 
 ----- args -----
 <removed>

--- a/crates/air/tests/integration/snapshots/integration__config__user_config_rooted_exclude_is_a_hard_error.snap
+++ b/crates/air/tests/integration/snapshots/integration__config__user_config_rooted_exclude_is_a_hard_error.snap
@@ -1,0 +1,18 @@
+---
+source: crates/air/tests/integration/config.rs
+assertion_line: 168
+expression: "Command::new(binary_path()).env(user_config_directory_env_var(),\nuser_config_directory).current_dir(directory).arg(\"format\").arg(\".\").arg(\"--no-color\").run().remove_arguments().replace_stderr(&user_air_toml(user_config_directory).display().to_string(),\n\"[AIR_TOML]\")"
+---
+success: false
+exit_code: 255
+----- stdout -----
+
+----- stderr -----
+air failed
+  Cause: Failed to parse [AIR_TOML]:
+Pattern `src/foo.R` must meet one of the following conditions:
+- Start with `**/`, i.e. `**/foo.R`
+- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`
+
+----- args -----
+<removed>

--- a/crates/air_r_formatter/tests/spec_test.rs
+++ b/crates/air_r_formatter/tests/spec_test.rs
@@ -55,7 +55,7 @@ fn format_options_for_test(code: &str) -> RFormatOptions {
 
     // Root directory isn't important here as long as we don't supply `exclude`,
     // which would not make sense anyways
-    let root = Path::new("");
+    let root = None;
 
     let settings = workspace::toml::parse_air_inline_toml(&contents)
         .expect("Can parse inline TOML")

--- a/crates/lsp/src/capabilities.rs
+++ b/crates/lsp/src/capabilities.rs
@@ -15,6 +15,7 @@ pub(crate) struct AirClientCapabilities {
     pub(crate) position_encodings: Vec<PositionEncodingKind>,
     pub(crate) dynamic_registration_for_did_change_configuration: bool,
     pub(crate) dynamic_registration_for_did_change_watched_files: bool,
+    pub(crate) relative_pattern_support_for_did_change_watched_files: bool,
     pub(crate) request_configuration: bool,
 }
 
@@ -32,11 +33,17 @@ impl AirClientCapabilities {
             .and_then(|did_change_configuration| did_change_configuration.dynamic_registration)
             .unwrap_or(false);
 
-        let dynamic_registration_for_did_change_watched_files = capabilities
+        let did_change_watched_files = capabilities
             .workspace
             .as_ref()
-            .and_then(|workspace| workspace.did_change_watched_files)
+            .and_then(|workspace| workspace.did_change_watched_files);
+
+        let dynamic_registration_for_did_change_watched_files = did_change_watched_files
             .and_then(|watched_files| watched_files.dynamic_registration)
+            .unwrap_or_default();
+
+        let relative_pattern_support_for_did_change_watched_files = did_change_watched_files
+            .and_then(|watched_files| watched_files.relative_pattern_support)
             .unwrap_or_default();
 
         let configuration = capabilities
@@ -49,6 +56,7 @@ impl AirClientCapabilities {
             position_encodings,
             dynamic_registration_for_did_change_configuration,
             dynamic_registration_for_did_change_watched_files,
+            relative_pattern_support_for_did_change_watched_files,
             request_configuration: configuration,
         }
     }

--- a/crates/lsp/src/handlers.rs
+++ b/crates/lsp/src/handlers.rs
@@ -9,6 +9,10 @@ use struct_field_names_as_array::FieldNamesAsArray;
 use tower_lsp::lsp_types;
 use tower_lsp::lsp_types::DidChangeWatchedFilesRegistrationOptions;
 use tower_lsp::lsp_types::FileSystemWatcher;
+use tower_lsp::lsp_types::GlobPattern;
+use tower_lsp::lsp_types::OneOf;
+use tower_lsp::lsp_types::RelativePattern;
+use tower_lsp::lsp_types::Url;
 use tracing::Instrument;
 
 use crate::main_loop::LspState;
@@ -57,28 +61,11 @@ pub(crate) async fn handle_initialized(lsp_state: &LspState) -> anyhow::Result<(
         .capabilities
         .dynamic_registration_for_did_change_watched_files
     {
-        // Watch for changes in configuration files so we can react dynamically
-        let watch_air_toml_registration = lsp_types::Registration {
-            id: String::from("air-toml-watcher"),
-            method: "workspace/didChangeWatchedFiles".into(),
-            register_options: Some(
-                serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
-                    watchers: vec![
-                        FileSystemWatcher {
-                            glob_pattern: lsp_types::GlobPattern::String("**/air.toml".into()),
-                            kind: None,
-                        },
-                        FileSystemWatcher {
-                            glob_pattern: lsp_types::GlobPattern::String("**/.air.toml".into()),
-                            kind: None,
-                        },
-                    ],
-                })
-                .unwrap(),
-            ),
-        };
-
-        registrations.push(watch_air_toml_registration);
+        registrations.push(air_toml_watched_file_registration(
+            lsp_state
+                .capabilities
+                .relative_pattern_support_for_did_change_watched_files,
+        ));
     }
 
     if !registrations.is_empty() {
@@ -104,4 +91,50 @@ fn collect_regs(
             register_options: Some(serde_json::json!({ "section": into_section(field) })),
         })
         .collect()
+}
+
+// Watch for changes in configuration files so we can react dynamically
+fn air_toml_watched_file_registration(relative_pattern_support: bool) -> lsp_types::Registration {
+    let mut watchers = Vec::new();
+
+    // Project level `air.toml`s. `GlobPattern::String` is relative to the workspace.
+    watchers.push(FileSystemWatcher {
+        glob_pattern: GlobPattern::String("**/air.toml".into()),
+        kind: None,
+    });
+    watchers.push(FileSystemWatcher {
+        glob_pattern: GlobPattern::String("**/.air.toml".into()),
+        kind: None,
+    });
+
+    // User configuration level `air.toml` lives outside any workspace folder, so we
+    // need `GlobPattern::Relative` if the IDE supports it
+    if relative_pattern_support
+        && let Some(directory) = workspace::config::user_config_directory()
+        && let Ok(directory) = Url::from_directory_path(&directory)
+    {
+        watchers.push(FileSystemWatcher {
+            glob_pattern: GlobPattern::Relative(RelativePattern {
+                base_uri: OneOf::Right(directory.clone()),
+                pattern: String::from("air.toml"),
+            }),
+            kind: None,
+        });
+        watchers.push(FileSystemWatcher {
+            glob_pattern: GlobPattern::Relative(RelativePattern {
+                base_uri: OneOf::Right(directory.clone()),
+                pattern: String::from(".air.toml"),
+            }),
+            kind: None,
+        });
+    }
+
+    let register_options =
+        Some(serde_json::to_value(DidChangeWatchedFilesRegistrationOptions { watchers }).unwrap());
+
+    lsp_types::Registration {
+        id: String::from("air-toml-watcher"),
+        method: String::from("workspace/didChangeWatchedFiles"),
+        register_options,
+    }
 }

--- a/crates/lsp/src/notifications/sync_file_settings.rs
+++ b/crates/lsp/src/notifications/sync_file_settings.rs
@@ -55,7 +55,7 @@ impl LspState {
                         format: FileFormatSettings::from_format_settings(&settings.format),
                     }),
                     // There is no TOML. Let the IDE use its own settings.
-                    WorkspaceSettings::Fallback(_) => None,
+                    WorkspaceSettings::Default(_) => None,
                 },
             )
             .collect();

--- a/crates/lsp/src/workspaces.rs
+++ b/crates/lsp/src/workspaces.rs
@@ -28,28 +28,46 @@ pub(crate) struct WorkspaceSettingsResolver {
     /// Resolves a `path` to the closest workspace specific `SettingsResolver`.
     /// That `SettingsResolver` can then return `Settings` for the `path`.
     path_to_settings_resolver: PathResolver<SettingsResolver>,
+
+    /// Settings for files that `path_to_settings_resolver` fails to resolve
+    workspace_default_settings: WorkspaceDefaultSettings,
 }
 
 /// Resolved [`WorkspaceSettings`] for a workspace specific [`Path`]
+#[derive(Debug)]
 pub(crate) enum WorkspaceSettings<'resolver> {
     Toml(&'resolver Settings),
-    Fallback(&'resolver Settings),
+    Default(&'resolver Settings),
+}
+
+/// Owned variant of [WorkspaceSettings] used for persistent default settings
+#[derive(Debug)]
+enum WorkspaceDefaultSettings {
+    /// Default settings created from a user level `air.toml`
+    Toml(Settings),
+
+    /// Default settings created from [Settings::default()]
+    Default(Settings),
+}
+
+impl Default for WorkspaceDefaultSettings {
+    fn default() -> Self {
+        Self::Default(Settings::default())
+    }
 }
 
 impl WorkspaceSettingsResolver {
     /// Construct a new workspace settings resolver from an initial set of workspace folders
     pub(crate) fn from_workspace_folders(workspace_folders: Vec<WorkspaceFolder>) -> Self {
-        // How to do better here?
-        let fallback = Settings::default();
-
-        let settings_resolver_fallback = SettingsResolver::new(fallback);
-        let path_to_settings_resolver = PathResolver::new(settings_resolver_fallback);
+        let path_to_settings_resolver = PathResolver::new();
+        let workspace_default_settings = WorkspaceDefaultSettings::discover();
 
         let mut resolver = Self {
             path_to_settings_resolver,
+            workspace_default_settings,
         };
 
-        // Add each workspace folder's settings into the resolver.
+        // Add each workspace folder's settings into the resolver
         for workspace_folder in workspace_folders {
             resolver.open_workspace_folder(&workspace_folder.uri)
         }
@@ -92,10 +110,7 @@ impl WorkspaceSettingsResolver {
             }
         };
 
-        // How to do better here?
-        let fallback = Settings::default();
-
-        let mut settings_resolver = SettingsResolver::new(fallback);
+        let mut settings_resolver = SettingsResolver::new();
 
         for DiscoveredSettings {
             directory,
@@ -146,7 +161,7 @@ impl WorkspaceSettingsResolver {
         }
 
         tracing::trace!("Using default settings for non-file URL: {url}");
-        WorkspaceSettings::Fallback(self.path_to_settings_resolver.fallback().fallback())
+        self.workspace_default_settings.as_workspace_settings()
     }
 
     /// Reloads all workspaces matched by the [`Url`]
@@ -177,6 +192,15 @@ impl WorkspaceSettingsResolver {
         }
 
         let mut changed = false;
+
+        // The user level `air.toml` lives outside any workspace folder! We register
+        // watchers for `{user_config_directory()}/air.toml`, so if we match against
+        // that, rediscover the default settings.
+        if path.parent() == workspace::config::user_config_directory().as_deref() {
+            tracing::trace!("Reloading user level settings");
+            self.workspace_default_settings = WorkspaceDefaultSettings::discover();
+            changed = true;
+        }
 
         for workspace_match in self.path_to_settings_resolver.matches_mut(&path) {
             // Clear existing settings up front, regardless of what happens when reloading.
@@ -227,11 +251,7 @@ impl WorkspaceSettingsResolver {
             .resolve(path)
             .and_then(|resolution| resolution.value().resolve(path))
             .map_or_else(
-                || {
-                    WorkspaceSettings::Fallback(
-                        self.path_to_settings_resolver.fallback().fallback(),
-                    )
-                },
+                || self.workspace_default_settings.as_workspace_settings(),
                 |resolution| WorkspaceSettings::Toml(resolution.value()),
             )
     }
@@ -253,7 +273,7 @@ impl WorkspaceSettings<'_> {
     pub(crate) fn settings(&self) -> &Settings {
         match self {
             WorkspaceSettings::Toml(settings) => settings,
-            WorkspaceSettings::Fallback(settings) => settings,
+            WorkspaceSettings::Default(settings) => settings,
         }
     }
 
@@ -267,11 +287,185 @@ impl WorkspaceSettings<'_> {
                 // If there is an actual TOML, that wins
                 settings.format.to_format_options(source)
             }
-            WorkspaceSettings::Fallback(settings) => {
-                // In the fallback case, merge with client provided `DocumentSettings`
+            WorkspaceSettings::Default(settings) => {
+                // In the default case, merge with client provided `DocumentSettings`
                 let format_options = settings.format.to_format_options(source);
                 DocumentSettings::merge(format_options, document_settings)
             }
         }
+    }
+}
+
+impl WorkspaceDefaultSettings {
+    fn discover() -> Self {
+        match workspace::discovery::discover_user_settings() {
+            Ok(Some(settings)) => Self::Toml(settings),
+            Ok(None) => Self::Default(Settings::default()),
+            Err(error) => {
+                tracing::error!("Failed to load user level air.toml:\n{error}");
+                Self::Default(Settings::default())
+            }
+        }
+    }
+
+    fn as_workspace_settings(&self) -> WorkspaceSettings<'_> {
+        match self {
+            WorkspaceDefaultSettings::Toml(settings) => WorkspaceSettings::Toml(settings),
+            WorkspaceDefaultSettings::Default(settings) => WorkspaceSettings::Default(settings),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use assert_matches::assert_matches;
+    use tempfile::TempDir;
+    use tower_lsp::lsp_types::Url;
+    use tower_lsp::lsp_types::WorkspaceFolder;
+    use workspace::config::set_user_config_directory_env_var;
+
+    use crate::workspaces::WorkspaceSettings;
+    use crate::workspaces::WorkspaceSettingsResolver;
+
+    #[test]
+    fn test_user_settings_used_as_fallback() {
+        let config_directory = TempDir::new().unwrap();
+        let config_directory = config_directory.path();
+        unsafe { set_user_config_directory_env_var(config_directory) };
+
+        let air_config_directory = config_directory.join("air");
+        std::fs::create_dir_all(&air_config_directory).unwrap();
+
+        std::fs::write(
+            air_config_directory.join("air.toml"),
+            "[format]
+        indent-width = 3",
+        )
+        .unwrap();
+
+        // No workspace folders, but we do have a user level `air.toml`, so we get that
+        let resolver = WorkspaceSettingsResolver::from_workspace_folders(vec![]);
+
+        let workspace = TempDir::new().unwrap();
+        let path = workspace.path().join("foo.R");
+
+        assert_matches!(resolver.settings_for_path(&path), WorkspaceSettings::Toml(settings) => {
+            assert_eq!(settings.format.indent_width.value(), 3);
+        });
+    }
+
+    #[test]
+    fn test_default_used_when_no_user_settings() {
+        // No `air.toml` written, but folder exists
+        let config_directory = TempDir::new().unwrap();
+        let config_directory = config_directory.path();
+        unsafe { set_user_config_directory_env_var(config_directory) };
+
+        let air_config_directory = config_directory.join("air");
+        std::fs::create_dir_all(&air_config_directory).unwrap();
+
+        let resolver = WorkspaceSettingsResolver::from_workspace_folders(vec![]);
+
+        let workspace = TempDir::new().unwrap();
+        let path = workspace.path().join("foo.R");
+
+        assert_matches!(
+            resolver.settings_for_path(&path),
+            WorkspaceSettings::Default(_)
+        );
+    }
+
+    #[test]
+    fn test_project_settings_win_over_user_settings() {
+        let config_directory = TempDir::new().unwrap();
+        let config_directory = config_directory.path();
+        unsafe { set_user_config_directory_env_var(config_directory) };
+
+        let air_config_directory = config_directory.join("air");
+        std::fs::create_dir_all(&air_config_directory).unwrap();
+
+        std::fs::write(
+            air_config_directory.join("air.toml"),
+            "[format]
+        indent-width = 3",
+        )
+        .unwrap();
+
+        let workspace = TempDir::new().unwrap();
+        let workspace = workspace.path();
+        std::fs::write(
+            workspace.join("air.toml"),
+            "[format]
+        indent-width = 5",
+        )
+        .unwrap();
+
+        let folder = WorkspaceFolder {
+            uri: Url::from_directory_path(workspace).unwrap(),
+            name: String::from("workspace"),
+        };
+        let resolver = WorkspaceSettingsResolver::from_workspace_folders(vec![folder]);
+
+        let path = workspace.join("foo.R");
+
+        // The project `air.toml` shadows the user level one
+        assert_matches!(resolver.settings_for_path(&path), WorkspaceSettings::Toml(settings) => {
+            assert_eq!(settings.format.indent_width.value(), 5);
+        });
+    }
+
+    #[test]
+    fn test_reload_of_user_settings_handles_create_edit_delete() {
+        let config_directory = TempDir::new().unwrap();
+        let config_directory = config_directory.path();
+        unsafe { set_user_config_directory_env_var(config_directory) };
+
+        let air_config_directory = config_directory.join("air");
+        std::fs::create_dir_all(&air_config_directory).unwrap();
+
+        let air_toml_path = air_config_directory.join("air.toml");
+        let air_toml_url = Url::from_file_path(&air_toml_path).unwrap();
+
+        // Initially no user level `air.toml`, so we fall back to defaults
+        let mut resolver = WorkspaceSettingsResolver::from_workspace_folders(vec![]);
+
+        let workspace = TempDir::new().unwrap();
+        let path = workspace.path().join("foo.R");
+        assert_matches!(
+            resolver.settings_for_path(&path),
+            WorkspaceSettings::Default(_)
+        );
+
+        // Create: pick up user settings
+        std::fs::write(
+            &air_toml_path,
+            "[format]
+        indent-width = 3",
+        )
+        .unwrap();
+        assert!(resolver.reload_workspaces_matched_by_url(&air_toml_url));
+        assert_matches!(resolver.settings_for_path(&path), WorkspaceSettings::Toml(settings) => {
+            assert_eq!(settings.format.indent_width.value(), 3);
+        });
+
+        // Edit: picks up the new settings
+        std::fs::write(
+            &air_toml_path,
+            "[format]
+        indent-width = 4",
+        )
+        .unwrap();
+        assert!(resolver.reload_workspaces_matched_by_url(&air_toml_url));
+        assert_matches!(resolver.settings_for_path(&path), WorkspaceSettings::Toml(settings) => {
+            assert_eq!(settings.format.indent_width.value(), 4);
+        });
+
+        // Delete: downgrades to default
+        std::fs::remove_file(&air_toml_path).unwrap();
+        assert!(resolver.reload_workspaces_matched_by_url(&air_toml_url));
+        assert_matches!(
+            resolver.settings_for_path(&path),
+            WorkspaceSettings::Default(_)
+        );
     }
 }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -16,6 +16,7 @@ air_r_formatter = { workspace = true }
 air_r_parser = { workspace = true }
 anyhow = { workspace = true }
 biome_formatter = { workspace = true, features = ["serde"] }
+etcetera = { workspace = true }
 fs = { workspace = true }
 ignore = { workspace = true }
 line_ending = { workspace = true }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+insta = { workspace = true }
 tempfile = { workspace = true }
 
 [features]

--- a/crates/workspace/src/config.rs
+++ b/crates/workspace/src/config.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use etcetera::BaseStrategy;
+
+/// Air's user level configuration directory
+///
+/// - Linux/macOS: `{XDG_CONFIG_HOME}/air` falling back to `~/.config/air/` if unset
+/// - Windows: `{APPDATA}\air\` falling back to `%APPDATA%\air\` if unset
+///
+/// Returns `None` if the base strategy can't be determined (e.g. no home directory).
+pub fn user_config_directory() -> Option<PathBuf> {
+    let strategy = match etcetera::choose_base_strategy() {
+        Ok(strategy) => strategy,
+        Err(error) => {
+            tracing::warn!("Failed to determine user configuration directory:\n{error}");
+            return None;
+        }
+    };
+
+    Some(strategy.config_dir().join("air"))
+}
+
+/// The environment variable corresponding to the user configuration directory
+///
+/// Used in integration and unit tests to set custom config directory locations
+pub fn user_config_directory_env_var() -> &'static str {
+    if cfg!(windows) {
+        "APPDATA"
+    } else {
+        "XDG_CONFIG_HOME"
+    }
+}
+
+/// Set the environment variable corresponding to the user configuration directory
+///
+/// # Safety
+///
+/// For use in single-threaded nextest tests, where nothing else can concurrently
+/// touch the environment
+pub unsafe fn set_user_config_directory_env_var(directory: &std::path::Path) {
+    unsafe { std::env::set_var(user_config_directory_env_var(), directory) }
+}

--- a/crates/workspace/src/discovery.rs
+++ b/crates/workspace/src/discovery.rs
@@ -11,6 +11,7 @@ use rustc_hash::FxHashSet;
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::config::user_config_directory;
 use crate::resolve::PathResolver;
 use crate::settings::DefaultExcludePatterns;
 use crate::settings::DefaultIncludePatterns;
@@ -50,7 +51,7 @@ pub fn discover_settings<P: AsRef<Path>>(paths: &[P]) -> anyhow::Result<Vec<Disc
             }
 
             if let Some(toml) = find_air_toml_in_directory(ancestor) {
-                let settings = parse_settings(&toml, ancestor)?;
+                let settings = parse_settings(&toml, Some(ancestor))?;
                 discovered_settings.push(DiscoveredSettings {
                     directory: ancestor.to_path_buf(),
                     settings,
@@ -73,13 +74,46 @@ pub fn discover_settings<P: AsRef<Path>>(paths: &[P]) -> anyhow::Result<Vec<Disc
     Ok(discovered_settings)
 }
 
+/// Discover the user level `air.toml`, if one exists
+///
+/// Searches [user_config_directory()] for an `air.toml`. Returns `Err` on parse
+/// failure, like [discover_settings()].
+///
+/// The user level config has no project directory to root against, so its `exclude`
+/// patterns are parsed as unrooted (a `root` of `None`), and a rooted pattern is a
+/// propagated error.
+pub fn discover_user_settings() -> anyhow::Result<Option<Settings>> {
+    let Some(directory) = user_config_directory() else {
+        return Ok(None);
+    };
+
+    let Some(toml) = find_air_toml_in_directory(&directory) else {
+        return Ok(None);
+    };
+
+    let settings = parse_settings(&toml, None)?;
+
+    tracing::trace!(
+        "Discovered user settings at '{directory}'",
+        directory = directory.display()
+    );
+
+    Ok(Some(settings))
+}
+
 /// Parse [Settings] from a given `air.toml`
 // TODO(hierarchical): Allow for an `extends` option in `air.toml`, which will make things
 // more complex, but will be very useful once we support hierarchical configuration as a
 // way of "inheriting" most top level configuration while slightly tweaking it in a nested directory.
-fn parse_settings(toml: &Path, root_directory: &Path) -> anyhow::Result<Settings> {
+fn parse_settings(toml: &Path, root: Option<&Path>) -> anyhow::Result<Settings> {
+    // TOML parsing errors nicely report the `toml` path in the error for context
     let options = parse_air_toml(toml)?;
-    let settings = options.into_settings(Some(root_directory))?;
+
+    // We add the `toml` path as context if conversion to `Settings` fails
+    let settings = options.into_settings(root).map_err(|error| {
+        anyhow::anyhow!("Failed to parse {toml}:\n{error}", toml = toml.display())
+    })?;
+
     Ok(settings)
 }
 
@@ -121,6 +155,7 @@ pub enum Include {
 pub fn discover_r_file_paths<P: AsRef<Path>>(
     paths: &[P],
     resolver: &PathResolver<Settings>,
+    default_settings: &Settings,
     mode: Mode,
     exclude: Exclude,
     include: Include,
@@ -161,7 +196,7 @@ pub fn discover_r_file_paths<P: AsRef<Path>>(
     let walker = builder.build_parallel();
 
     // Run the `WalkParallel` to collect all R files.
-    let state = FilesState::new(resolver, mode, exclude, include);
+    let state = FilesState::new(resolver, default_settings, mode, exclude, include);
     let mut visitor_builder = FilesVisitorBuilder::new(&state);
     walker.visit(&mut visitor_builder);
 
@@ -169,17 +204,19 @@ pub fn discover_r_file_paths<P: AsRef<Path>>(
 }
 
 /// Shared state across the threads of the walker
-struct FilesState<'resolver> {
+struct FilesState<'settings> {
     files: std::sync::Mutex<DiscoveredFiles>,
-    resolver: &'resolver PathResolver<Settings>,
+    resolver: &'settings PathResolver<Settings>,
+    default_settings: &'settings Settings,
     mode: Mode,
     exclude: Exclude,
     include: Include,
 }
 
-impl<'resolver> FilesState<'resolver> {
+impl<'settings> FilesState<'settings> {
     fn new(
-        resolver: &'resolver PathResolver<Settings>,
+        resolver: &'settings PathResolver<Settings>,
+        default_settings: &'settings Settings,
         mode: Mode,
         exclude: Exclude,
         include: Include,
@@ -187,6 +224,7 @@ impl<'resolver> FilesState<'resolver> {
         Self {
             files: std::sync::Mutex::new(Vec::new()),
             resolver,
+            default_settings,
             mode,
             exclude,
             include,
@@ -202,19 +240,19 @@ impl<'resolver> FilesState<'resolver> {
 ///
 /// Implements the `build()` method of [ignore::ParallelVisitorBuilder], which
 /// [ignore::WalkParallel] utilizes to create one [FilesVisitor] per thread.
-struct FilesVisitorBuilder<'state, 'resolver> {
-    state: &'state FilesState<'resolver>,
+struct FilesVisitorBuilder<'settings> {
+    state: &'settings FilesState<'settings>,
 }
 
-impl<'state, 'resolver> FilesVisitorBuilder<'state, 'resolver> {
-    fn new(state: &'state FilesState<'resolver>) -> Self {
+impl<'settings> FilesVisitorBuilder<'settings> {
+    fn new(state: &'settings FilesState<'settings>) -> Self {
         Self { state }
     }
 }
 
-impl<'state> ignore::ParallelVisitorBuilder<'state> for FilesVisitorBuilder<'state, '_> {
+impl<'settings> ignore::ParallelVisitorBuilder<'settings> for FilesVisitorBuilder<'settings> {
     /// Constructs the per-thread [FilesVisitor], called for us by `ignore`
-    fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 'state> {
+    fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 'settings> {
         Box::new(FilesVisitor {
             files: vec![],
             state: self.state,
@@ -227,12 +265,12 @@ impl<'state> ignore::ParallelVisitorBuilder<'state> for FilesVisitorBuilder<'sta
 /// A files visitor has its `visit()` method repeatedly called. It modifies its own
 /// synchronous state by pushing to its thread specific `files` while visiting. On `Drop`,
 /// the collected `files` are appended to the global set of `state.files`.
-struct FilesVisitor<'state, 'resolver> {
+struct FilesVisitor<'settings> {
     files: DiscoveredFiles,
-    state: &'state FilesState<'resolver>,
+    state: &'settings FilesState<'settings>,
 }
 
-impl ignore::ParallelVisitor for FilesVisitor<'_, '_> {
+impl ignore::ParallelVisitor for FilesVisitor<'_> {
     /// Visit a file in the tree
     ///
     /// Visiting a file requires two actions:
@@ -267,7 +305,7 @@ impl ignore::ParallelVisitor for FilesVisitor<'_, '_> {
     }
 }
 
-impl FilesVisitor<'_, '_> {
+impl FilesVisitor<'_> {
     /// Visit each entry using formatter specific `exclude` and `include` rules
     fn visit_format(&mut self, entry: DirEntry) -> ignore::WalkState {
         let path = entry.path();
@@ -279,7 +317,11 @@ impl FilesVisitor<'_, '_> {
         let is_directory = entry.file_type().is_none_or(|ft| ft.is_dir());
 
         // Retrieve the settings for this `path`
-        let settings = self.state.resolver.resolve_or_fallback(path);
+        let settings = self
+            .state
+            .resolver
+            .resolve(path)
+            .map_or(self.state.default_settings, |item| item.value());
 
         match self.state.exclude {
             Exclude::Matched => {
@@ -369,7 +411,7 @@ impl FilesVisitor<'_, '_> {
     }
 }
 
-impl Drop for FilesVisitor<'_, '_> {
+impl Drop for FilesVisitor<'_> {
     fn drop(&mut self) {
         // Lock the global shared set of `files`
         // Unwrap: If we can't lock the mutex then something is very wrong
@@ -456,11 +498,13 @@ mod test {
     use anyhow::Context;
     use tempfile::TempDir;
 
+    use crate::config::set_user_config_directory_env_var;
     use crate::discovery::Exclude;
     use crate::discovery::Include;
     use crate::discovery::Mode;
     use crate::discovery::discover_r_file_paths;
     use crate::discovery::discover_settings;
+    use crate::discovery::discover_user_settings;
     use crate::resolve::PathResolver;
     use crate::settings::Settings;
 
@@ -479,11 +523,13 @@ mod test {
         let test2_path = tempdir.join("tests").join("testthat").join("test2.R");
         std::fs::write(&test2_path, b"")?;
 
-        let resolver = PathResolver::new(Settings::default());
+        let resolver = PathResolver::new();
+        let default_settings = Settings::default();
 
         let mut paths = discover_r_file_paths(
             &[tempdir],
             &resolver,
+            &default_settings,
             Mode::Format,
             Exclude::Matched,
             Include::Matched,
@@ -512,11 +558,13 @@ mod test {
         std::fs::write(&test_r, b"")?;
         std::fs::write(&test_py, b"")?;
 
-        let resolver = PathResolver::new(Settings::default());
+        let resolver = PathResolver::new();
+        let default_settings = Settings::default();
 
         let mut paths = discover_r_file_paths(
             &[tempdir],
             &resolver,
+            &default_settings,
             Mode::Format,
             Exclude::Matched,
             Include::Matched,
@@ -547,10 +595,12 @@ mod test {
             // `{tempdir}/test1.R`
             // Part of default includes, so accepted
             let start = &[&test_big_r];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let mut paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -563,10 +613,12 @@ mod test {
             // `{tempdir}/test2.r`
             // Part of default includes, so accepted
             let start = &[&test_little_r];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let mut paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -582,10 +634,12 @@ mod test {
             // do `air format my.qmd` and be surprised if by chance it parses then happens
             // to bork their qmd.
             let start = &[&test_qmd];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -623,10 +677,12 @@ mod test {
             // `{tempdir}`
             // Folder containing folders and files that match default excludes
             let start = &[tempdir];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let mut paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -640,10 +696,12 @@ mod test {
             // Directly supplied file matching default excludes is excluded
             // https://github.com/posit-dev/air/issues/472
             let start = &[tempdir.join("R").join("cpp11.R")];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -656,10 +714,12 @@ mod test {
             // Directly supplied directory matching default excludes is excluded
             // https://github.com/posit-dev/air/issues/472
             let start = &[tempdir.join("renv")];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -672,10 +732,12 @@ mod test {
             // Directly supplied file with parent matching default excludes is excluded
             // https://github.com/posit-dev/air/issues/472
             let start = &[tempdir.join("renv").join("activate.R")];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -688,10 +750,12 @@ mod test {
             // Directly supplied directory with parent matching default excludes is excluded
             // https://github.com/posit-dev/air/issues/472
             let start = &[tempdir.join("renv").join("subdir")];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -728,12 +792,14 @@ exclude = ["exclude/"]
             let mut settings = discover_settings(start)?;
             let settings = settings.pop().context("Should find air.toml")?;
 
-            let mut resolver = PathResolver::new(Settings::default());
+            let mut resolver = PathResolver::new();
             resolver.add(&settings.directory, settings.settings);
+            let default_settings = Settings::default();
 
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -750,12 +816,14 @@ exclude = ["exclude/"]
             let mut settings = discover_settings(start)?;
             let settings = settings.pop().context("Should find air.toml")?;
 
-            let mut resolver = PathResolver::new(Settings::default());
+            let mut resolver = PathResolver::new();
             resolver.add(&settings.directory, settings.settings);
+            let default_settings = Settings::default();
 
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -772,12 +840,14 @@ exclude = ["exclude/"]
             let mut settings = discover_settings(start)?;
             let settings = settings.pop().context("Should find air.toml")?;
 
-            let mut resolver = PathResolver::new(Settings::default());
+            let mut resolver = PathResolver::new();
             resolver.add(&settings.directory, settings.settings);
+            let default_settings = Settings::default();
 
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -794,12 +864,14 @@ exclude = ["exclude/"]
             let mut settings = discover_settings(start)?;
             let settings = settings.pop().context("Should find air.toml")?;
 
-            let mut resolver = PathResolver::new(Settings::default());
+            let mut resolver = PathResolver::new();
             resolver.add(&settings.directory, settings.settings);
+            let default_settings = Settings::default();
 
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -822,10 +894,12 @@ exclude = ["exclude/"]
 
         // `cpp11.R` is a default exclude, but `Exclude::Nothing` bypasses it
         let start = &[&cpp11_path];
-        let resolver = PathResolver::new(Settings::default());
+        let resolver = PathResolver::new();
+        let default_settings = Settings::default();
         let mut paths = discover_r_file_paths(
             start,
             &resolver,
+            &default_settings,
             Mode::Format,
             Exclude::Nothing,
             Include::Matched,
@@ -856,10 +930,12 @@ exclude = ["exclude/"]
         // Recursing into `tempdir` with `Exclude::Nothing` discovers `test.R` and
         // `cpp11.R`, but not `test.qmd`
         let start = &[tempdir];
-        let resolver = PathResolver::new(Settings::default());
+        let resolver = PathResolver::new();
+        let default_settings = Settings::default();
         let mut paths = discover_r_file_paths(
             start,
             &resolver,
+            &default_settings,
             Mode::Format,
             Exclude::Nothing,
             Include::Matched,
@@ -885,10 +961,12 @@ exclude = ["exclude/"]
 
         // `.qmd` is not part of default includes, but `Include::Everything` bypasses that
         let start = &[&test_qmd];
-        let resolver = PathResolver::new(Settings::default());
+        let resolver = PathResolver::new();
+        let default_settings = Settings::default();
         let mut paths = discover_r_file_paths(
             start,
             &resolver,
+            &default_settings,
             Mode::Format,
             Exclude::Matched,
             Include::Everything,
@@ -919,10 +997,12 @@ exclude = ["exclude/"]
         // Recursing into `tempdir` with `Include::Everything` discovers `test.R` and
         // `test.qmd`, but not `cpp11.R`
         let start = &[tempdir];
-        let resolver = PathResolver::new(Settings::default());
+        let resolver = PathResolver::new();
+        let default_settings = Settings::default();
         let mut paths = discover_r_file_paths(
             start,
             &resolver,
+            &default_settings,
             Mode::Format,
             Exclude::Matched,
             Include::Everything,
@@ -962,10 +1042,12 @@ ignore/
             // `{tempdir}/`
             // When `ignore/` is "discovered" via recursive search, the `.gitignore` is respected
             let start = &[tempdir];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
@@ -982,16 +1064,105 @@ ignore/
             // it's unlikely that a user (or pre-commit or RStudio) will call `air format
             // <folder-that-has-been-gitignored>` directly.
             let start = &[tempdir.join("ignore")];
-            let resolver = PathResolver::new(Settings::default());
+            let resolver = PathResolver::new();
+            let default_settings = Settings::default();
             let paths = discover_r_file_paths(
                 start,
                 &resolver,
+                &default_settings,
                 Mode::Format,
                 Exclude::Matched,
                 Include::Matched,
             );
             assert_eq!(paths.len(), 2);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_discover_user_settings_present() -> anyhow::Result<()> {
+        let tempdir = TempDir::new()?;
+        let tempdir = tempdir.path();
+
+        // `user_config_directory()` appends `air` to the config directory
+        let directory = tempdir.join("air");
+        std::fs::create_dir(&directory)?;
+        std::fs::write(directory.join("air.toml"), "[format]\nindent-width = 3\n")?;
+
+        unsafe { set_user_config_directory_env_var(tempdir) };
+
+        let settings = discover_user_settings()?.context("Should find user air.toml")?;
+        assert_eq!(
+            settings.format.indent_width,
+            settings::IndentWidth::try_from(3u8)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_discover_user_settings_prefers_visible_air_toml() -> anyhow::Result<()> {
+        let tempdir = TempDir::new()?;
+        let tempdir = tempdir.path();
+
+        let directory = tempdir.join("air");
+        std::fs::create_dir(&directory)?;
+        std::fs::write(directory.join("air.toml"), "[format]\nindent-width = 3\n")?;
+        std::fs::write(directory.join(".air.toml"), "[format]\nindent-width = 4\n")?;
+
+        unsafe { set_user_config_directory_env_var(tempdir) };
+
+        // `air.toml` wins over `.air.toml`
+        let settings = discover_user_settings()?.context("Should find user air.toml")?;
+        assert_eq!(
+            settings.format.indent_width,
+            settings::IndentWidth::try_from(3u8)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_discover_user_settings_unparseable() -> anyhow::Result<()> {
+        let tempdir = TempDir::new()?;
+        let tempdir = tempdir.path();
+
+        let directory = tempdir.join("air");
+        std::fs::create_dir(&directory)?;
+
+        let air_toml = directory.join("air.toml");
+        std::fs::write(&air_toml, "this is not valid toml")?;
+
+        unsafe { set_user_config_directory_env_var(tempdir) };
+
+        // Scrub the tempdir path so the snapshot is stable across machines
+        let error = discover_user_settings().unwrap_err().to_string();
+        let error = error.replace(air_toml.to_str().unwrap(), "[AIR_TOML]");
+        insta::assert_snapshot!(error);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_discover_user_settings_rejects_rooted_exclude() -> anyhow::Result<()> {
+        let tempdir = TempDir::new()?;
+        let tempdir = tempdir.path();
+
+        let directory = tempdir.join("air");
+        std::fs::create_dir(&directory)?;
+
+        // A rooted `exclude` pattern (interior `/`) has no meaning without a project
+        // directory to root against, so it is an error in a user level config
+        let air_toml = directory.join("air.toml");
+        std::fs::write(&air_toml, "[format]\nexclude = [\"src/foo.R\"]\n")?;
+
+        unsafe { set_user_config_directory_env_var(tempdir) };
+
+        // Scrub the tempdir path so the snapshot is stable across machines
+        let error = discover_user_settings().unwrap_err().to_string();
+        let error = error.replace(air_toml.to_str().unwrap(), "[AIR_TOML]");
+        insta::assert_snapshot!(error);
 
         Ok(())
     }

--- a/crates/workspace/src/discovery.rs
+++ b/crates/workspace/src/discovery.rs
@@ -79,7 +79,7 @@ pub fn discover_settings<P: AsRef<Path>>(paths: &[P]) -> anyhow::Result<Vec<Disc
 // way of "inheriting" most top level configuration while slightly tweaking it in a nested directory.
 fn parse_settings(toml: &Path, root_directory: &Path) -> anyhow::Result<Settings> {
     let options = parse_air_toml(toml)?;
-    let settings = options.into_settings(root_directory)?;
+    let settings = options.into_settings(Some(root_directory))?;
     Ok(settings)
 }
 

--- a/crates/workspace/src/file_patterns.rs
+++ b/crates/workspace/src/file_patterns.rs
@@ -6,42 +6,40 @@ use ignore::gitignore::Gitignore;
 use ignore::gitignore::GitignoreBuilder;
 use ignore::gitignore::Glob;
 
-/// Matcher for globs that follow a `.gitignore` style
+/// Matcher for globs rooted at a directory
 ///
-/// When constructing the matcher, you supply a `root` path along with the `patterns`
-/// to be included in the matcher. When [FilePatterns::matched] is called, the `root`
+/// When constructing the matcher, you supply a `root` path along with the `patterns` to
+/// be included in the matcher. When [RootedFilePatterns::matched] is called, the `root`
 /// path is always stripped from `path` before matching is done. This ensures that users
-/// can specify `"/special.R"` in their `air.toml` to match only `{root}/special.R`, and
-/// not also `{root}/subdir/special.R`.
+/// can specify `/special.R` in their `air.toml` to match only `{root}/special.R`, and not
+/// also `{root}/subdir/special.R`.
 #[derive(Clone, Debug)]
-pub struct FilePatterns {
+pub struct RootedFilePatterns {
     matcher: Gitignore,
 }
 
-/// Matcher for a default set of globs
+/// Matcher for globs with no `root`, matching at any depth
 ///
-/// Compared to [FilePatterns], [DefaultFilePatterns] is special because it does not
-/// allow specification of a `root` path. When constructing [crate::settings::Settings]
-/// for a "virtual" `air.toml`, there is no `root` path, but we still want to respect
-/// default includes and excludes. To ensure this works correctly, we have to make two
-/// main changes:
+/// Compared to [RootedFilePatterns], [UnrootedFilePatterns] is special because it does
+/// not allow specification of a `root` path. This is what backs default includes and
+/// excludes, which apply with or without a physical `air.toml`, as well as user level
+/// `air.toml` `exclude` patterns, which have no project directory to root against. To
+/// ensure this works correctly, we have to make two main changes:
 ///
-/// - All `patterns` must start with `**/` so they don't depend on the `root`, this is
-///   enforced by [DefaultFilePatterns::try_from_iter] at creation time.
+/// - Every `pattern` must match at any depth rather than relative to a `root`, which is
+///   enforced by [is_unrooted] in [UnrootedFilePatterns::try_from_iter] at creation time.
 ///
-/// - [DefaultFilePatterns::matched_path_or_any_parents] is custom, rather than relying
-///   on [Gitignore] directly. The reason we do this is because [Gitignore]'s version
-///   will panic if the `path` we provide contains a root component after `root` stripping
-///   has occurred (like a leading `/` on Unix, or leading `C:/` on Windows). We don't
-///   have a `root` to strip, and our globs don't depend on `root`, so we don't need this
-///   restriction.
+/// - [UnrootedFilePatterns::matched_path_or_any_parents] is custom rather than deferring
+///   to [Gitignore]. [Gitignore]'s version panics if `path` still has a root component
+///   after `root` stripping (a leading `/` on Unix, or `C:/` on Windows). We never strip
+///   a `root` and our globs don't depend on one, so that restriction doesn't apply.
 #[derive(Clone, Debug)]
-pub struct DefaultFilePatterns {
+pub struct UnrootedFilePatterns {
     matcher: Gitignore,
 }
 
-impl FilePatterns {
-    /// Construct [FilePatterns] from an iterator of patterns
+impl RootedFilePatterns {
+    /// Construct [RootedFilePatterns] from an iterator of patterns
     pub(crate) fn try_from_iter<'str, P, I>(root: P, patterns: I) -> anyhow::Result<Self>
     where
         P: AsRef<Path>,
@@ -77,7 +75,7 @@ impl FilePatterns {
     /// Returns the glob that matches this `path` or any parent, or `None` if no glob
     /// matches
     ///
-    /// More expensive than [FilePatterns::matched], but is required in the LSP where you
+    /// More expensive than [RootedFilePatterns::matched], but is required in the LSP where you
     /// don't recursively search a directory, but are instead handed a single file at a
     /// time.
     pub fn matched_path_or_any_parents<P>(&self, path: P, is_directory: bool) -> Option<&Glob>
@@ -92,23 +90,24 @@ impl FilePatterns {
     }
 }
 
-impl DefaultFilePatterns {
-    /// Construct [DefaultFilePatterns] from an iterator of patterns
+impl UnrootedFilePatterns {
+    /// Construct [UnrootedFilePatterns] from an iterator of patterns
     ///
-    /// Note:
-    /// - Uses an empty string for the `root`.
-    /// - Enforces that all patterns start with `**/`, since we don't have a `root`.
+    /// Every pattern must be unrooted, as verified by [is_unrooted]. A rooted pattern is
+    /// a hard error, since there is no `root` for it to resolve against.
     pub(crate) fn try_from_iter<'str, I>(patterns: I) -> anyhow::Result<Self>
     where
         I: IntoIterator<Item = &'str str>,
     {
-        // For the *default* case, the `root` path is always the empty string
+        // Use an empty `root` so that nothing is stripped from a `path` before matching
         let root = PathBuf::new();
 
         let mut builder = GitignoreBuilder::new(root);
 
         for pattern in patterns {
-            debug_assert!(pattern.starts_with("**/"));
+            if !is_unrooted(pattern) {
+                return Err(err_rooted(pattern));
+            }
             builder.add_line(None, pattern)?;
         }
 
@@ -133,7 +132,7 @@ impl DefaultFilePatterns {
     /// matches
     ///
     /// Implementation is based on [ignore::gitignore::Gitignore::matched_path_or_any_parents],
-    /// excluding the `assert!(!path.has_root())` check since default patterns don't
+    /// excluding the `assert!(!path.has_root())` check since unrooted patterns don't
     /// depend on the `root`.
     pub fn matched_path_or_any_parents<P>(&self, path: P, is_directory: bool) -> Option<&Glob>
     where
@@ -156,15 +155,53 @@ impl DefaultFilePatterns {
     }
 }
 
+/// Check if a `pattern` is unrooted
+///
+/// Constructed by carefully analyzing [GitignoreBuilder]'s `add_line()`, which itself
+/// is derived from git's man page. It should be very stable.
+///
+/// Ideally we'd somehow analyze the fields in the [GitignoreBuilder] output rather than
+/// recreating the rules here, but there is no public API for determining if a supplied
+/// pattern was rooted or not (it's admittedly a slightly odd use case from a git
+/// perspective).
+fn is_unrooted(pattern: &str) -> bool {
+    // Strip leading `!`
+    let pattern = pattern.strip_prefix('!').unwrap_or(pattern);
+
+    // Explicit `**/`
+    if pattern.starts_with("**/") {
+        return true;
+    }
+
+    // Implicit `**/`, i.e.:
+    // - `foo.R`
+    // - `folder/`
+    // but not:
+    // - `foo/bar.R`
+    // - `/foo.R`
+    // - `foo/**/bar.R`
+    let pattern = pattern.strip_suffix('/').unwrap_or(pattern);
+    !pattern.contains('/')
+}
+
+fn err_rooted(pattern: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Pattern `{pattern}` must meet one of the following conditions:
+- Start with `**/`, i.e. `**/foo.R`
+- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`"
+    )
+}
+
 #[cfg(test)]
 mod test {
-    use crate::file_patterns::DefaultFilePatterns;
-    use crate::file_patterns::FilePatterns;
+    use crate::file_patterns::RootedFilePatterns;
+    use crate::file_patterns::UnrootedFilePatterns;
+    use crate::file_patterns::is_unrooted;
     use std::path::Path;
 
-    fn from_str<P: AsRef<Path>>(root: P, pattern: &str) -> FilePatterns {
+    fn from_str<P: AsRef<Path>>(root: P, pattern: &str) -> RootedFilePatterns {
         let patterns = vec![pattern];
-        FilePatterns::try_from_iter(root, patterns).unwrap()
+        RootedFilePatterns::try_from_iter(root, patterns).unwrap()
     }
 
     macro_rules! ignored {
@@ -292,12 +329,12 @@ mod test {
     }
 
     #[test]
-    fn test_default_file_pattern_works_with_rooted_paths() -> anyhow::Result<()> {
-        let patterns = DefaultFilePatterns::try_from_iter(vec!["**/cpp11.R"])?;
+    fn test_unrooted_file_pattern_works_with_rooted_paths() -> anyhow::Result<()> {
+        let patterns = UnrootedFilePatterns::try_from_iter(vec!["**/cpp11.R"])?;
 
         // These look like they have a `root`, which `Gitignore::matched_path_or_any_parents()`
-        // would typically panic on, so we have our own version to avoid this, since all
-        // of our default patterns include `**/` and are root agnostic.
+        // would typically panic on, so we have our own version to avoid this, since
+        // unrooted patterns match at any depth and don't depend on the `root`.
         assert!(
             patterns
                 .matched_path_or_any_parents("/etc/cpp11.R", false)
@@ -310,6 +347,48 @@ mod test {
                 .is_some()
         );
 
+        // The `folder/` shorthand also floats to any depth, even though the user didn't
+        // write `**/`, because `add_line()` supplies the `**/` prefix for us
+        let patterns = UnrootedFilePatterns::try_from_iter(vec!["renv/"])?;
+        assert!(
+            patterns
+                .matched_path_or_any_parents("/etc/renv", true)
+                .is_some()
+        );
+
         Ok(())
+    }
+
+    #[test]
+    fn test_unrooted_file_pattern_rejects_rooted_patterns() {
+        // A rooted pattern is a hard error, since there is no `root` for it to resolve against
+        let error = UnrootedFilePatterns::try_from_iter(vec!["foo/bar.R"]).unwrap_err();
+        insta::assert_snapshot!(error);
+    }
+
+    #[test]
+    fn test_is_unrooted() {
+        // An explicit `**/` prefix floats to any depth
+        assert!(is_unrooted("**/foo.R"));
+        assert!(is_unrooted("**/customfolder/"));
+        assert!(is_unrooted("**/renv/**/*.R"));
+
+        // No leading or interior `/` means `add_line()` supplies the `**/` prefix,
+        // so these float to any depth. A trailing `/` (directory-only) is still fine.
+        assert!(is_unrooted("foo.R"));
+        assert!(is_unrooted("customfolder/"));
+        assert!(is_unrooted("import-standalone-*.R"));
+
+        // A leading `!` (whitelist) doesn't affect whether the pattern is rooted
+        assert!(is_unrooted("!foo.R"));
+        assert!(is_unrooted("!**/foo.R"));
+
+        // A leading or interior `/` roots the pattern at a `root` we don't have
+        assert!(!is_unrooted("/foo.R"));
+        assert!(!is_unrooted("foo/bar.R"));
+        assert!(!is_unrooted("foo/**/bar.R"));
+        assert!(!is_unrooted("/customfolder/"));
+        assert!(!is_unrooted("!foo/bar.R"));
+        assert!(!is_unrooted("/**/foo"));
     }
 }

--- a/crates/workspace/src/file_patterns.rs
+++ b/crates/workspace/src/file_patterns.rs
@@ -157,6 +157,13 @@ impl UnrootedFilePatterns {
 
 /// Check if a `pattern` is unrooted
 ///
+/// Unrooted patterns start with `**/` and match at any depth. Additionally, for
+/// convenience, simple patterns such as `foo.R` and `folder/` are internally treated as
+/// their explicitly unrooted equivalents of `**/foo.R` and `**/folder`.
+///
+/// Rooted patterns are ones with a leading or interior `/`, such as `/foo.R` and
+/// `R/foo.R`, and imply `{root}/foo.R` and `{root}/R/foo.R`.
+///
 /// Constructed by carefully analyzing [GitignoreBuilder]'s `add_line()`, which itself
 /// is derived from git's man page. It should be very stable.
 ///
@@ -168,27 +175,33 @@ fn is_unrooted(pattern: &str) -> bool {
     // Strip leading `!`
     let pattern = pattern.strip_prefix('!').unwrap_or(pattern);
 
-    // Explicit `**/`
+    // Explicitly unrooted
     if pattern.starts_with("**/") {
         return true;
     }
 
-    // Implicit `**/`, i.e.:
+    // Implicitly unrooted
     // - `foo.R`
     // - `folder/`
     // but not:
-    // - `foo/bar.R`
     // - `/foo.R`
-    // - `foo/**/bar.R`
+    // - `R/foo.R`
+    // - `R/**/foo.R`
     let pattern = pattern.strip_suffix('/').unwrap_or(pattern);
     !pattern.contains('/')
 }
 
 fn err_rooted(pattern: &str) -> anyhow::Error {
+    let rooted_pattern = if pattern.starts_with('/') {
+        format!("{{root}}{pattern}")
+    } else {
+        format!("{{root}}/{pattern}")
+    };
+
     anyhow::anyhow!(
-        "Pattern `{pattern}` must meet one of the following conditions:
-- Start with `**/`, i.e. `**/foo.R`
-- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`"
+        "Pattern `{pattern}` must be unrooted. It is currently a rooted pattern implying `{rooted_pattern}`.
+- Unrooted patterns start with `**/` and match at any depth. For convenience, simple patterns like `foo.R` and `folder/` are also considered to be unrooted.
+- Rooted patterns contain a leading or interior `/`, like `/foo.R` or `R/foo.R`, and imply `{{root}}/foo.R` or `{{root}}/R/foo.R`, which can't be resolved by a user level `air.toml`."
     )
 }
 
@@ -362,6 +375,8 @@ mod test {
     #[test]
     fn test_unrooted_file_pattern_rejects_rooted_patterns() {
         // A rooted pattern is a hard error, since there is no `root` for it to resolve against
+        let error = UnrootedFilePatterns::try_from_iter(vec!["/foo.R"]).unwrap_err();
+        insta::assert_snapshot!(error);
         let error = UnrootedFilePatterns::try_from_iter(vec!["foo/bar.R"]).unwrap_err();
         insta::assert_snapshot!(error);
     }

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -5,6 +5,7 @@
 //
 //
 
+pub mod config;
 pub mod discovery;
 pub mod file_patterns;
 pub mod format;

--- a/crates/workspace/src/resolve.rs
+++ b/crates/workspace/src/resolve.rs
@@ -16,9 +16,6 @@ use std::path::{Path, PathBuf};
 /// See [`PathResolver::resolve()`] for more details on the implementation.
 #[derive(Debug, Default)]
 pub struct PathResolver<T> {
-    /// Fallback value to be used when a `path` isn't associated with any `items`
-    fallback: T,
-
     /// A sorted vector of `PathItem`. Sorted on the `PathBuf` in increasing order.
     items: Vec<PathItem<T>>,
 }
@@ -48,15 +45,8 @@ impl<T> PathItem<T> {
 
 impl<T> PathResolver<T> {
     /// Create a new empty [`PathResolver`]
-    pub fn new(fallback: T) -> Self {
-        Self {
-            fallback,
-            items: Vec::new(),
-        }
-    }
-
-    pub fn fallback(&self) -> &T {
-        &self.fallback
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
     }
 
     /// Add a `path` and its `value` into the resolver
@@ -154,13 +144,6 @@ impl<T> PathResolver<T> {
             .find(|item| path.starts_with(item.path()))
     }
 
-    /// Convenience method when you don't care about manually handling the fallback
-    /// case and don't need the matched path in the tree
-    pub fn resolve_or_fallback<P: AsRef<Path>>(&self, path: P) -> &T {
-        self.resolve(path)
-            .map_or_else(|| self.fallback(), |item| item.value())
-    }
-
     /// Returns all matches matched by the `path` rather than just the closest one
     ///
     /// See [PathResolver::resolve()] for implementation details.
@@ -201,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_items_are_added_and_removed_in_sorted_order() {
-        let mut resolver = PathResolver::new(String::from("fallback"));
+        let mut resolver = PathResolver::new();
 
         resolver.add("/user/c", String::from("c"));
         resolver.add("/user/a", String::from("a"));
@@ -221,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_matches_must_be_strict_prefixes() {
-        let mut resolver = PathResolver::new(String::from("fallback"));
+        let mut resolver = PathResolver::new();
         resolver.add("/user/a", String::from("a"));
         resolver.add("/user/b", String::from("b"));
         resolver.add("/user/b/c", String::from("c"));
@@ -241,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_starts_with_strategy_only_matches_full_components() {
-        let mut resolver = PathResolver::new(0);
+        let mut resolver = PathResolver::new();
         resolver.add("/user/a", 1);
 
         // Technically `/user/a.R` "starts with" `/user/a`, but `path.starts_with()`
@@ -251,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_can_resolve_in_simple_cases() {
-        let mut resolver = PathResolver::new(0);
+        let mut resolver = PathResolver::new();
         resolver.add("/user/a", 1);
         resolver.add("/user/b", 2);
 
@@ -266,7 +249,7 @@ mod tests {
 
     #[test]
     fn test_resolves_to_closest_path() {
-        let mut resolver = PathResolver::new(0);
+        let mut resolver = PathResolver::new();
         resolver.add("/user/b", 1);
         resolver.add("/user/b/a", 2);
 

--- a/crates/workspace/src/settings/default_exclude_patterns.rs
+++ b/crates/workspace/src/settings/default_exclude_patterns.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 use std::sync::LazyLock;
 
-use crate::file_patterns::DefaultFilePatterns;
+use crate::file_patterns::UnrootedFilePatterns;
 
 /// The set of default exclude patterns
 ///
@@ -33,8 +33,8 @@ static DEFAULT_EXCLUDE_PATTERN_NAMES: &[&str] = &[
     "**/import-standalone-*.R",
 ];
 
-static DEFAULT_EXCLUDE_PATTERNS: LazyLock<DefaultFilePatterns> = LazyLock::new(|| {
-    DefaultFilePatterns::try_from_iter(DEFAULT_EXCLUDE_PATTERN_NAMES.iter().copied())
+static DEFAULT_EXCLUDE_PATTERNS: LazyLock<UnrootedFilePatterns> = LazyLock::new(|| {
+    UnrootedFilePatterns::try_from_iter(DEFAULT_EXCLUDE_PATTERN_NAMES.iter().copied())
         .expect("Can create default exclude patterns")
 });
 
@@ -43,7 +43,7 @@ static DEFAULT_EXCLUDE_PATTERNS: LazyLock<DefaultFilePatterns> = LazyLock::new(|
 /// Allows for free creation of [DefaultExcludePatterns] structs without needing to clone
 /// the global [DEFAULT_EXCLUDE_PATTERNS] object.
 #[derive(Debug)]
-pub struct DefaultExcludePatterns(&'static DefaultFilePatterns);
+pub struct DefaultExcludePatterns(&'static UnrootedFilePatterns);
 
 impl Default for DefaultExcludePatterns {
     /// Default exclude patterns
@@ -56,7 +56,7 @@ impl Default for DefaultExcludePatterns {
 }
 
 impl Deref for DefaultExcludePatterns {
-    type Target = DefaultFilePatterns;
+    type Target = UnrootedFilePatterns;
 
     fn deref(&self) -> &Self::Target {
         self.0

--- a/crates/workspace/src/settings/default_include_patterns.rs
+++ b/crates/workspace/src/settings/default_include_patterns.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 use std::sync::LazyLock;
 
-use crate::file_patterns::DefaultFilePatterns;
+use crate::file_patterns::UnrootedFilePatterns;
 
 /// The set of default include patterns
 ///
@@ -12,8 +12,8 @@ static DEFAULT_INCLUDE_PATTERN_NAMES: &[&str] = &[
     "**/*.[R,r]",
 ];
 
-static DEFAULT_INCLUDE_PATTERNS: LazyLock<DefaultFilePatterns> = LazyLock::new(|| {
-    DefaultFilePatterns::try_from_iter(DEFAULT_INCLUDE_PATTERN_NAMES.iter().copied())
+static DEFAULT_INCLUDE_PATTERNS: LazyLock<UnrootedFilePatterns> = LazyLock::new(|| {
+    UnrootedFilePatterns::try_from_iter(DEFAULT_INCLUDE_PATTERN_NAMES.iter().copied())
         .expect("Can create default include patterns")
 });
 
@@ -22,7 +22,7 @@ static DEFAULT_INCLUDE_PATTERNS: LazyLock<DefaultFilePatterns> = LazyLock::new(|
 /// Allows for free creation of [DefaultIncludePatterns] structs without needing to clone
 /// the global [DEFAULT_INCLUDE_PATTERNS] object.
 #[derive(Debug)]
-pub struct DefaultIncludePatterns(&'static DefaultFilePatterns);
+pub struct DefaultIncludePatterns(&'static UnrootedFilePatterns);
 
 impl Default for DefaultIncludePatterns {
     /// Default include patterns
@@ -35,7 +35,7 @@ impl Default for DefaultIncludePatterns {
 }
 
 impl Deref for DefaultIncludePatterns {
-    type Target = DefaultFilePatterns;
+    type Target = UnrootedFilePatterns;
 
     fn deref(&self) -> &Self::Target {
         self.0

--- a/crates/workspace/src/settings/exclude_patterns.rs
+++ b/crates/workspace/src/settings/exclude_patterns.rs
@@ -1,32 +1,63 @@
-use std::ops::Deref;
-use std::ops::DerefMut;
 use std::path::Path;
 
-use crate::file_patterns::FilePatterns;
+use ignore::gitignore::Glob;
 
+use crate::file_patterns::RootedFilePatterns;
+use crate::file_patterns::UnrootedFilePatterns;
+
+/// User supplied `exclude` patterns
+///
+/// The presence of a `root` at construction time determines the variant:
+/// - A project `air.toml` roots its patterns at the folder it lives in, giving
+///   [ExcludePatterns::Rooted].
+/// - A user level `air.toml` has no project directory to root against, giving
+///   [ExcludePatterns::Unrooted], whose patterns must each match at any depth.
 #[derive(Debug, Clone)]
-pub struct ExcludePatterns(FilePatterns);
+pub enum ExcludePatterns {
+    Rooted(RootedFilePatterns),
+    Unrooted(UnrootedFilePatterns),
+}
 
 impl ExcludePatterns {
-    pub(crate) fn try_from_iter<'str, P, I>(root: P, patterns: I) -> anyhow::Result<Self>
+    /// Construct [ExcludePatterns] from an iterator of patterns
+    ///
+    /// A `root` of `Some` roots the patterns at that directory. A `root` of `None` means
+    /// there is no directory to root against, so every pattern must match at any depth,
+    /// otherwise an error is thrown on creation.
+    pub(crate) fn try_from_iter<'str, I>(root: Option<&Path>, patterns: I) -> anyhow::Result<Self>
     where
-        P: AsRef<Path>,
         I: IntoIterator<Item = &'str str>,
     {
-        Ok(Self(FilePatterns::try_from_iter(root, patterns)?))
+        match root {
+            Some(root) => Ok(Self::Rooted(RootedFilePatterns::try_from_iter(
+                root, patterns,
+            )?)),
+            None => Ok(Self::Unrooted(UnrootedFilePatterns::try_from_iter(
+                patterns,
+            )?)),
+        }
     }
-}
 
-impl Deref for ExcludePatterns {
-    type Target = FilePatterns;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    /// Returns the glob that matches this `path`, or `None` if no glob matches
+    pub(crate) fn matched<P>(&self, path: P, is_directory: bool) -> Option<&Glob>
+    where
+        P: AsRef<Path>,
+    {
+        match self {
+            Self::Rooted(patterns) => patterns.matched(path, is_directory),
+            Self::Unrooted(patterns) => patterns.matched(path, is_directory),
+        }
     }
-}
 
-impl DerefMut for ExcludePatterns {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    /// Returns the glob that matches this `path` or any parent, or `None` if no glob
+    /// matches
+    pub fn matched_path_or_any_parents<P>(&self, path: P, is_directory: bool) -> Option<&Glob>
+    where
+        P: AsRef<Path>,
+    {
+        match self {
+            Self::Rooted(patterns) => patterns.matched_path_or_any_parents(path, is_directory),
+            Self::Unrooted(patterns) => patterns.matched_path_or_any_parents(path, is_directory),
+        }
     }
 }

--- a/crates/workspace/src/snapshots/workspace__discovery__test__discover_user_settings_rejects_rooted_exclude.snap
+++ b/crates/workspace/src/snapshots/workspace__discovery__test__discover_user_settings_rejects_rooted_exclude.snap
@@ -1,0 +1,8 @@
+---
+source: crates/workspace/src/discovery.rs
+expression: error
+---
+Failed to parse [AIR_TOML]:
+Pattern `src/foo.R` must meet one of the following conditions:
+- Start with `**/`, i.e. `**/foo.R`
+- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`

--- a/crates/workspace/src/snapshots/workspace__discovery__test__discover_user_settings_rejects_rooted_exclude.snap
+++ b/crates/workspace/src/snapshots/workspace__discovery__test__discover_user_settings_rejects_rooted_exclude.snap
@@ -3,6 +3,6 @@ source: crates/workspace/src/discovery.rs
 expression: error
 ---
 Failed to parse [AIR_TOML]:
-Pattern `src/foo.R` must meet one of the following conditions:
-- Start with `**/`, i.e. `**/foo.R`
-- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`
+Pattern `src/foo.R` must be unrooted. It is currently a rooted pattern implying `{root}/src/foo.R`.
+- Unrooted patterns start with `**/` and match at any depth. For convenience, simple patterns like `foo.R` and `folder/` are also considered to be unrooted.
+- Rooted patterns contain a leading or interior `/`, like `/foo.R` or `R/foo.R`, and imply `{root}/foo.R` or `{root}/R/foo.R`, which can't be resolved by a user level `air.toml`.

--- a/crates/workspace/src/snapshots/workspace__discovery__test__discover_user_settings_unparseable.snap
+++ b/crates/workspace/src/snapshots/workspace__discovery__test__discover_user_settings_unparseable.snap
@@ -1,0 +1,10 @@
+---
+source: crates/workspace/src/discovery.rs
+expression: error
+---
+Failed to parse [AIR_TOML]:
+TOML parse error at line 1, column 6
+  |
+1 | this is not valid toml
+  |      ^
+expected `.`, `=`

--- a/crates/workspace/src/snapshots/workspace__file_patterns__test__unrooted_file_pattern_rejects_rooted_patterns-2.snap
+++ b/crates/workspace/src/snapshots/workspace__file_patterns__test__unrooted_file_pattern_rejects_rooted_patterns-2.snap
@@ -2,6 +2,6 @@
 source: crates/workspace/src/file_patterns.rs
 expression: error
 ---
-Pattern `/foo.R` must be unrooted. It is currently a rooted pattern implying `{root}/foo.R`.
+Pattern `foo/bar.R` must be unrooted. It is currently a rooted pattern implying `{root}/foo/bar.R`.
 - Unrooted patterns start with `**/` and match at any depth. For convenience, simple patterns like `foo.R` and `folder/` are also considered to be unrooted.
 - Rooted patterns contain a leading or interior `/`, like `/foo.R` or `R/foo.R`, and imply `{root}/foo.R` or `{root}/R/foo.R`, which can't be resolved by a user level `air.toml`.

--- a/crates/workspace/src/snapshots/workspace__file_patterns__test__unrooted_file_pattern_rejects_rooted_patterns.snap
+++ b/crates/workspace/src/snapshots/workspace__file_patterns__test__unrooted_file_pattern_rejects_rooted_patterns.snap
@@ -1,0 +1,7 @@
+---
+source: crates/workspace/src/file_patterns.rs
+expression: error
+---
+Pattern `foo/bar.R` must meet one of the following conditions:
+- Start with `**/`, i.e. `**/foo.R`
+- Contain no `/` characters unless it is at the very end, i.e. `foo.R` or `folder/`

--- a/crates/workspace/src/toml_options.rs
+++ b/crates/workspace/src/toml_options.rs
@@ -235,7 +235,7 @@ pub struct FormatTomlOptions {
 }
 
 impl TomlOptions {
-    pub fn into_settings(self, root: &Path) -> anyhow::Result<Settings> {
+    pub fn into_settings(self, root: Option<&Path>) -> anyhow::Result<Settings> {
         let format = self.format.unwrap_or_default();
 
         let table = if format.default_table.unwrap_or(true) {

--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -85,11 +85,20 @@ Air looks for a user level configuration file at:
 -   `%APPDATA%\air\air.toml` on Windows.
     The environment variable `APPDATA` can be set as an alternative to `%APPDATA%`, i.e. if set, Air will look in `{APPDATA}\air\air.toml`.
 
+A project level `air.toml` takes precedence over a user level `air.toml`.
 A user level `air.toml` takes precedence over IDE settings when [IDE settings synchronization](#configuration-settings-synchronization) is supported.
 
-Because user level `air.toml`s exist in a directory outside of your project's tree, any `exclude` patterns you provide must match at any depth.
-Any pattern that begins with `**/` is allowed, as well as simple patterns such as `file.R` and `folder/`, which are internally treated as `**/file.R` and `**/folder/`.
-Patterns with a leading or interior `/` are not allowed, such as `/foo.R` and `R/foo.R`, as these imply `{root}/foo.R` and `{root}/R/foo.R`, which isn't applicable with a user level `air.toml`.
+#### Unrooted patterns {#configuration-unrooted-patterns}
+
+Because user level `air.toml`s exist in a directory outside of your project's tree, any `exclude` patterns you provide must be *unrooted*:
+
+-   An *unrooted* pattern is one that begins with `**/`, which matches the pattern at any depth.
+    Additionally, for convenience, simple patterns such as `file.R` and `folder/` are internally treated as their explicitly unrooted equivalents of `**/file.R` and `**/folder/`.
+
+-   A *rooted* pattern is one that contains a leading or interior `/`, such as `/foo.R` or `R/foo.R`.
+    These imply `{root}/foo.R` and `{root}/R/foo.R`, which can't be resolved by a user level `air.toml`.
+
+This distinction between rooted and unrooted patterns was chosen for consistency with Git.
 
 ## Settings synchronization {#configuration-settings-synchronization}
 

--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -72,6 +72,25 @@ If you run `air format` with a working directory of `~/packages/dplyr` or open y
 Air also supports walking up the directory tree from the project root.
 For example, if you ran `air format` from within `~/packages/dplyr/R`, then Air would look "up" one directory and would find and use `~/packages/dplyr/air.toml`.
 
+### User level configuration
+
+We highly recommend that you use a project level `air.toml` file to ensure that all collaborators share the same settings, however Air also supports a user level `air.toml`.
+This is a convenient place to set your personal defaults for any project that doesn't specify its own configuration.
+
+Air looks for a user level configuration file at:
+
+-   `~/.config/air/air.toml` on Linux and macOS.
+    The environment variable `XDG_CONFIG_HOME` can be set as an alternative to `~/.config`, i.e. if set, Air will look in `{XDG_CONFIG_HOME}/air/air.toml`.
+
+-   `%APPDATA%\air\air.toml` on Windows.
+    The environment variable `APPDATA` can be set as an alternative to `%APPDATA%`, i.e. if set, Air will look in `{APPDATA}\air\air.toml`.
+
+A user level `air.toml` takes precedence over IDE settings when [IDE settings synchronization](#configuration-settings-synchronization) is supported.
+
+Because user level `air.toml`s exist in a directory outside of your project's tree, any `exclude` patterns you provide must match at any depth.
+Any pattern that begins with `**/` is allowed, as well as simple patterns such as `file.R` and `folder/`, which are internally treated as `**/file.R` and `**/folder/`.
+Patterns with a leading or interior `/` are not allowed, such as `/foo.R` and `R/foo.R`, as these imply `{root}/foo.R` and `{root}/R/foo.R`, which isn't applicable with a user level `air.toml`.
+
 ## Settings synchronization {#configuration-settings-synchronization}
 
 In IDEs that support synchronization (VS Code and Positron currently), Air does its best to ensure that the formatter and the IDE are in agreement.


### PR DESCRIPTION
Closes #309 

This PR adds user level `air.toml` support. It uses the etcetera crate, same as ark and ruff, to locate a config directory that is OS specific:

-   `~/.config/air/air.toml` on Linux and macOS. The environment variable `XDG_CONFIG_HOME` can be set as an alternative to `~/.config`, i.e. if set, Air will look in `{XDG_CONFIG_HOME}/air/air.toml`.

-   `%APPDATA%\air\air.toml` on Windows. The environment variable `APPDATA` can be set as an alternative to `%APPDATA%`, i.e. if set, Air will look in `{APPDATA}\air\air.toml`.

When there isn't a project level `air.toml`, Air will now look for a user level `air.toml` before falling back to the default Air settings. This makes the user level `air.toml` a useful place to put personal settings for scratch files or projects that don't use Air. We still highly encourage using a project level `air.toml` for collaborative projects.

### IDE Synchronization

A user level `air.toml` counts as a "real" `air.toml`, and takes precedence over IDE settings.

### Watched files notifications

We use `GlobPattern::Relative` to watch a directory _outside_ of the workspace, i.e.:

```rust
        watchers.push(FileSystemWatcher {
            glob_pattern: GlobPattern::Relative(RelativePattern {
                base_uri: OneOf::Right(directory.clone()),
                pattern: String::from("air.toml"),
            }),
            kind: None,
        });
```

where `directory` here is the user config directory of `~/.config/air/` (on mac). Note how we update `~/.config/air/air.toml` outside of the IDE and still get a change notification!

https://github.com/user-attachments/assets/1affb54c-3aa9-4353-a1cb-81fddb5df323

### `exclude`s

The most complicated part of this PR is `exclude` handling.

A user level `air.toml` lives _outside_ of your project's directory tree, so you can't specify _rooted_ (or relative) patterns like `R/foo.R` because this resolves to `{root}/R/foo.R`.

Instead, you must supply _unrooted_ (or global) patterns like `**/foo.R` or the simpler `foo.R`, which also resolves to `**/foo.R`. You can also do `folder/`, which resolves to `**/folder/`.

The simplest way to think about it is that you can't supply anything with _leading or interior `/`_, as that is relative to a `{root}`, which isn't applicable for user level `air.toml`s. I don't anticipate this being restrictive at all, and we give a pretty good error message about it. (These are also the same rules that git follows, as implemented by the ignore crate).