### PR TITLE
Add --no-configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Development version
 
+- New `--no-configuration` flag to format with Air's built-in defaults without loading a project or user configuration file (#479).
+
 # 0.11.0
 
 - New support for a user level `air.toml`. This is used as a fallback instead of Air's default settings whenever there isn't a project level `air.toml` available (#309):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Development version
 
-- New `--no-configuration` flag to format with Air's built-in defaults without loading a project or user configuration file (#479).
+- New `--no-configuration` flag to format with Air's built-in defaults without loading a project or user configuration file (#479, @LeonidasZhak).
 
 # 0.11.0
 

--- a/crates/air/src/args.rs
+++ b/crates/air/src/args.rs
@@ -61,6 +61,11 @@ pub(crate) struct FormatCommand {
     #[arg(long)]
     pub force: bool,
 
+    /// Format with Air's default settings without discovering a project or user
+    /// configuration file.
+    #[arg(long)]
+    pub no_configuration: bool,
+
     /// Use this option to enable reading from stdin and writing to stdout. This specifies
     /// a file path to associate the standard input with, which is used as the location to
     /// begin searching for configuration files from. The file does not have to exist and

--- a/crates/air/src/commands/format.rs
+++ b/crates/air/src/commands/format.rs
@@ -1,4 +1,9 @@
+use std::path::Path;
+
 use workspace::discovery;
+use workspace::discovery::DiscoveredSettings;
+use workspace::resolve::PathResolver;
+use workspace::settings::Settings;
 
 use crate::ExitStatus;
 use crate::args::FormatCommand;
@@ -12,12 +17,19 @@ enum FormatMode {
     Check,
 }
 
+#[derive(Copy, Clone, Debug)]
+enum ConfigurationMode {
+    Discover,
+    Disabled,
+}
+
 pub(crate) fn format(command: FormatCommand) -> anyhow::Result<ExitStatus> {
     if let Some(status) = check_argument_consistency(&command) {
         return Ok(status);
     }
 
     let mode = FormatMode::from_command(&command);
+    let configuration = ConfigurationMode::from_command(&command);
 
     let (exclude, include) = if command.force {
         (discovery::Exclude::Nothing, discovery::Include::Everything)
@@ -26,9 +38,31 @@ pub(crate) fn format(command: FormatCommand) -> anyhow::Result<ExitStatus> {
     };
 
     match command.stdin_file_path {
-        Some(path) => stdin::format(path, mode, exclude, include),
-        None => paths::format(command.paths, mode, exclude, include),
+        Some(path) => stdin::format(path, mode, configuration, exclude, include),
+        None => paths::format(command.paths, mode, configuration, exclude, include),
     }
+}
+
+fn resolve_settings<P: AsRef<Path>>(
+    paths: &[P],
+    configuration: ConfigurationMode,
+) -> anyhow::Result<(PathResolver<Settings>, Settings)> {
+    let mut resolver = PathResolver::new();
+
+    if let ConfigurationMode::Discover = configuration {
+        for DiscoveredSettings {
+            directory,
+            settings,
+        } in discovery::discover_settings(paths)?
+        {
+            resolver.add(&directory, settings);
+        }
+
+        let default_settings = discovery::discover_user_settings()?.unwrap_or_default();
+        return Ok((resolver, default_settings));
+    }
+
+    Ok((resolver, Settings::default()))
 }
 
 fn check_argument_consistency(command: &FormatCommand) -> Option<ExitStatus> {
@@ -54,6 +88,16 @@ impl FormatMode {
             FormatMode::Check
         } else {
             FormatMode::Write
+        }
+    }
+}
+
+impl ConfigurationMode {
+    fn from_command(command: &FormatCommand) -> Self {
+        if command.no_configuration {
+            ConfigurationMode::Disabled
+        } else {
+            ConfigurationMode::Discover
         }
     }
 }

--- a/crates/air/src/commands/format/paths.rs
+++ b/crates/air/src/commands/format/paths.rs
@@ -12,10 +12,7 @@ use itertools::Either;
 use itertools::Itertools;
 use thiserror::Error;
 use workspace::discovery;
-use workspace::discovery::DiscoveredSettings;
 use workspace::discovery::discover_r_file_paths;
-use workspace::discovery::discover_settings;
-use workspace::discovery::discover_user_settings;
 use workspace::format::FormatSourceError;
 use workspace::format::FormattedSource;
 use workspace::resolve::PathResolver;
@@ -23,7 +20,9 @@ use workspace::settings::FormatSettings;
 use workspace::settings::Settings;
 
 use crate::ExitStatus;
+use crate::commands::format::ConfigurationMode;
 use crate::commands::format::FormatMode;
+use crate::commands::format::resolve_settings;
 
 #[derive(Error, Debug)]
 enum FormatPathError {
@@ -36,20 +35,11 @@ enum FormatPathError {
 pub(crate) fn format(
     paths: Vec<PathBuf>,
     mode: FormatMode,
+    configuration: ConfigurationMode,
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> anyhow::Result<ExitStatus> {
-    let mut resolver = PathResolver::new();
-
-    for DiscoveredSettings {
-        directory,
-        settings,
-    } in discover_settings(&paths)?
-    {
-        resolver.add(&directory, settings);
-    }
-
-    let default_settings = discover_user_settings()?.unwrap_or_default();
+    let (resolver, default_settings) = resolve_settings(&paths, configuration)?;
 
     match mode {
         FormatMode::Write => {

--- a/crates/air/src/commands/format/stdin.rs
+++ b/crates/air/src/commands/format/stdin.rs
@@ -8,9 +8,6 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 use workspace::discovery;
-use workspace::discovery::DiscoveredSettings;
-use workspace::discovery::discover_settings;
-use workspace::discovery::discover_user_settings;
 use workspace::format::FormatSourceError;
 use workspace::format::FormattedSource;
 use workspace::resolve::PathResolver;
@@ -18,7 +15,9 @@ use workspace::settings::FormatSettings;
 use workspace::settings::Settings;
 
 use crate::ExitStatus;
+use crate::commands::format::ConfigurationMode;
 use crate::commands::format::FormatMode;
+use crate::commands::format::resolve_settings;
 
 #[derive(Debug)]
 enum FormattedStdin {
@@ -38,23 +37,14 @@ enum FormatStdinError {
 pub(crate) fn format(
     path: PathBuf,
     mode: FormatMode,
+    configuration: ConfigurationMode,
     exclude: discovery::Exclude,
     include: discovery::Include,
 ) -> anyhow::Result<ExitStatus> {
     // Normalize up front, relative to current working directory
     let path = fs::normalize_path(path);
 
-    let mut resolver = PathResolver::new();
-
-    for DiscoveredSettings {
-        directory,
-        settings,
-    } in discover_settings(&[&path])?
-    {
-        resolver.add(&directory, settings);
-    }
-
-    let default_settings = discover_user_settings()?.unwrap_or_default();
+    let (resolver, default_settings) = resolve_settings(&[&path], configuration)?;
 
     match mode {
         FormatMode::Write => {

--- a/crates/air/tests/integration/config.rs
+++ b/crates/air/tests/integration/config.rs
@@ -267,3 +267,56 @@ fn test_user_config_broken_toml_is_a_hard_error() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_no_configuration_ignores_project_and_user_config() -> anyhow::Result<()> {
+    let user_config_directory = TempDir::new()?;
+    let user_config_directory = user_config_directory.path();
+    write_user_air_toml(user_config_directory, "not valid toml")?;
+
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+    std::fs::write(directory.join("air.toml"), "also not valid toml")?;
+
+    let test_path = "test.R";
+    std::fs::write(directory.join(test_path), "if (TRUE) {\n1\n}\n")?;
+
+    let output = Command::new(binary_path())
+        .env(user_config_directory_env_var(), user_config_directory)
+        .current_dir(directory)
+        .arg("format")
+        .arg(test_path)
+        .arg("--no-configuration")
+        .run();
+
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(directory.join(test_path))?,
+        "if (TRUE) {\n  1\n}\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_no_configuration_applies_to_stdin() -> anyhow::Result<()> {
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+    std::fs::write(directory.join("air.toml"), "[format]\nindent-width = 8\n")?;
+
+    let output = Command::new(binary_path())
+        .current_dir(directory)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("format")
+        .arg("--stdin-file-path")
+        .arg("test.R")
+        .arg("--no-configuration")
+        .run_with_stdin("if (TRUE) {\n1\n}\n".to_string());
+
+    assert!(output.status.success());
+    assert_eq!(output.stdout, "if (TRUE) {\n  1\n}\n");
+
+    Ok(())
+}

--- a/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_bash.snap
+++ b/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_bash.snap
@@ -72,7 +72,7 @@ _air() {
             return 0
             ;;
         air__format)
-            opts="-h --check --force --stdin-file-path --log-level --no-color --help [PATHS]..."
+            opts="-h --check --force --no-configuration --stdin-file-path --log-level --no-color --help [PATHS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_elvish.snap
+++ b/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_elvish.snap
@@ -41,6 +41,7 @@ set edit:completion:arg-completer[air] = {|@words|
             cand --log-level 'The log level [default: warn]'
             cand --check 'If enabled, format results are not written back to the file. Instead, exit with a non-zero status code if any files would have been modified, and zero otherwise'
             cand --force 'Force formatting to occur regardless of exclusion patterns. This applies recursively to directories. This serves as an escape hatch for cases like `air format r-code.txt --force`, but is very rarely needed'
+            cand --no-configuration 'Format with Air''s default settings without discovering a project or user configuration file'
             cand --no-color 'Disable colored output. To turn colored output off, either set this option or set the environment variable `NO_COLOR` to any non-zero value'
             cand -h 'Print help'
             cand --help 'Print help'

--- a/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_fish.snap
+++ b/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_fish.snap
@@ -51,6 +51,7 @@ debug\t''
 trace\t''"
 complete -c air -n "__fish_air_using_subcommand format" -l check -d 'If enabled, format results are not written back to the file. Instead, exit with a non-zero status code if any files would have been modified, and zero otherwise'
 complete -c air -n "__fish_air_using_subcommand format" -l force -d 'Force formatting to occur regardless of exclusion patterns. This applies recursively to directories. This serves as an escape hatch for cases like `air format r-code.txt --force`, but is very rarely needed'
+complete -c air -n "__fish_air_using_subcommand format" -l no-configuration -d 'Format with Air\'s default settings without discovering a project or user configuration file'
 complete -c air -n "__fish_air_using_subcommand format" -l no-color -d 'Disable colored output. To turn colored output off, either set this option or set the environment variable `NO_COLOR` to any non-zero value'
 complete -c air -n "__fish_air_using_subcommand format" -s h -l help -d 'Print help'
 complete -c air -n "__fish_air_using_subcommand language-server" -l log-level -d 'The log level [default: warn]' -r -f -a "error\t''

--- a/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_powershell.snap
+++ b/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_powershell.snap
@@ -45,6 +45,7 @@ Register-ArgumentCompleter -Native -CommandName 'air' -ScriptBlock {
             [CompletionResult]::new('--log-level', '--log-level', [CompletionResultType]::ParameterName, 'The log level [default: warn]')
             [CompletionResult]::new('--check', '--check', [CompletionResultType]::ParameterName, 'If enabled, format results are not written back to the file. Instead, exit with a non-zero status code if any files would have been modified, and zero otherwise')
             [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, 'Force formatting to occur regardless of exclusion patterns. This applies recursively to directories. This serves as an escape hatch for cases like `air format r-code.txt --force`, but is very rarely needed')
+            [CompletionResult]::new('--no-configuration', '--no-configuration', [CompletionResultType]::ParameterName, 'Format with Air''s default settings without discovering a project or user configuration file')
             [CompletionResult]::new('--no-color', '--no-color', [CompletionResultType]::ParameterName, 'Disable colored output. To turn colored output off, either set this option or set the environment variable `NO_COLOR` to any non-zero value')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')

--- a/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_zsh.snap
+++ b/crates/air/tests/integration/snapshots/integration__generate_shell_completion__completions_zsh.snap
@@ -43,6 +43,7 @@ _arguments "${_arguments_options[@]}" : \
 '--log-level=[The log level \[default\: warn\]]:LOG_LEVEL:(error warn info debug trace)' \
 '--check[If enabled, format results are not written back to the file. Instead, exit with a non-zero status code if any files would have been modified, and zero otherwise]' \
 '--force[Force formatting to occur regardless of exclusion patterns. This applies recursively to directories. This serves as an escape hatch for cases like \`air format r-code.txt --force\`, but is very rarely needed]' \
+'--no-configuration[Format with Air'\''s default settings without discovering a project or user configuration file]' \
 '--no-color[Disable colored output. To turn colored output off, either set this option or set the environment variable \`NO_COLOR\` to any non-zero value]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/crates/air/tests/integration/snapshots/integration__help__format_help-2.snap
+++ b/crates/air/tests/integration/snapshots/integration__help__format_help-2.snap
@@ -20,6 +20,9 @@ Options:
           Force formatting to occur regardless of exclusion patterns. This applies recursively to
           directories. This serves as an escape hatch for cases like `air format r-code.txt
           --force`, but is very rarely needed
+      --no-configuration
+          Format with Air's default settings without discovering a project or user configuration
+          file
       --stdin-file-path <STDIN_FILE_PATH>
           Use this option to enable reading from stdin and writing to stdout. This specifies a file
           path to associate the standard input with, which is used as the location to begin

--- a/crates/air/tests/integration/snapshots/integration__help__format_help-3.snap
+++ b/crates/air/tests/integration/snapshots/integration__help__format_help-3.snap
@@ -20,6 +20,9 @@ Options:
           Force formatting to occur regardless of exclusion patterns. This applies recursively to
           directories. This serves as an escape hatch for cases like `air format r-code.txt
           --force`, but is very rarely needed
+      --no-configuration
+          Format with Air's default settings without discovering a project or user configuration
+          file
       --stdin-file-path <STDIN_FILE_PATH>
           Use this option to enable reading from stdin and writing to stdout. This specifies a file
           path to associate the standard input with, which is used as the location to begin

--- a/crates/air/tests/integration/snapshots/integration__help__format_help.snap
+++ b/crates/air/tests/integration/snapshots/integration__help__format_help.snap
@@ -22,6 +22,9 @@ Options:
           Force formatting to occur regardless of exclusion patterns. This applies recursively to
           directories. This serves as an escape hatch for cases like `air format r-code.txt
           --force`, but is very rarely needed
+      --no-configuration
+          Format with Air's default settings without discovering a project or user configuration
+          file
       --stdin-file-path <STDIN_FILE_PATH>
           Use this option to enable reading from stdin and writing to stdout. This specifies a file
           path to associate the standard input with, which is used as the location to begin

--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -98,6 +98,18 @@ Air's conda-forge package is community-maintained.
 
 # Features
 
+## Configuration
+
+By default, Air discovers the nearest project `air.toml` and falls back to a user-level configuration file when no project configuration exists.
+Use `--no-configuration` to skip both configuration sources and format with Air's built-in defaults:
+
+``` bash
+air format --no-configuration path/to/file.R
+```
+
+This flag does not disable Air's built-in include and exclude rules.
+Combine it with `--force` only when you also need to bypass those rules.
+
 ## Stdin
 
 Air supports reading from stdin at the command line via `--stdin-file-path`.


### PR DESCRIPTION
## Summary

Add `air format --no-configuration` to format with Air's built-in defaults without reading project or user configuration files.

## Thanks to maintainers

Thanks for outlining the option and preferred name in #479.

## Issue or motivation

Closes #479. Stdin and CI callers sometimes need formatting output that is independent of ambient configuration.

## Root cause

Both path and stdin formatting always ran project discovery and user fallback before formatting. There was no route to select `Settings::default()` directly.

## Change

- Add the flag and share configuration resolution between path and stdin formatting.
- Skip both project and user configuration while preserving Air's built-in include and exclude rules.
- Cover invalid project/user configuration and stdin behavior.
- Update help, shell completions, CLI documentation, and the changelog.

## Tests

- `cargo build`
- `just test -p air --test integration config` — 9 passed
- `just test -p air --test integration` — 43 passed
- `just test` — 240 passed, 3 skipped
- `cargo clippy --workspace --all-targets -- -D warnings` — completed; reports the repository's existing renamed-lint warning
- Scoped `rustfmt --check` and `git diff --check` — passed

## Scope

This does not change language-server configuration, configuration discovery itself, built-in defaults, or `--force` and include/exclude semantics.
