### PR TITLE
fix: preserve walrus comments across formatter passes

### DIFF
--- a/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
+++ b/crates/air_r_formatter/src/r/auxiliary/binary_expression.rs
@@ -161,7 +161,9 @@ fn fmt_binary_sticky(
 /// Walrus assignment is not considered when looking for persistent line breaks because we
 /// don't want the `:=` case below to look like a request for expansion. While `:=` is
 /// technically parsed as a binary operator, we format it more like a named argument with
-/// a simple `space()` between the operator and the right hand side.
+/// a simple `space()` between the operator and the right hand side. An own-line comment
+/// between `:=` and the RHS is the exception: it must keep the expression expanded so the
+/// comment does not change position on a second formatting pass.
 ///
 /// ```r
 /// # `:=` here is technically a binary operator, `x := y` is technically an unnamed argument
@@ -455,6 +457,15 @@ fn binary_assignment_has_persistent_line_break(
     right: &AnyRExpression,
     options: &RFormatOptions,
 ) -> bool {
+    if operator.kind() == RSyntaxKind::WALRUS {
+        let right_has_leading_comment = right
+            .syntax()
+            .first_token()
+            .is_some_and(|token| token.has_leading_comments());
+
+        return right_has_leading_comment && !operator.has_trailing_comments();
+    }
+
     if options.persistent_line_breaks().is_ignore() {
         return false;
     }

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_walrus_comment.R
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_walrus_comment.R
@@ -1,0 +1,16 @@
+#| [format]
+#| persistent-line-breaks = false
+
+# https://github.com/posit-dev/air/issues/512
+# An own-line comment after `:=` keeps the expression expanded and idempotent.
+walrus :=
+  # comment
+  value
+
+# A comment-free line break still follows persistent-line-breaks = false.
+walrus_without_comment :=
+  value
+
+# An end-of-line comment still allows the walrus expression to flatten.
+walrus_end_of_line := # comment
+  value

--- a/crates/air_r_formatter/tests/specs/r/binary_expression_walrus_comment.R.snap
+++ b/crates/air_r_formatter/tests/specs/r/binary_expression_walrus_comment.R.snap
@@ -1,0 +1,59 @@
+---
+source: crates/air_formatter_test/src/snapshot_builder.rs
+info: r/binary_expression_walrus_comment.R
+---
+# Input
+
+```R
+#| [format]
+#| persistent-line-breaks = false
+
+# https://github.com/posit-dev/air/issues/512
+# An own-line comment after `:=` keeps the expression expanded and idempotent.
+walrus :=
+  # comment
+  value
+
+# A comment-free line break still follows persistent-line-breaks = false.
+walrus_without_comment :=
+  value
+
+# An end-of-line comment still allows the walrus expression to flatten.
+walrus_end_of_line := # comment
+  value
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Space
+Indent width: 2
+Line ending: LF
+Line width: 80
+Persistent line breaks: Ignore
+Assignment style: Arrow
+Table: fcase, tribble
+-----
+
+```R
+#| [format]
+#| persistent-line-breaks = false
+
+# https://github.com/posit-dev/air/issues/512
+# An own-line comment after `:=` keeps the expression expanded and idempotent.
+walrus :=
+  # comment
+  value
+
+# A comment-free line break still follows persistent-line-breaks = false.
+walrus_without_comment := value
+
+# An end-of-line comment still allows the walrus expression to flatten.
+walrus_end_of_line := value # comment
+```


### PR DESCRIPTION
Fixes #512.

## Summary

Preserve an own-line comment between `:=` and its RHS so that formatting is idempotent. Comment-free walrus line breaks and end-of-line comments retain Air's existing compact canonical output.

## Root cause

Walrus formatting intentionally flattens ordinary line breaks. When the RHS instead starts with an own-line comment, flattening changes the comment's syntactic position; a second pass then moves it after the RHS.

## Validation

- `cargo test -p air_r_formatter`
- `cargo test --workspace --exclude lsp`
- `cargo clippy -p air_r_formatter --all-targets`
- compiled CLI two-pass checks for own-line, comment-free, and end-of-line comment cases
